### PR TITLE
Stop using depreciated msbuild assembly in test projects

### DIFF
--- a/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/OpenRiaServices.DomainServices.Tools.TextTemplate.Test.csproj
+++ b/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/OpenRiaServices.DomainServices.Tools.TextTemplate.Test.csproj
@@ -52,7 +52,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />

--- a/OpenRiaServices.DomainServices.Tools/Test/AssemblyGenerator.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/AssemblyGenerator.cs
@@ -14,7 +14,6 @@ namespace OpenRiaServices.DomainServices.Tools.Test
     {
         private readonly string _relativeTestDir;
         private readonly bool _isCSharp;
-        private string _outputAssemblyName;
         private readonly IEnumerable<Type> _domainServiceTypes;
         private DomainServiceCatalog _domainServiceCatalog;
         private MockBuildEngine _mockBuildEngine;
@@ -22,10 +21,8 @@ namespace OpenRiaServices.DomainServices.Tools.Test
         private string _generatedCode;
         private Assembly _generatedAssembly;
         private IList<string> _referenceAssemblies;
-        private string _generatedCodeFile;
         private Type[] _generatedTypes;
         private string _userCode;
-        private string _userCodeFile;
         private readonly bool _useFullTypeNames;
 
 
@@ -42,6 +39,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
             this._isCSharp = isCSharp;
             this._useFullTypeNames = useFullTypeNames;
             this._domainServiceTypes = domainServiceTypes;
+            this.OutputAssemblyName = Guid.NewGuid().ToString();
         }
 
 
@@ -61,17 +59,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
             }
         }
 
-        internal string OutputAssemblyName
-        {
-            get
-            {
-                if (this._outputAssemblyName == null)
-                {
-                    this._outputAssemblyName = Path.GetTempFileName() + ".dll";
-                }
-                return this._outputAssemblyName;
-            }
-        }
+        internal string OutputAssemblyName { get; }
 
         internal string UserCode
         {
@@ -84,23 +72,6 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                 this._userCode = value;
             }
         }
-
-        internal string UserCodeFile
-        {
-            get
-            {
-                if (this._userCodeFile == null)
-                {
-                    if (!string.IsNullOrEmpty(this.UserCode))
-                    {
-                        this._userCodeFile = Path.GetTempFileName();
-                        File.WriteAllText(this._userCodeFile, this.UserCode);
-                    }
-                }
-                return this._userCodeFile;
-            }
-        }
-
 
         internal MockBuildEngine MockBuildEngine
         {
@@ -361,20 +332,6 @@ namespace OpenRiaServices.DomainServices.Tools.Test
             return false;
         }
 
-        private string GeneratedCodeFile
-        {
-            get
-            {
-                if (this._generatedCodeFile == null)
-                {
-                    this._generatedCodeFile = Path.GetTempFileName();
-                    File.WriteAllText(this._generatedCodeFile, this.GeneratedCode);
-                }
-                return this._generatedCodeFile;
-            }
-
-        }
-
         private string GenerateCode()
         {
             ClientCodeGenerationOptions options = new ClientCodeGenerationOptions()
@@ -486,26 +443,8 @@ namespace OpenRiaServices.DomainServices.Tools.Test
         {
             this._generatedTypes = null;
             this._generatedAssembly = null;
-            this.SafeDelete(this._generatedCodeFile);
-            this.SafeDelete(this._userCodeFile);
         }
 
         #endregion
-
-        private void SafeDelete(string file)
-        {
-            if (!string.IsNullOrEmpty(file) && File.Exists(file))
-            {
-                try
-                {
-                    File.Delete(file);
-                    System.Diagnostics.Debug.WriteLine("Deleted test file: " + file);
-                }
-                catch (Exception ex)
-                {
-                    System.Diagnostics.Debug.WriteLine("Could not delete " + file + ":\r\n" + ex.Message);
-                }
-            }
-        }
     }
 }

