### PR TITLE
fix #113

### DIFF
--- a/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntitySet.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Silverlight/Data/EntitySet.cs
@@ -737,7 +737,13 @@ namespace OpenRiaServices.DomainServices.Client
                 this.AddToCache(entity);
                 cachedEntity = entity;
 
-                int idx = this._list.Add(entity);
+                int idx = 0;
+                bool isInList = this.InterestingEntities.Contains(entity);
+                if (!isInList)
+                {
+                    idx = this._list.Add(entity);
+                }
+
                 entity.MarkUnmodified();
                 entity.EntitySet = this;
 
@@ -749,7 +755,11 @@ namespace OpenRiaServices.DomainServices.Client
                 }
 
                 entity.OnLoaded(true);
-                this.OnCollectionChanged(NotifyCollectionChangedAction.Add, entity, idx);
+
+                if (!isInList)
+                {
+                    this.OnCollectionChanged(NotifyCollectionChangedAction.Add, entity, idx);
+                }
             }
             else
             {

--- a/OpenRiaServices.DomainServices.Client/Test/Silverlight/Data/ChangeSetTests.cs
+++ b/OpenRiaServices.DomainServices.Client/Test/Silverlight/Data/ChangeSetTests.cs
@@ -326,6 +326,10 @@ namespace OpenRiaServices.DomainServices.Client.Test
             Assert.AreEqual(1, cs.ModifiedEntities.Count);
             Assert.IsFalse(cs.AddedEntities.Contains(newProduct2));
             Assert.IsTrue(cs.ModifiedEntities.Contains(newProduct2));
+
+            // verify that duplicate references aren't added when an
+            // inferred entity is attached
+            Assert.AreEqual(2, ec.GetEntitySet<Product>().Count);
         }
 
         /// <summary>

--- a/OpenRiaServices.DomainServices.Client/Test/Silverlight/Data/EntitySetTests.cs
+++ b/OpenRiaServices.DomainServices.Client/Test/Silverlight/Data/EntitySetTests.cs
@@ -255,10 +255,13 @@ namespace OpenRiaServices.DomainServices.Client.Test
             int productAdded = 0;
             int productRemoved = 0;
             int productPropertyChanged = 0;
+            int productsCollectionChanged = 0;
             EntitySet<Product> productsSet = ec.GetEntitySet<Product>();
             productsSet.EntityAdded += (obj, args) => productAdded += 1;
             productsSet.EntityRemoved += (obj, args) => productRemoved += 1;
             productsSet.PropertyChanged += (obj, args) => productPropertyChanged += 1;
+            ((INotifyCollectionChanged) productsSet).CollectionChanged += (obj, args) =>
+                productsCollectionChanged += 1;
 
             // create and add order to container
             Order order = new Order
@@ -287,6 +290,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             Assert.AreEqual(1, productAdded);
             Assert.AreEqual(0, productRemoved);
             Assert.AreEqual(2, productPropertyChanged);
+            Assert.AreEqual(1, productsCollectionChanged);
 
             // now explicitly attach product
             productsSet.Attach(product);
@@ -298,6 +302,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             Assert.AreEqual(1, productAdded);
             Assert.AreEqual(0, productRemoved);
             Assert.AreEqual(2, productPropertyChanged);
+            Assert.AreEqual(1, productsCollectionChanged);
         }
 
         private EntitySet<T> CreateEntitySet<T>() where T : Entity


### PR DESCRIPTION
Fixed by checking InterestingEntities before adding to _list in LoadEntity, as suggested in #113 . All tests that pass in master on my machine still pass, plus the additional test I added. Performance difference from master is negligible.