### PR TITLE
Use roslyn to compile sources in Tools tests

### DIFF
--- a/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/App.config
+++ b/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/App.config
@@ -3,7 +3,7 @@
   <configSections>
     
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
+  </configSections>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
@@ -15,6 +15,6 @@
     </providers>
   </entityFramework>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
   </startup>
 </configuration>

--- a/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/OpenRiaServices.DomainServices.Tools.TextTemplate.Test.csproj
+++ b/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/OpenRiaServices.DomainServices.Tools.TextTemplate.Test.csproj
@@ -1,50 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <FeaturePackageRoot>$(MSBuildProjectDirectory)\..\..</FeaturePackageRoot>
-  </PropertyGroup>
-  <PropertyGroup>
-    <NoWarn>618</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugNet40|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\DebugNet40\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <NoWarn>618</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseNet40|AnyCPU'">
-    <OutputPath>bin\ReleaseNet40\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>618</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'MyGet40|AnyCPU'">
-    <OutputPath>bin\MyGet40\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>618</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed|AnyCPU'">
-    <OutputPath>bin\Signed\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>618</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <Import Project="$(FeaturePackageRoot)\FeaturePackage.targets" />
   <PropertyGroup>
@@ -57,11 +14,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenRiaServices.DomainServices.Tools.TextTemplate.Test</RootNamespace>
     <AssemblyName>OpenRiaServices.DomainServices.Tools.TextTemplate.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <AppDesignerFolder>Properties</AppDesignerFolder>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -79,26 +38,19 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'CodeCov|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;CODECOV</DefineConstants>
+    <NoWarn>618</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>
   <PropertyGroup>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Framework" />
@@ -183,9 +135,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\OpenRiaServices.DomainServices.Tools\Test\ProjectPath.txt">

--- a/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/packages.config
+++ b/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
-</packages>

--- a/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/project.json
+++ b/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/project.json
@@ -1,0 +1,11 @@
+﻿{
+    "dependencies": {
+        "EntityFramework": "6.1.3",
+        "Microsoft.CodeAnalysis.CSharp": "2.7.0",
+        "Microsoft.CodeAnalysis.VisualBasic": "2.7.0"
+    },
+    "frameworks": {
+        "net46": {}
+    },
+    "runtimes": { "win": {} }
+}

--- a/OpenRiaServices.DomainServices.Tools/Test/App.config
+++ b/OpenRiaServices.DomainServices.Tools/Test/App.config
@@ -2,26 +2,12 @@
 <configuration>
   <configSections>
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-    
-  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
+  </configSections>
   <connectionStrings>
     <add name="AdventureWorksEntities" connectionString="metadata=res://*/DataModels.AdventureWorks.csdl|res://*/DataModels.AdventureWorks.ssdl|res://*/DataModels.AdventureWorks.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=AdventureWorks;Integrated Security=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient" />
     <add name="NorthwindEntities" connectionString="metadata=res://*/DataModels.Northwind.csdl|res://*/DataModels.Northwind.ssdl|res://*/DataModels.Northwind.msl;provider=System.Data.SqlClient;provider connection string=&quot;Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Northwind;Integrated Security=True;MultipleActiveResultSets=True&quot;" providerName="System.Data.EntityClient" />
     <add name="Northwind" connectionString="Data Source=(localdb)\MSSQLLocalDB;Initial Catalog=Northwind;Integrated Security=True;MultipleActiveResultSets=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
-  <runtime>
-    <generatePublisherEvidence enabled="false" />
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CompactFramework.Build.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="10.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>