--- a/OpenRiaServices.DomainServices.Tools/Test/MsBuildHelper.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/MsBuildHelper.cs
@@ -42,9 +42,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
             var project = LoadProject(projectPath);
 
             // Ask to be told of generated outputs
-            string[] buildTargets = new string[] { "ResolveAssemblyReferences" };
-
-            var results = project.Build(buildTargets);
+            var results = project.Build(new string[] { "ResolveAssemblyReferences" });
             Assert.AreEqual(BuildResultCode.Success, results.OverallResult, "ResolveAssemblyReferences failed");
 
             foreach (var reference in project.ProjectInstance.GetItems("_ResolveAssemblyReferenceResolvedFiles"))

--- a/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
+++ b/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
@@ -53,7 +53,6 @@
   <Import Project="$(FeaturePackageRoot)\FeaturePackage.targets" />
   <ItemGroup>
     <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
@@ -79,6 +78,7 @@
     <Compile Include="DomainServiceClientCodeGeneratorAttributeTests.cs" />
     <Compile Include="FilenameMapTests.cs" />
     <Compile Include="MockCodeGenerationHost.cs" />
+    <Compile Include="MsBuildHelper.cs" />
     <Compile Include="RiaClientFilesTaskTests.cs" />
     <Compile Include="SourceFileLocationServiceTests.cs" />
     <Compile Include="AssemblyGenerator.cs" />
@@ -106,7 +106,6 @@
     <Compile Include="MockBuildEngine.cs" />
     <Compile Include="MockDomainServices.cs" />
     <Compile Include="MockSharedCodeService.cs" />
-    <Compile Include="MsBuildHelper.cs" />
     <Compile Include="NamingTests.cs" />
     <Compile Include="NotificationMethodGeneratorTest.cs" />
     <Compile Include="PdbReaderTests.cs" />

--- a/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
+++ b/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
@@ -78,7 +78,6 @@
     <Compile Include="DomainServiceClientCodeGeneratorAttributeTests.cs" />
     <Compile Include="FilenameMapTests.cs" />
     <Compile Include="MockCodeGenerationHost.cs" />
-    <Compile Include="MsBuildHelper.cs" />
     <Compile Include="RiaClientFilesTaskTests.cs" />
     <Compile Include="SourceFileLocationServiceTests.cs" />
     <Compile Include="AssemblyGenerator.cs" />
@@ -106,6 +105,7 @@
     <Compile Include="MockBuildEngine.cs" />
     <Compile Include="MockDomainServices.cs" />
     <Compile Include="MockSharedCodeService.cs" />
+    <Compile Include="MsBuildHelper.cs" />
     <Compile Include="NamingTests.cs" />
     <Compile Include="NotificationMethodGeneratorTest.cs" />
     <Compile Include="PdbReaderTests.cs" />

--- a/OpenRiaServices.DomainServices.Tools/Test/ProjectFileReaderTests.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/ProjectFileReaderTests.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using OpenRiaServices.DomainServices.Client.Test;
 using OpenRiaServices.DomainServices.Server.Test.Utilities;
-using Microsoft.Build.BuildEngine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ConsoleLogger = OpenRiaServices.DomainServices.Server.Test.Utilities.ConsoleLogger;
 
@@ -89,19 +88,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                     projectFileReader.LoadProject(badProjectPath);
 
                     // Simulate the exception so we get the exact text
-                    string warningMessage = null;
-                    try
-                    {
-                        Engine engine = new Engine();
-                        Project project = new Project(engine);
-                        project.Load(badProjectPath);
-
-                    }
-                    catch (InvalidProjectFileException ipfe)
-                    {
-                        warningMessage = string.Format(CultureInfo.CurrentCulture, Resource.Failed_To_Open_Project, badProjectPath, ipfe.Message);
-                    }
-
+                    string warningMessage = TestHelper.GetFailedToOpenProjectMessage(badProjectPath);
                     TestHelper.AssertContainsWarnings(logger, new string[] { warningMessage });
                 }
                 finally

