### PR TITLE
Improve MetaMember reflection performance 

### DIFF
--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/ChangeSetBuilder.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/ChangeSetBuilder.cs
@@ -125,11 +125,11 @@ namespace OpenRiaServices.DomainServices.Client
             {
                 if (entity.EntityState == EntityState.Modified)
                 {
-                    foreach (PropertyInfo modifiedProperty in entity.ModifiedProperties)
+                    foreach (MetaMember member in entity.ModifiedProperties)
                     {
-                        if (modifiedProperty.GetCustomAttributes(typeof(KeyAttribute), false).Any())
+                        if (member.IsKeyMember)
                         {
-                            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.Entity_KeyMembersCannotBeChanged, modifiedProperty.Name, entity.GetType().Name));
+                            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.Entity_KeyMembersCannotBeChanged, member.Name, entity.GetType().Name));
                         }
                     }
                 }

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/ComplexObject.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/ComplexObject.cs
@@ -284,7 +284,7 @@ namespace OpenRiaServices.DomainServices.Client
         {
             // First check if the parent has an existing instance attached for this
             // property and detach if necessary.
-            string memberName = metaMember.Member.Name;
+            string memberName = metaMember.Name;
             ComplexObject prevInstance = null;
             if (this.TrackedInstances.TryGetValue(memberName, out prevInstance))
             {

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/Entity.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/Entity.cs
@@ -394,6 +394,10 @@ namespace OpenRiaServices.DomainServices.Client
 
         private void RaiseCanInvokeChanged()
         {
+            // If no one is listening for property changes then do not emit them
+            if (_propChangedHandler == null)
+                return;
+
             foreach (var customMethod in MetaType.GetEntityActions())
             {
                 this.RaisePropertyChanged(customMethod.CanInvokePropertyName);

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/Entity.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/Entity.cs
@@ -20,13 +20,13 @@ namespace OpenRiaServices.DomainServices.Client
     {
         private Action _setChangedCallback;
         private EditSession _editSession;
-        private IList<EntityAction> _customMethodInvocations;
+        private List<EntityAction> _customMethodInvocations;
         private EntityConflict _conflict;
         private EntitySet _lastSet;
         private EntitySet _entitySet;
         private EntityState _entityState = EntityState.Detached;
         private IDictionary<string, object> _originalValues;
-        private IDictionary<string, IEntityRef> _entityRefs;
+        private Dictionary<string, IEntityRef> _entityRefs;
         private PropertyChangedEventHandler _propChangedHandler;
         private EntityValidationResultCollection _validationErrors;
         private bool _isApplyingState;
@@ -921,7 +921,7 @@ namespace OpenRiaServices.DomainServices.Client
         /// <summary>
         /// Gets the map of EntityRef member name to IEntityRef instance.
         /// </summary>
-        private IDictionary<string, IEntityRef> EntityRefs
+        private Dictionary<string, IEntityRef> EntityRefs
         {
             get
             {

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/Entity.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/Entity.cs
@@ -525,23 +525,26 @@ namespace OpenRiaServices.DomainServices.Client
             }
         }
 
+        /// <summary>
+        /// Get a value indicating if we are currently merging state from another entity.
+        /// This is common when loading entities.
+        /// 
+        /// This flag us used to suspended change tracking and edit enforcement   
+        /// during the merge
+        /// </summary>
         protected internal bool IsMergingState
         {
             get { return this._isMerging; }
             private set
             {
                 this._isMerging = value;
-
-                MetaType metaType = MetaType.GetMetaType(this.GetType());
-
-                foreach (MetaMember metaMember in metaType.DataMembers.Where(f => f.IsComplex && !f.IsCollection))
+                foreach (MetaMember metaMember in MetaType.DataMembers.Where(f => f.IsComplex && !f.IsCollection))
                 {
                     ComplexObject propertyValue = metaMember.GetValue(this) as ComplexObject;
                     if (propertyValue != null)
                     {
                         propertyValue.IsMergingState = this._isMerging;
                     }
-
                 }
             }
         }

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntityConflict.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntityConflict.cs
@@ -157,7 +157,7 @@ namespace OpenRiaServices.DomainServices.Client
                 object storeValue = versionMember.GetValue(this._storeEntity);
 
                 // since Timestamp values are readonly, we must use ApplyState to set the value
-                this._currentEntity.ApplyState(new Dictionary<string, object> { { versionMember.Member.Name, storeValue } });
+                this._currentEntity.ApplyState(new Dictionary<string, object> { { versionMember.Name, storeValue } });
             }
 
             // clear the conflict now that it is resolved

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntitySet.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntitySet.cs
@@ -1077,7 +1077,7 @@ namespace OpenRiaServices.DomainServices.Client
                 base.Visit(entity);
             }
 
-            protected override void VisitEntityCollection(IEntityCollection entityCollection, PropertyInfo propertyInfo)
+            protected override void VisitEntityCollection(IEntityCollection entityCollection, MetaMember member)
             {
                 if (entityCollection != null && entityCollection.HasValues)
                 {
@@ -1088,7 +1088,7 @@ namespace OpenRiaServices.DomainServices.Client
                 }
             }
 
-            protected override void VisitEntityRef(IEntityRef entityRef, Entity parent, PropertyInfo propertyInfo)
+            protected override void VisitEntityRef(IEntityRef entityRef, Entity parent, MetaMember member)
             {
                 // only visit the Entity if the value has been assigned
                 // or loaded - we don't want to cause deferred loads.
@@ -1114,9 +1114,9 @@ namespace OpenRiaServices.DomainServices.Client
             {
             }
 
-            protected override void VisitEntityCollection(IEntityCollection entityCollection, PropertyInfo propertyInfo)
+            protected override void VisitEntityCollection(IEntityCollection entityCollection, MetaMember member)
             {
-                if (propertyInfo.GetCustomAttributes(typeof(CompositionAttribute), false).Any())
+                if (member.IsComposition)
                 {
                     IEnumerable<Entity> children = entityCollection.Entities.ToArray();
                     foreach (Entity child in children)
@@ -1127,9 +1127,9 @@ namespace OpenRiaServices.DomainServices.Client
                 }
             }
 
-            protected override void VisitEntityRef(IEntityRef entityRef, Entity parent, PropertyInfo propertyInfo)
+            protected override void VisitEntityRef(IEntityRef entityRef, Entity parent, MetaMember member)
             {
-                if (propertyInfo.GetCustomAttributes(typeof(CompositionAttribute), false).Any())
+                if (member.IsComposition)
                 {
                     Entity child = null;
                     if (entityRef == null)
@@ -1137,7 +1137,7 @@ namespace OpenRiaServices.DomainServices.Client
                         // If the EntityRef hasn't been accesssed before, it might
                         // not be initialized yet. In this case we need to access
                         // the property directly.
-                        child = (Entity)propertyInfo.GetValue(parent, null);
+                        child = (Entity)member.GetValue(parent);
                     }
                     else
                     {
@@ -1146,7 +1146,7 @@ namespace OpenRiaServices.DomainServices.Client
 
                     // set value though property setter to ensure that
                     // FK sync code is run
-                    propertyInfo.SetValue(parent, null, null);
+                    member.SetValue(parent, null);
 
                     if (child != null)
                     {
@@ -1170,9 +1170,9 @@ namespace OpenRiaServices.DomainServices.Client
             {
             }
 
-            protected override void VisitEntityCollection(IEntityCollection entityCollection, PropertyInfo propertyInfo)
+            protected override void VisitEntityCollection(IEntityCollection entityCollection, MetaMember member)
             {
-                if (propertyInfo.GetCustomAttributes(typeof(CompositionAttribute), false).Any())
+                if (member.IsComposition)
                 {
                     IEnumerable<Entity> children = entityCollection.Entities.ToArray();
                     foreach (Entity child in children)
@@ -1185,17 +1185,17 @@ namespace OpenRiaServices.DomainServices.Client
                 }
             }
 
-            protected override void VisitEntityRef(IEntityRef entityRef, Entity parent, PropertyInfo propertyInfo)
+            protected override void VisitEntityRef(IEntityRef entityRef, Entity parent, MetaMember member)
             {
-                if (propertyInfo.GetCustomAttributes(typeof(CompositionAttribute), false).Any())
+                if (member.IsComposition)
                 {
                     Entity child = null;
                     if (entityRef == null)
                     {
-                        // If the EntityRef hasn't been accesssed before, it might
+                        // If the EntityRef hasn't been accessed before, it might
                         // not be initialized yet. In this case we need to access
                         // the property directly.
-                        child = (Entity)propertyInfo.GetValue(parent, null);
+                        child = (Entity)member.GetValue(parent);
                     }
                     else
                     {

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntitySet.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntitySet.cs
@@ -913,7 +913,10 @@ namespace OpenRiaServices.DomainServices.Client
                 this._collectionChangedEventHandler(this, args);
             }
 
-            this.RaisePropertyChanged("Count");
+            if (this.PropertyChanged != null)
+            {
+                this.RaisePropertyChanged("Count");
+            }
         }
 
 #region IEnumerable Members

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntityVisitor.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntityVisitor.cs
@@ -22,11 +22,11 @@ namespace OpenRiaServices.DomainServices.Client
                 throw new ArgumentNullException("entity");
             }
 
-            foreach (PropertyInfo association in entity.MetaType.AssociationMembers)
+            foreach (MetaMember association in entity.MetaType.AssociationMembers)
             {
                 if (typeof(IEntityCollection).IsAssignableFrom(association.PropertyType))
                 {
-                    this.VisitEntityCollection((IEntityCollection)association.GetValue(entity, null), association);
+                    this.VisitEntityCollection((IEntityCollection)association.GetValue(entity), association);
                 }
                 else
                 {
@@ -42,8 +42,8 @@ namespace OpenRiaServices.DomainServices.Client
         /// Visit the specified <see cref="IEntityCollection"/>.
         /// </summary>
         /// <param name="entityCollection">The <see cref="IEntityCollection"/>.</param>
-        /// <param name="propertyInfo">The <see cref="PropertyInfo"/> for the collection member.</param>
-        protected virtual void VisitEntityCollection(IEntityCollection entityCollection, PropertyInfo propertyInfo)
+        /// <param name="member">The <see cref="MetaMember"/> for the collection member.</param>
+        protected virtual void VisitEntityCollection(IEntityCollection entityCollection, MetaMember member)
         {
         }
 
@@ -52,8 +52,8 @@ namespace OpenRiaServices.DomainServices.Client
         /// </summary>
         /// <param name="entityRef">The EntityRef to visit.</param>
         /// <param name="parent">The parent of the reference member</param>
-        /// <param name="propertyInfo">The <see cref="PropertyInfo"/> for the reference member</param>
-        protected virtual void VisitEntityRef(IEntityRef entityRef, Entity parent, PropertyInfo propertyInfo)
+        /// <param name="member">The <see cref="MetaMember"/> for the reference member</param>
+        protected virtual void VisitEntityRef(IEntityRef entityRef, Entity parent, MetaMember member)
         {
         }
     }

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/MetaType.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/MetaType.cs
@@ -37,7 +37,7 @@ namespace OpenRiaServices.DomainServices.Client
         private readonly bool _hasComposition;
         private readonly bool _shouldRoundtripOriginal;
         private readonly Type _type;
-        private readonly IEnumerable<Type> _childTypes = new List<Type>();
+        private readonly Type[] _childTypes;
         private readonly Dictionary<string, MetaMember> _metaMembers = new Dictionary<string, MetaMember>();
         private readonly MetaMember _versionMember;
         private readonly ReadOnlyCollection<MetaMember> _keyMembers;
@@ -45,7 +45,7 @@ namespace OpenRiaServices.DomainServices.Client
         private readonly ReadOnlyCollection<ValidationAttribute> _validationAttributes;
 
 
-        private readonly IDictionary<string, EntityActionAttribute> _customUpdateMethods = new Dictionary<string, EntityActionAttribute>();
+        private readonly Dictionary<string, EntityActionAttribute> _customUpdateMethods = new Dictionary<string, EntityActionAttribute>();
 
         /// <summary>
         /// Returns the MetaType for the specified Type.
@@ -161,10 +161,13 @@ namespace OpenRiaServices.DomainServices.Client
 
             if (this._hasComposition)
             {
-                this._childTypes = type
-                        .GetProperties(MemberBindingFlags)
-                        .Where(p => p.GetCustomAttributes(typeof(CompositionAttribute), false).Any())
+                this._childTypes = _metaMembers.Values
+                        .Where(m => m.IsComposition)
                         .Select(p => TypeUtility.GetElementType(p.PropertyType)).ToArray();
+            }
+            else
+            {
+                this._childTypes = TypeUtility.EmptyTypes;
             }
 
             this._type = type;

--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/ValidationUtilities.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/ValidationUtilities.cs
@@ -222,7 +222,7 @@ namespace OpenRiaServices.DomainServices.Client
             foreach (MetaMember metaMember in metaType.Members.Where(m => m.RequiresValidation || m.IsComplex))
             {
                 ValidationContext propertyValidationContext = ValidationUtilities.CreateValidationContext(instance, validationContext);
-                propertyValidationContext.MemberName = metaMember.Member.Name;
+                propertyValidationContext.MemberName = metaMember.Name;
 
                 // Form the current member path, appending the current
                 // member name if it is complex.
@@ -233,7 +233,7 @@ namespace OpenRiaServices.DomainServices.Client
                     {
                         currMemberPath += ".";
                     }
-                    currMemberPath += metaMember.Member.Name;
+                    currMemberPath += metaMember.Name;
                 }
 
                 object value = metaMember.GetValue(instance);
@@ -538,12 +538,12 @@ namespace OpenRiaServices.DomainServices.Client
             {
                 // filter the results to only those with a member name that begins with a dotted path
                 // starting at the current complex member
-                IEnumerable<ValidationResult> results = validationResults.Where(p => p.MemberNames.Any(q => !string.IsNullOrEmpty(q) && q.StartsWith(complexMember.Member.Name + ".", StringComparison.Ordinal)));
+                IEnumerable<ValidationResult> results = validationResults.Where(p => p.MemberNames.Any(q => !string.IsNullOrEmpty(q) && q.StartsWith(complexMember.Name + ".", StringComparison.Ordinal)));
                 
                 ComplexObject complexObject = (ComplexObject)complexMember.GetValue(instance);
                 if (complexObject != null)
                 {
-                    results = ValidationUtilities.RemoveMemberPrefix(results, complexMember.Member.Name);
+                    results = ValidationUtilities.RemoveMemberPrefix(results, complexMember.Name);
                     ApplyValidationErrors(complexObject, results);
                 }
             }

--- a/OpenRiaServices.DomainServices.Client/Test/Desktop/OpenRiaServices.DomainServices.Client.Test.csproj
+++ b/OpenRiaServices.DomainServices.Client/Test/Desktop/OpenRiaServices.DomainServices.Client.Test.csproj
@@ -48,7 +48,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed|AnyCPU'">
     <OutputPath>bin\Signed\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <NoWarn>108</NoWarn>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/OpenRiaServices.DomainServices.Server/Framework/Data/MetaType.cs
+++ b/OpenRiaServices.DomainServices.Server/Framework/Data/MetaType.cs
@@ -256,6 +256,8 @@ namespace OpenRiaServices.DomainServices.Server
             this.MetaType = metaType;
         }
 
+        public string Name => Member.Name;
+
         public MetaType MetaType
         {
             get;


### PR DESCRIPTION
Improve reflection logic for performance improvements in a number of scenarios.

Examples of affected changes includes 
* Load
* Submit
* ToString 
* Builtin fallback  implementation of GetIdentity
* Validation specifically on entity level

Approximate numbers for different methods when processing 1000 of the "Citites" entities found in the test project. The timings include client only processing (excluding serialization/deserialization) and timings are taken from a single run of the Benchmarks (https://github.com/OpenRIAServices/Benchmarks) project for master compared to this branch.

|Metod| Average approximate speedup | % or original | 
|---|--|--|
|Add|+27%|79%|
|Attach|+20%|84%|
|Submit|+169%|37%|
|Load|158%|39%|
|Modify attached entity|21%|82%|
|Total time (excluding test setup)|47%|68%|