--- a/OpenRiaServices.DomainServices.Tools/Test/AssemblyGenerator.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/AssemblyGenerator.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using OpenRiaServices.DomainServices.Server.Test.Utilities;
 using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.CodeAnalysis.Text;
 
 namespace OpenRiaServices.DomainServices.Tools.Test
 {
@@ -461,24 +462,28 @@ namespace OpenRiaServices.DomainServices.Tools.Test
 
         private MemoryStream CompileSource()
         {
-            List<string> files = new List<string>(capacity:2) { GeneratedCodeFile };
-            // If client has added extra user code into the
-            // compile request, add it in now
-            string userCodeFile = this.UserCodeFile;
-            if (!string.IsNullOrEmpty(userCodeFile))
-            {
-                files.Add(userCodeFile);
-            }
-
             string assemblyname = Path.GetFileNameWithoutExtension(this.OutputAssemblyName);
             if (this._isCSharp)
             {
+                var contents = new List<SourceText>(capacity: 2);
+                contents.Add(SourceText.From(GeneratedCode));
+                if (!string.IsNullOrEmpty(UserCode))
+                    contents.Add(SourceText.From(UserCode));
 
-                return CompilerHelper.CompileCSharpSilverlightAssembly(assemblyname, files, ReferenceAssemblies);
+                return CompilerHelper.CompileCSharpSilverlightAssembly(assemblyname, files:null, referenceAssemblies: ReferenceAssemblies, sources: contents);
             }
             else
             {
-                return CompilerHelper.CompileVBSilverlightAssembly(assemblyname, files, ReferenceAssemblies);
+                var files = new List<string>(capacity: 2) { GeneratedCodeFile };
+                // If client has added extra user code into the
+                // compile request, add it in now
+                string userCodeFile = this.UserCodeFile;
+                if (!string.IsNullOrEmpty(userCodeFile))
+                {
+                    files.Add(userCodeFile);
+                }
+
+                return CompilerHelper.CompileVBSilverlightAssembly(assemblyname, files, ReferenceAssemblies, rootNamespace: "TestRootNS", documentationFile: null);
             }
         }
 

--- a/OpenRiaServices.DomainServices.Tools/Test/AssemblyGenerator.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/AssemblyGenerator.cs
@@ -463,27 +463,18 @@ namespace OpenRiaServices.DomainServices.Tools.Test
         private MemoryStream CompileSource()
         {
             string assemblyname = Path.GetFileNameWithoutExtension(this.OutputAssemblyName);
+            var contents = new List<SourceText>(capacity: 2);
+            contents.Add(SourceText.From(GeneratedCode));
+            if (!string.IsNullOrEmpty(UserCode))
+                contents.Add(SourceText.From(UserCode));
+
             if (this._isCSharp)
             {
-                var contents = new List<SourceText>(capacity: 2);
-                contents.Add(SourceText.From(GeneratedCode));
-                if (!string.IsNullOrEmpty(UserCode))
-                    contents.Add(SourceText.From(UserCode));
-
-                return CompilerHelper.CompileCSharpSilverlightAssembly(assemblyname, files:null, referenceAssemblies: ReferenceAssemblies, sources: contents);
+                return CompilerHelper.CompileCSharpSilverlightAssembly(assemblyname, contents, referenceAssemblies: ReferenceAssemblies);
             }
             else
             {
-                var files = new List<string>(capacity: 2) { GeneratedCodeFile };
-                // If client has added extra user code into the
-                // compile request, add it in now
-                string userCodeFile = this.UserCodeFile;
-                if (!string.IsNullOrEmpty(userCodeFile))
-                {
-                    files.Add(userCodeFile);
-                }
-
-                return CompilerHelper.CompileVBSilverlightAssembly(assemblyname, files, ReferenceAssemblies, rootNamespace: "TestRootNS", documentationFile: null);
+                return CompilerHelper.CompileVBSilverlightAssembly(assemblyname, contents, ReferenceAssemblies, rootNamespace: "TestRootNS", documentationFile: null);
             }
         }
 

--- a/OpenRiaServices.DomainServices.Tools/Test/CompilerHelper.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/CompilerHelper.cs
@@ -15,6 +15,8 @@ namespace OpenRiaServices.DomainServices.Tools.Test
     {
         // The version of Silverlight we use in registry keys below
         private const string SLVER = "v5.0";
+        private static ParseOptions _cSharpParseOptions = new CSharpParseOptions(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp5,  preprocessorSymbols: new
+                    [] { "SILVERLIGHT" });
 
         /// <summary>
         /// Invokes CSC to build the given files against the given set of references
@@ -61,13 +63,10 @@ namespace OpenRiaServices.DomainServices.Tools.Test
 
             try
             {
-                var parseOptions = new CSharpParseOptions(preprocessorSymbols: new
-                    [] { "SILVERLIGHT" });
-
                 // Parse files
                 List<SyntaxTree> syntaxTrees = new List<SyntaxTree>();
                 foreach (var file in files)
-                    syntaxTrees.Add(ParseCSharpFile(file, parseOptions));
+                    syntaxTrees.Add(ParseCSharpFile(file, _cSharpParseOptions));
 
                 // Do compilation when parsing succeeded
                 var compileOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
@@ -92,7 +91,8 @@ namespace OpenRiaServices.DomainServices.Tools.Test
 
             try
             {
-                var parseOptions = new VisualBasicParseOptions(preprocessorSymbols: new
+                var parseOptions = new VisualBasicParseOptions(Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14,
+                    preprocessorSymbols: new
                     [] { new KeyValuePair<string, object>("SILVERLIGHT", 1) });
 
                 // Parse files

--- a/OpenRiaServices.DomainServices.Tools/Test/CompilerHelper.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/CompilerHelper.cs
@@ -15,6 +15,8 @@ namespace OpenRiaServices.DomainServices.Tools.Test
     {
         // The version of Silverlight we use in registry keys below
         private const string SLVER = "v5.0";
+        private static Dictionary<string, PortableExecutableReference> s_referenceCache = new Dictionary<string, PortableExecutableReference>();
+
         private static ParseOptions _cSharpParseOptions = new CSharpParseOptions(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp5,  preprocessorSymbols: new
                     [] { "SILVERLIGHT" });
 
@@ -94,6 +96,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                 var parseOptions = new VisualBasicParseOptions(Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14,
                     preprocessorSymbols: new
                     [] { new KeyValuePair<string, object>("SILVERLIGHT", 1) });
+                references.Add(GetVisualBasicReference());
 
                 // Parse files
                 List<SyntaxTree> syntaxTrees = new List<SyntaxTree>();
@@ -115,6 +118,26 @@ namespace OpenRiaServices.DomainServices.Tools.Test
             }
         }
 
+        private static PortableExecutableReference
+            GetReference(string filename)
+        {
+            PortableExecutableReference reference;
+
+            if (s_referenceCache.TryGetValue(filename, out reference))
+            {
+                return reference;
+            }
+
+            reference = MetadataReference.CreateFromFile(filename);
+            s_referenceCache.Add(filename, reference);
+            return reference;
+        }
+
+        private static PortableExecutableReference GetVisualBasicReference()
+        {
+            return GetReference(Path.Combine(GetSilverlightSdkReferenceAssembliesPath(), "Microsoft.VisualBasic.dll"));
+        }
+
         private static MemoryStream Compile(Compilation compilation, string documentationFile)
         {
             var memoryStream = new MemoryStream();
@@ -133,7 +156,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
         {
             List<MetadataReference> references = new List<MetadataReference>();
             foreach (string s in referenceAssemblies)
-                references.Add(MetadataReference.CreateFromFile(s));
+                references.Add(GetReference(s));
             return references;
         }
 

--- a/OpenRiaServices.DomainServices.Tools/Test/CompilerHelper.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/CompilerHelper.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.VisualBasic;
+using System.Collections.Immutable;
 
 namespace OpenRiaServices.DomainServices.Tools.Test
 {
@@ -71,7 +72,8 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                     syntaxTrees.Add(ParseCSharpFile(file, _cSharpParseOptions));
 
                 // Do compilation when parsing succeeded
-                var compileOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+                var compileOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                    assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);
                 Compilation compilation = CSharpCompilation.Create(assemblyName, syntaxTrees, references, compileOptions);
 
                 return Compile(compilation, documentationFile);
@@ -104,7 +106,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                     syntaxTrees.Add(ParseVBFile(file, parseOptions));
 
                 // Do compilation when parsing succeeded
-                var compileOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+                var compileOptions = new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary, assemblyIdentityComparer: DesktopAssemblyIdentityComparer.Default);
                 Compilation compilation = VisualBasicCompilation.Create(assemblyName, syntaxTrees, references, compileOptions);
 
                 // Same file
@@ -149,6 +151,24 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                     Assert.Fail("Failed to compile assembly \r\n {0}", string.Join(" \r\n", emitResult.Diagnostics));
                 }
                 return memoryStream;
+            }
+        }
+
+        class DummyComparer : MetadataReferenceResolver
+        {
+            public override bool Equals(object other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int GetHashCode()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)
+            {
+                throw new NotImplementedException();
             }
         }
 

--- a/OpenRiaServices.DomainServices.Tools/Test/MockBuildEngine.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/MockBuildEngine.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using Microsoft.Build.BuildEngine;
 using Microsoft.Build.Framework;
 using ConsoleLogger = OpenRiaServices.DomainServices.Server.Test.Utilities.ConsoleLogger;
 
@@ -7,7 +6,6 @@ namespace OpenRiaServices.DomainServices.Tools.Test
 {
     class MockBuildEngine : IBuildEngine
     {
-        private readonly Engine _realEngine = new Engine();
         private readonly ConsoleLogger _consoleLogger = new ConsoleLogger();
 
         public ConsoleLogger ConsoleLogger

--- a/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
+++ b/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="WriteProjectPath;Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="WriteProjectPath;Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <FeaturePackageRoot>$(MSBuildProjectDirectory)\..\..</FeaturePackageRoot>
     <TargetFrameworkProfile />
@@ -18,7 +18,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenRiaServices.DomainServices.Tools.Test</RootNamespace>
     <AssemblyName>OpenRiaServices.DomainServices.Tools.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
@@ -50,18 +50,9 @@
   </PropertyGroup>
   <Import Project="$(FeaturePackageRoot)\FeaturePackage.targets" />
   <ItemGroup>
-    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
@@ -70,6 +61,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Linq" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
@@ -196,9 +188,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="NotificationMethodGeneratorTestCodeSnippets.xml">

--- a/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
+++ b/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
@@ -21,6 +21,8 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/OpenRiaServices.DomainServices.Tools/Test/TestHelper.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/TestHelper.cs
@@ -756,12 +756,12 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                 if (isCSharp)
                 {
                     files.AddRange(codeGenOptions.SharedFiles.Where(sharedFile => Path.GetExtension(sharedFile).Equals(".cs")));
-                    CompilerHelper.CompileCSharpSource(files, referenceAssemblies, documentationFile);
+                    CompilerHelper.CompileCSharpSourceFromFiles(files, referenceAssemblies, documentationFile);
                 }
                 else
                 {
                     files.AddRange(codeGenOptions.SharedFiles.Where(sharedFile => Path.GetExtension(sharedFile).Equals(".vb")));
-                    CompilerHelper.CompileVisualBasicSource(files, referenceAssemblies, options.ClientRootNamespace, documentationFile);
+                    CompilerHelper.CompileVisualBasicSourceFromFiles(files, referenceAssemblies, options.ClientRootNamespace, documentationFile);
                 }
             }
             finally

--- a/OpenRiaServices.DomainServices.Tools/Test/packages.config
+++ b/OpenRiaServices.DomainServices.Tools/Test/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="EntityFramework" version="6.1.3" targetFramework="net45" />
-</packages>

--- a/OpenRiaServices.DomainServices.Tools/Test/project.json
+++ b/OpenRiaServices.DomainServices.Tools/Test/project.json
@@ -1,0 +1,11 @@
+﻿{
+    "dependencies": {
+        "EntityFramework": "6.1.3",
+        "Microsoft.CodeAnalysis.CSharp": "2.7.0",
+        "Microsoft.CodeAnalysis.VisualBasic": "2.7.0"
+    },
+    "frameworks": {
+        "net46": {}
+    },
+    "runtimes": { "win": {} }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ init:
 - cmd: git lfs uninstall
 before_build:
 - ps: >-
-    dotnet restore OpenRiaServices.DomainServices.Client\Framework\Silverlight\project.json
+    dotnet restore .
     
     nuget restore RiaServices.sln
     


### PR DESCRIPTION
This will in the long run make it easier to emit code using newver version of CSharp and VisualBasic as well as allowing using never versions of the msbuild framework.

Test run should now also be faster