--- a/OpenRiaServices.DomainServices.Tools/Test/ProjectSourceFileCacheTests.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/ProjectSourceFileCacheTests.cs
@@ -4,8 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using OpenRiaServices.DomainServices.Client.Test;
-using OpenRiaServices.DomainServices.Server.Test.Utilities;
-using Microsoft.Build.BuildEngine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ConsoleLogger = OpenRiaServices.DomainServices.Server.Test.Utilities.ConsoleLogger;
 
@@ -189,19 +187,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                     IEnumerable<string> projects = cache.GetAllKnownProjects();
 
                     // Simulate the exception so we get the exact text
-                    string warningMessage = null;
-                    try
-                    {
-                        Engine engine = new Engine();
-                        Project project = new Project(engine);
-                        project.Load(badProjectPath);
-
-                    }
-                    catch (InvalidProjectFileException ipfe)
-                    {
-                        warningMessage = string.Format(CultureInfo.CurrentCulture, Resource.Failed_To_Open_Project, badProjectPath, ipfe.Message);
-                    }
-
+                    string warningMessage = TestHelper.GetFailedToOpenProjectMessage(badProjectPath);
                     TestHelper.AssertContainsWarnings(logger, new string[] { warningMessage });
 
                 }
@@ -228,19 +214,7 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                     IEnumerable<string> files = projectFileReader.LoadSourceFilesFromProject(badProjectPath);
 
                     // Simulate the exception so we get the exact text
-                    string warningMessage = null;
-                    try
-                    {
-                        Engine engine = new Engine();
-                        Project project = new Project(engine);
-                        project.Load(badProjectPath);
-
-                    }
-                    catch (InvalidProjectFileException ipfe)
-                    {
-                        warningMessage = string.Format(CultureInfo.CurrentCulture, Resource.Failed_To_Open_Project, badProjectPath, ipfe.Message);
-                    }
-
+                    string warningMessage = TestHelper.GetFailedToOpenProjectMessage(badProjectPath);
                     TestHelper.AssertContainsWarnings(logger, new string[] { warningMessage });
 
                 }

--- a/OpenRiaServices.DomainServices.Tools/Test/TestHelper.cs
+++ b/OpenRiaServices.DomainServices.Tools/Test/TestHelper.cs
@@ -13,6 +13,8 @@ using OpenRiaServices.DomainServices.Tools.SharedTypes;
 using OpenRiaServices.DomainServices.Tools.Test;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.DomainServices.Server.Test.Utilities;
+using System.Globalization;
+using Microsoft.Build.Exceptions;
 
 namespace OpenRiaServices.DomainServices.Tools.Test
 {
@@ -658,6 +660,22 @@ namespace OpenRiaServices.DomainServices.Tools.Test
         internal static string GenerateCodeAssertSuccess(string language, IEnumerable<Type> domainServiceTypes, ISharedCodeService typeService)
         {
             return TestHelper.GenerateCodeAssertSuccess(language, domainServiceTypes, new ConsoleLogger(), typeService);
+        }
+
+        internal static string GetFailedToOpenProjectMessage(string badProjectPath)
+        {
+            // Simulate the exception so we get the exact text
+            try
+            {
+                MsBuildHelper.LoadProject(badProjectPath);
+            }
+            catch (InvalidProjectFileException ipfe)
+            {
+                return string.Format(CultureInfo.CurrentCulture, Resource.Failed_To_Open_Project, badProjectPath, ipfe.Message);
+            }
+
+            Assert.Fail("load should have failed");
+            return null;
         }
 
         /// <summary>

--- a/OpenRiaServices.DomainServices.Tools/Test/TestWap/TestWap.csproj
+++ b/OpenRiaServices.DomainServices.Tools/Test/TestWap/TestWap.csproj
@@ -153,7 +153,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != '' and Exists('$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets')" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <ProjectExtensions>
     <VisualStudio>


### PR DESCRIPTION
Stop using depreciated BuildEngine assembly
Instead use Microsoft.Build.Evaluation and Execution
Also cleanup some unused code
This should make updating msbuild dependency easier