### PR TITLE
obsolete old webdomain client constructor

### DIFF
--- a/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient.cs
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient.cs
@@ -41,7 +41,7 @@ namespace OpenRiaServices.DomainServices.Client
         /// is null.
         /// </exception>
         public WebDomainClient(Uri serviceUri)
-            : this(serviceUri, /* usesHttps */ false, (ChannelFactory<TContract>)null)
+            : this(serviceUri, /* usesHttps */ false, (WcfDomainClientFactory)null)
         {
         }
 
@@ -59,7 +59,7 @@ namespace OpenRiaServices.DomainServices.Client
         /// is absolute and <paramref name="usesHttps"/> is true.
         /// </exception>
         public WebDomainClient(Uri serviceUri, bool usesHttps)
-            : this(serviceUri, usesHttps, (ChannelFactory<TContract>)null)
+            : this(serviceUri, usesHttps, (WcfDomainClientFactory)null)
         {
         }
 
@@ -77,6 +77,7 @@ namespace OpenRiaServices.DomainServices.Client
         /// <exception cref="ArgumentException"> is thrown if <paramref name="serviceUri"/>
         /// is absolute and <paramref name="usesHttps"/> is true.
         /// </exception>
+        [Obsolete("Use constructor taking a WcfDomainClientFactory instead")]
         public WebDomainClient(Uri serviceUri, bool usesHttps, ChannelFactory<TContract> channelFactory)
          : this(serviceUri, usesHttps, (WcfDomainClientFactory)null)
         {

--- a/OpenRiaServices.DomainServices.Client/Test/Silverlight/Data/WebDomainClientTests.cs
+++ b/OpenRiaServices.DomainServices.Client/Test/Silverlight/Data/WebDomainClientTests.cs
@@ -617,10 +617,12 @@ namespace OpenRiaServices.DomainServices.Client.Test
 
             this.CityDomainContext =
                 new CityDomainContext(
+#pragma warning disable CS0618 // We are intentionally using constructor which is intended to be removed
                     new WebDomainClient<CityDomainContext.ICityDomainServiceContract>(uri, usesHttps: false, channelFactory: factory)
                     {
                         EntityTypes = new List<Type>() { typeof(City), typeof(Zip) }
                     });
+#pragma warning restore CS0618 // We are intentionally using constructor which is intended to be removed
         }
 
         private void AssertInProgress(IAsyncResult asyncResult)


### PR DESCRIPTION
Removing the constructor will make it easier to extend the WcfDomainClientFactory so that ChannelFactory instances can be cached with much improved timings for "first" access for each DomainContext