### PR TITLE
dont allocate PropertyChangedEventArgs if not needed

### DIFF
--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/DomainDataSource.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/DomainDataSource.cs
@@ -573,7 +573,7 @@ namespace OpenRiaServices.Controls
                 if (this._canRejectChanges != value)
                 {
                     this._canRejectChanges = value;
-                    this.CommandPropertyNotifier.RaisePropertyChanged("CanRejectChanges");
+                    this.CommandPropertyNotifier.RaisePropertyChanged(nameof(CanRejectChanges));
                 }
             }
         }
@@ -596,7 +596,7 @@ namespace OpenRiaServices.Controls
                 if (this._canSubmitChanges != value)
                 {
                     this._canSubmitChanges = value;
-                    this.CommandPropertyNotifier.RaisePropertyChanged("CanSubmitChanges");
+                    this.CommandPropertyNotifier.RaisePropertyChanged(nameof(CanSubmitChanges));
                 }
             }
         }
@@ -1214,7 +1214,7 @@ namespace OpenRiaServices.Controls
             DomainDataSource.ReadOnlyPropertyChanged(depObj, e, "CanLoad");
 
             DomainDataSource dds = (DomainDataSource)depObj;
-            dds.CommandPropertyNotifier.RaisePropertyChanged("CanLoad");
+            dds.CommandPropertyNotifier.RaisePropertyChanged(nameof(CanLoad));
         }
 
         /// <summary>
@@ -1628,7 +1628,7 @@ namespace OpenRiaServices.Controls
             DomainDataSource.ReadOnlyPropertyChanged(depObj, e, "IsSubmittingChanges");
 
             DomainDataSource dds = (DomainDataSource)depObj;
-            dds.CommandPropertyNotifier.RaisePropertyChanged("IsSubmittingChanges");
+            dds.CommandPropertyNotifier.RaisePropertyChanged(nameof(IsSubmittingChanges));
         }
 
         /// <summary>

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/DomainDataSourceView.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/DomainDataSourceView.cs
@@ -822,20 +822,7 @@ namespace OpenRiaServices.Controls
         {
             if (DomainDataSourceView.NotifyProperties.Contains(e.PropertyName))
             {
-                this.OnPropertyChanged(e);
-            }
-        }
-
-        /// <summary>
-        /// Raises property changed events
-        /// </summary>
-        /// <param name="e">The event to raise</param>
-        private void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
-            PropertyChangedEventHandler handler = this._propertyChangedHandler;
-            if (handler != null)
-            {
-                handler(this, e);
+                this._propertyChangedHandler?.Invoke(this, e);
             }
         }
 

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/EntityCollectionView.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/EntityCollectionView.cs
@@ -864,22 +864,22 @@ namespace OpenRiaServices.Controls
 
             if (this.CurrentPosition != oldCurrentPosition)
             {
-                this.RaisePropertyChanged("CurrentPosition");
+                this.RaisePropertyChanged(nameof(CurrentPosition));
             }
 
             if (this.CurrentItem != oldCurrentItem)
             {
-                this.RaisePropertyChanged("CurrentItem");
+                this.RaisePropertyChanged(nameof(CurrentItem));
             }
 
             if (this.IsCurrentBeforeFirst != oldIsCurrentBeforeFirst)
             {
-                this.RaisePropertyChanged("IsCurrentBeforeFirst");
+                this.RaisePropertyChanged(nameof(IsCurrentBeforeFirst));
             }
 
             if (this.IsCurrentAfterLast != oldIsCurrentAfterLast)
             {
-                this.RaisePropertyChanged("IsCurrentAfterLast");
+                this.RaisePropertyChanged(nameof(IsCurrentAfterLast));
             }
         }
 
@@ -1355,7 +1355,7 @@ namespace OpenRiaServices.Controls
                 if (this._canAddNew != value)
                 {
                     this._canAddNew = value;
-                    this.RaisePropertyChanged("CanAddNew");
+                    this.RaisePropertyChanged(nameof(CanAddNew));
                 }
             }
         }
@@ -1375,7 +1375,7 @@ namespace OpenRiaServices.Controls
                 if (this._canCancelEdit != value)
                 {
                     this._canCancelEdit = value;
-                    this.RaisePropertyChanged("CanCancelEdit");
+                    this.RaisePropertyChanged(nameof(CanCancelEdit));
                 }
             }
         }
@@ -1395,7 +1395,7 @@ namespace OpenRiaServices.Controls
                 if (this._canRemove != value)
                 {
                     this._canRemove = value;
-                    this.RaisePropertyChanged("CanRemove");
+                    this.RaisePropertyChanged(nameof(CanRemove));
                 }
             }
         }
@@ -1526,7 +1526,7 @@ namespace OpenRiaServices.Controls
                 if (!Object.Equals(this._currentAddItem, value))
                 {
                     this._currentAddItem = (Entity)value;
-                    this.RaisePropertyChanged("CurrentAddItem");
+                    this.RaisePropertyChanged(nameof(CurrentAddItem));
                     this.CalculateIsAddingNew();
                 }
             }
@@ -1547,7 +1547,7 @@ namespace OpenRiaServices.Controls
                 if (!Object.Equals(this._currentEditItem, value))
                 {
                     this._currentEditItem = (Entity)value;
-                    this.RaisePropertyChanged("CurrentEditItem");
+                    this.RaisePropertyChanged(nameof(CurrentEditItem));
                     this.CalculateIsEditingItem();
                 }
             }
@@ -1628,7 +1628,7 @@ namespace OpenRiaServices.Controls
                 if (this._isAddingNew != value)
                 {
                     this._isAddingNew = value;
-                    this.RaisePropertyChanged("IsAddingNew");
+                    this.RaisePropertyChanged(nameof(IsAddingNew));
                     this.CalculateCanRemove();
                 }
             }
@@ -1649,7 +1649,7 @@ namespace OpenRiaServices.Controls
                 if (this._isEditingItem != value)
                 {
                     this._isEditingItem = value;
-                    this.RaisePropertyChanged("IsEditingItem");
+                    this.RaisePropertyChanged(nameof(IsEditingItem));
                     this.CalculateCanCancelEdit();
                     this.CalculateCanRemove();
                 }

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/FilterDescriptor.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/FilterDescriptor.cs
@@ -199,23 +199,23 @@ namespace OpenRiaServices.Controls
 
         private static void HandleIgnoredValueChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((FilterDescriptor)sender).RaisePropertyChanged("IgnoredValue");
+            ((FilterDescriptor)sender).RaisePropertyChanged(nameof(IgnoredValue));
         }
         private static void HandleIsCaseSensitiveChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((FilterDescriptor)sender).RaisePropertyChanged("IsCaseSensitive");
+            ((FilterDescriptor)sender).RaisePropertyChanged(nameof(IsCaseSensitive));
         }
         private static void HandleOperatorChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((FilterDescriptor)sender).RaisePropertyChanged("Operator");
+            ((FilterDescriptor)sender).RaisePropertyChanged(nameof(Operator));
         }
         private static void HandlePropertyPathChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((FilterDescriptor)sender).RaisePropertyChanged("PropertyPath");
+            ((FilterDescriptor)sender).RaisePropertyChanged(nameof(PropertyPath));
         }
         private static void HandleValueChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((FilterDescriptor)sender).RaisePropertyChanged("Value");
+            ((FilterDescriptor)sender).RaisePropertyChanged(nameof(Value));
         }
 
         /// <summary>

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/GroupDescriptor.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/GroupDescriptor.cs
@@ -82,7 +82,7 @@ namespace OpenRiaServices.Controls
 
         private static void HandlePropertyPathChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((GroupDescriptor)sender).RaisePropertyChanged("PropertyPath");
+            ((GroupDescriptor)sender).RaisePropertyChanged(nameof(PropertyPath));
         }
 
         /// <summary>

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/PagedEntityCollection.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/PagedEntityCollection.cs
@@ -154,7 +154,7 @@ namespace OpenRiaServices.Controls
                     }
 
                     this._sourceEntitySet = value;
-                    this.RaisePropertyChanged("BackingEntitySet");
+                    this.RaisePropertyChanged(nameof(BackingEntitySet));
 
                     if (value != null)
                     {
@@ -179,7 +179,7 @@ namespace OpenRiaServices.Controls
                 if (this._entityType != value)
                 {
                     this._entityType = value;
-                    this.RaisePropertyChanged("EntityType");
+                    this.RaisePropertyChanged(nameof(EntityType));
                 }
             }
         }
@@ -199,7 +199,7 @@ namespace OpenRiaServices.Controls
                 if (this._isPagingOperationPending != value)
                 {
                     this._isPagingOperationPending = value;
-                    this.RaisePropertyChanged("IsPagingOperationPending");
+                    this.RaisePropertyChanged(nameof(IsPagingOperationPending));
                 }
             }
         }
@@ -219,7 +219,7 @@ namespace OpenRiaServices.Controls
                 if (this._itemCount != value)
                 {
                     this._itemCount = value;
-                    this.RaisePropertyChanged("ItemCount");
+                    this.RaisePropertyChanged(nameof(ItemCount));
                 }
             }
         }
@@ -238,7 +238,7 @@ namespace OpenRiaServices.Controls
                 if (this._pageIndex != value)
                 {
                     this._pageIndex = value;
-                    this.RaisePropertyChanged("PageIndex");
+                    this.RaisePropertyChanged(nameof(PageIndex));
                     this.CalculateIsPagingOperationPending();
                 }
             }
@@ -259,7 +259,7 @@ namespace OpenRiaServices.Controls
                 if (this._pageSize != value)
                 {
                     this._pageSize = value;
-                    this.RaisePropertyChanged("PageSize");
+                    this.RaisePropertyChanged(nameof(PageSize));
                 }
             }
         }
@@ -280,7 +280,7 @@ namespace OpenRiaServices.Controls
                 if (this._totalItemCount != value)
                 {
                     this._totalItemCount = value;
-                    this.RaisePropertyChanged("TotalItemCount");
+                    this.RaisePropertyChanged(nameof(TotalItemCount));
                 }
             }
         }
@@ -370,8 +370,8 @@ namespace OpenRiaServices.Controls
                 if (this._pageCount != value)
                 {
                     this._pageCount = value;
-                    this.RaisePropertyChanged("PageCount");
-                    this.RaisePropertyChanged("ItemCount");
+                    this.RaisePropertyChanged(nameof(PageCount));
+                    this.RaisePropertyChanged(nameof(ItemCount));
                 }
             }
         }
@@ -391,7 +391,7 @@ namespace OpenRiaServices.Controls
                 if (this._startPageIndex != value)
                 {
                     this._startPageIndex = value;
-                    this.RaisePropertyChanged("StartPageIndex");
+                    this.RaisePropertyChanged(nameof(StartPageIndex));
                     this.CalculateIsPagingOperationPending();
                 }
             }
@@ -466,7 +466,7 @@ namespace OpenRiaServices.Controls
 
             if ((this.PageSize == 0 || trackedPage >= this.StartPageIndex) && this._raiseCollectionChangedEvents)
             {
-                this.RaisePropertyChanged("ItemCount");
+                this.RaisePropertyChanged(nameof(ItemCount));
             }
         }
 
@@ -616,7 +616,7 @@ namespace OpenRiaServices.Controls
             // Ensure that the added entities are exposed in the collection
             this.AddTrackedItems(e => this.Add(e));
 
-            this.RaisePropertyChanged("ItemCount");
+            this.RaisePropertyChanged(nameof(ItemCount));
             this.RaiseCollectionChanged(NotifyCollectionChangedAction.Reset, null, -1);
             this._raiseCollectionChangedEvents = true;
         }

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/PagedEntityCollectionView.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/PagedEntityCollectionView.cs
@@ -284,7 +284,7 @@ namespace OpenRiaServices.Controls
                 if (this._canAdd != value)
                 {
                     this._canAdd = value;
-                    this.RaisePropertyChanged("CanAdd");
+                    this.RaisePropertyChanged(nameof(CanAdd));
                 }
             }
         }
@@ -306,7 +306,7 @@ namespace OpenRiaServices.Controls
                 if (this._canChangePage != value)
                 {
                     this._canChangePage = value;
-                    this.RaisePropertyChanged("CanChangePage");
+                    this.RaisePropertyChanged(nameof(CanChangePage));
                 }
             }
         }
@@ -440,7 +440,7 @@ namespace OpenRiaServices.Controls
                 if (this.CheckFlag(CollectionViewFlags.IsPageChanging) != value)
                 {
                     this.SetFlag(CollectionViewFlags.IsPageChanging, value);
-                    this.RaisePropertyChanged("IsPageChanging");
+                    this.RaisePropertyChanged(nameof(IsPageChanging));
                 }
             }
         }
@@ -476,7 +476,7 @@ namespace OpenRiaServices.Controls
                 if (this._itemCount != value)
                 {
                     this._itemCount = value;
-                    this.RaisePropertyChanged("ItemCount");
+                    this.RaisePropertyChanged(nameof(ItemCount));
                 }
             }
         }
@@ -495,7 +495,7 @@ namespace OpenRiaServices.Controls
                 if (this._pageIndex != value)
                 {
                     this._pageIndex = value;
-                    this.RaisePropertyChanged("PageIndex");
+                    this.RaisePropertyChanged(nameof(PageIndex));
                 }
             }
         }
@@ -572,7 +572,7 @@ namespace OpenRiaServices.Controls
                         }
 
                         this.SourcePagedEntityList.PageSize = value;
-                        this.RaisePropertyChanged("PageSize");
+                        this.RaisePropertyChanged(nameof(PageSize));
                         this.CalculatePageCount();
                         this.CalculateCanChangePage();
                         this.CalculateCanAdd();
@@ -605,7 +605,7 @@ namespace OpenRiaServices.Controls
                         // if the count has changed
                         if (this.Count != oldCount)
                         {
-                            this.RaisePropertyChanged("Count");
+                            this.RaisePropertyChanged(nameof(Count));
                         }
 
                         // reset currency values
@@ -624,7 +624,7 @@ namespace OpenRiaServices.Controls
                 if (this._pageSize != value)
                 {
                     this._pageSize = value;
-                    this.RaisePropertyChanged("PageSize");
+                    this.RaisePropertyChanged(nameof(PageSize));
                 }
             }
         }
@@ -667,7 +667,7 @@ namespace OpenRiaServices.Controls
                 if (this._totalItemCount != value)
                 {
                     this._totalItemCount = value;
-                    this.RaisePropertyChanged("TotalItemCount");
+                    this.RaisePropertyChanged(nameof(TotalItemCount));
                     this.CalculatePageCount();
                 }
             }
@@ -771,7 +771,7 @@ namespace OpenRiaServices.Controls
                 if (this._pageCount != value)
                 {
                     this._pageCount = value;
-                    this.RaisePropertyChanged("PageCount");
+                    this.RaisePropertyChanged(nameof(PageCount));
                 }
             }
         }
@@ -1534,14 +1534,14 @@ namespace OpenRiaServices.Controls
             // replaced within the collection.
             if (args.Action != NotifyCollectionChangedAction.Replace)
             {
-                this.RaisePropertyChanged("Count");
+                this.RaisePropertyChanged(nameof(Count));
             }
 
             bool listIsEmpty = this.IsEmpty;
             if (listIsEmpty != this.CheckFlag(CollectionViewFlags.CachedIsEmpty))
             {
                 this.SetFlag(CollectionViewFlags.CachedIsEmpty, listIsEmpty);
-                this.RaisePropertyChanged("IsEmpty");
+                this.RaisePropertyChanged(nameof(IsEmpty));
             }
         }
 

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/Parameter.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/Parameter.cs
@@ -91,11 +91,11 @@ namespace OpenRiaServices.Controls
 
         private static void HandleParameterNameChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((Parameter)sender).RaisePropertyChanged("ParameterName");
+            ((Parameter)sender).RaisePropertyChanged(nameof(ParameterName));
         }
         private static void HandleValueChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((Parameter)sender).RaisePropertyChanged("Value");
+            ((Parameter)sender).RaisePropertyChanged(nameof(Value));
         }
 
         /// <summary>

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/PropertyChangedNotifier.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/PropertyChangedNotifier.cs
@@ -57,20 +57,7 @@ namespace OpenRiaServices.Controls
         /// <param name="propertyName">The property that changed</param>
         internal void RaisePropertyChanged(string propertyName)
         {
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
-        }
-
-        /// <summary>
-        /// Raises a <see cref="PropertyChanged"/> event.
-        /// </summary>
-        /// <param name="e">The event to raise</param>
-        private void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
-            PropertyChangedEventHandler handler = this.PropertyChanged;
-            if (handler != null)
-            {
-                handler(this._sender, e);
-            }
+            PropertyChanged?.Invoke(this._sender, new PropertyChangedEventArgs(propertyName));
         }
 
         #endregion

--- a/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/SortDescriptor.cs
+++ b/OpenRiaServices.Controls.DomainServices/Framework/OpenRiaServices.Windows.Controls/SortDescriptor.cs
@@ -104,11 +104,11 @@ namespace OpenRiaServices.Controls
 
         private static void HandleDirectionChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((SortDescriptor)sender).RaisePropertyChanged("Direction");
+            ((SortDescriptor)sender).RaisePropertyChanged(nameof(Direction));
         }
         private static void HandlePropertyPathChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            ((SortDescriptor)sender).RaisePropertyChanged("PropertyPath");
+            ((SortDescriptor)sender).RaisePropertyChanged(nameof(PropertyPath));
         }
 
         /// <summary>

--- a/OpenRiaServices.Data.DomainServices/Framework/CollectionViewWrapper.cs
+++ b/OpenRiaServices.Data.DomainServices/Framework/CollectionViewWrapper.cs
@@ -937,20 +937,7 @@ namespace OpenRiaServices.Data.DomainServices
         /// <param name="e">The event args</param>
         protected virtual void OnViewPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            this.OnPropertyChanged(e);
-        }
-
-        /// <summary>
-        /// Raises a <see cref="PropertyChanged"/> event
-        /// </summary>
-        /// <param name="e">The event args</param>
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
-            PropertyChangedEventHandler handler = this.PropertyChanged;
-            if (handler != null)
-            {
-                handler(this, e);
-            }
+            PropertyChanged?.Invoke(this, e);
         }
 
         #endregion

--- a/OpenRiaServices.Data.DomainServices/Framework/CollectionViewWrapper.cs
+++ b/OpenRiaServices.Data.DomainServices/Framework/CollectionViewWrapper.cs
@@ -940,6 +940,11 @@ namespace OpenRiaServices.Data.DomainServices
             PropertyChanged?.Invoke(this, e);
         }
 
+        protected void RaisePropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
         #endregion
 
         #region Nested Classes

--- a/OpenRiaServices.Data.DomainServices/Framework/DomainCollectionView.cs
+++ b/OpenRiaServices.Data.DomainServices/Framework/DomainCollectionView.cs
@@ -524,15 +524,6 @@ namespace OpenRiaServices.Data.DomainServices
             }
         }
 
-        /// <summary>
-        /// Raises <see cref="INotifyPropertyChanged.PropertyChanged"/> events for the specified property
-        /// </summary>
-        /// <param name="propertyName">The property to raise an event for</param>
-        protected void RaisePropertyChanged(string propertyName)
-        {
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
-        }
-
         #endregion
 
         #region Nested Classes

--- a/OpenRiaServices.Data.DomainServices/Framework/DomainCollectionView.cs
+++ b/OpenRiaServices.Data.DomainServices/Framework/DomainCollectionView.cs
@@ -481,7 +481,7 @@ namespace OpenRiaServices.Data.DomainServices
             if (this._canChangePage != canChangePage)
             {
                 this._canChangePage = canChangePage;
-                this.RaisePropertyChanged("CanChangePage");
+                this.RaisePropertyChanged(nameof(CanChangePage));
             }
         }
 
@@ -494,7 +494,7 @@ namespace OpenRiaServices.Data.DomainServices
             if (this._canGroup != canGroup)
             {
                 this._canGroup = canGroup;
-                this.RaisePropertyChanged("CanGroup");
+                this.RaisePropertyChanged(nameof(CanGroup));
             }
         }
 
@@ -507,7 +507,7 @@ namespace OpenRiaServices.Data.DomainServices
             if (this._canSort != canSort)
             {
                 this._canSort = canSort;
-                this.RaisePropertyChanged("CanSort");
+                this.RaisePropertyChanged(nameof(CanSort));
             }
         }
 
@@ -520,7 +520,7 @@ namespace OpenRiaServices.Data.DomainServices
             if (this._pageIndex != pageIndex)
             {
                 this._pageIndex = pageIndex;
-                this.RaisePropertyChanged("PageIndex");
+                this.RaisePropertyChanged(nameof(PageIndex));
             }
         }
 

--- a/OpenRiaServices.Data.DomainServices/Framework/PagedCollectionViewBase.cs
+++ b/OpenRiaServices.Data.DomainServices/Framework/PagedCollectionViewBase.cs
@@ -350,20 +350,8 @@ namespace OpenRiaServices.Data.DomainServices
             {
                 throw new ArgumentNullException("propertyName");
             }
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
-        }
 
-        /// <summary>
-        /// Raises a <see cref="PropertyChanged"/> event
-        /// </summary>
-        /// <param name="e">The event args</param>
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
-            PropertyChangedEventHandler handler = this.PropertyChanged;
-            if (handler != null)
-            {
-                handler(this, e);
-            }
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         #endregion

--- a/OpenRiaServices.Data.DomainServices/Framework/PagedCollectionViewBase.cs
+++ b/OpenRiaServices.Data.DomainServices/Framework/PagedCollectionViewBase.cs
@@ -70,7 +70,7 @@ namespace OpenRiaServices.Data.DomainServices
                 if (this._canChangePage != value)
                 {
                     this._canChangePage = value;
-                    this.RaisePropertyChanged("CanChangePage");
+                    this.RaisePropertyChanged(nameof(CanChangePage));
                 }
             }
         }
@@ -98,7 +98,7 @@ namespace OpenRiaServices.Data.DomainServices
                 if (this._isPageChanging != value)
                 {
                     this._isPageChanging = value;
-                    this.RaisePropertyChanged("IsPageChanging");
+                    this.RaisePropertyChanged(nameof(IsPageChanging));
                 }
             }
         }
@@ -118,7 +118,7 @@ namespace OpenRiaServices.Data.DomainServices
                 if (this._itemCount != value)
                 {
                     this._itemCount = value;
-                    this.RaisePropertyChanged("ItemCount");
+                    this.RaisePropertyChanged(nameof(ItemCount));
                 }
             }
         }
@@ -152,7 +152,7 @@ namespace OpenRiaServices.Data.DomainServices
                 if (this._pageIndex != value)
                 {
                     this._pageIndex = value;
-                    this.RaisePropertyChanged("PageIndex");
+                    this.RaisePropertyChanged(nameof(PageIndex));
                 }
             }
         }
@@ -171,7 +171,7 @@ namespace OpenRiaServices.Data.DomainServices
                 if (this._pageSize != value)
                 {
                     this._pageSize = value;
-                    this.RaisePropertyChanged("PageSize");
+                    this.RaisePropertyChanged(nameof(PageSize));
                 }
             }
         }
@@ -190,7 +190,7 @@ namespace OpenRiaServices.Data.DomainServices
                 if (this._totalItemCount != value)
                 {
                     this._totalItemCount = value;
-                    this.RaisePropertyChanged("TotalItemCount");
+                    this.RaisePropertyChanged(nameof(TotalItemCount));
                 }
             }
         }

--- a/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationOperation.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationOperation.cs
@@ -210,7 +210,7 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         {
             if (this.User != null)
             {
-                this.RaisePropertyChanged("User");
+                this.RaisePropertyChanged(nameof(User));
             }
         }
 

--- a/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationService.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationService.cs
@@ -532,19 +532,12 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
             {
                 throw new ArgumentNullException("propertyName");
             }
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
-        }
-
-        /// <summary>
-        /// Raises a <see cref="INotifyPropertyChanged.PropertyChanged"/> event.
-        /// </summary>
-        /// <param name="e">The event to raise</param>
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
+            
             PropertyChangedEventHandler handler = this._propertyChangedEventHandler;
             if (handler != null)
             {
-                this.RunInSynchronizationContext(state => handler(this, e), null);
+                var eventArgs = new PropertyChangedEventArgs(propertyName);
+                this.RunInSynchronizationContext(state => handler(this, eventArgs), null);
             }
         }
 

--- a/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationService.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationService.cs
@@ -414,9 +414,9 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
                     // Raise notification events as appropriate
                     if (raiseUserChanged)
                     {
-                        this.RaisePropertyChanged("User");
+                        this.RaisePropertyChanged(nameof(User));
                     }
-                    this.RaisePropertyChanged("IsBusy");
+                    this.RaisePropertyChanged(nameof(IsBusy));
                     this.RaisePropertyChanged(AuthenticationService.GetBusyPropertyName(ao));
 
                     if (raiseLoggedIn)
@@ -459,7 +459,7 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
                 throw;
             }
 
-            this.RaisePropertyChanged("IsBusy");
+            this.RaisePropertyChanged(nameof(IsBusy));
             this.RaisePropertyChanged(AuthenticationService.GetBusyPropertyName(this.Operation));
         }
 

--- a/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LoginOperation.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LoginOperation.cs
@@ -92,7 +92,7 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
             base.RaiseCompletionPropertyChanges();
             if (this.LoginSuccess)
             {
-                this.RaisePropertyChanged("LoginSuccess");
+                this.RaisePropertyChanged(nameof(LoginSuccess));
             }
         }
 

--- a/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/WebContextBase.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/WebContextBase.cs
@@ -129,8 +129,8 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
                     ((INotifyPropertyChanged)this._authentication).PropertyChanged -= this.AuthenticationService_PropertyChanged;
                     this._authentication = value;
                     ((INotifyPropertyChanged)this._authentication).PropertyChanged += this.AuthenticationService_PropertyChanged;
-                    this.RaisePropertyChanged("Authentication");
-                    this.RaisePropertyChanged("User");
+                    this.RaisePropertyChanged(nameof(Authentication));
+                    this.RaisePropertyChanged(nameof(User));
                 }
             }
         }
@@ -164,7 +164,7 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         {
             if (e.PropertyName == "User")
             {
-                this.RaisePropertyChanged("User");
+                this.RaisePropertyChanged(nameof(User));
             }
         }
 

--- a/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/WebContextBase.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/WebContextBase.cs
@@ -81,7 +81,7 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         /// </exception>
         public static WebContextBase Current
         {
-            get 
+            get
             {
                 if (WebContextBase.current == null)
                 {
@@ -152,20 +152,7 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
             {
                 throw new ArgumentNullException("propertyName");
             }
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
-        }
-
-        /// <summary>
-        /// Raises an <see cref="INotifyPropertyChanged.PropertyChanged"/> event.
-        /// </summary>
-        /// <param name="e">The event to raise</param>
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
-            PropertyChangedEventHandler handler = this._propertyChangedEventHandler;
-            if (handler != null)
-            {
-                handler(this, e);
-            }
+            this._propertyChangedEventHandler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         /// <summary>

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/ComplexObject.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/ComplexObject.cs
@@ -225,24 +225,16 @@ namespace OpenRiaServices.DomainServices.Client
                 throw new ArgumentNullException("propertyName");
             }
 
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+            OnPropertyChanged(propertyName);
         }
 
         /// <summary>
         /// Called when a <see cref="ComplexObject"/> property has changed.
         /// </summary>
-        /// <param name="e">The event arguments</param>
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
+        /// <param name="propertyName">The name of the property that has changed</param>
+        protected virtual void OnPropertyChanged(string propertyName)
         {
-            if (e == null)
-            {
-                throw new ArgumentNullException("e");
-            }
-
-            if (this._propChangedHandler != null)
-            {
-                this._propChangedHandler(this, e);
-            }
+            _propChangedHandler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         /// <summary>
@@ -273,7 +265,7 @@ namespace OpenRiaServices.DomainServices.Client
 
             this.OnDataMemberChanged();
 
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+            this.OnPropertyChanged(propertyName);
         }
 
         /// <summary>

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/ComplexObject.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/ComplexObject.cs
@@ -813,12 +813,12 @@ namespace OpenRiaServices.DomainServices.Client
 
             protected override void OnCollectionChanged()
             {
-                this._complexObject.RaisePropertyChanged("ValidationErrors");
+                this._complexObject.RaisePropertyChanged(nameof(ValidationErrors));
             }
 
             protected override void OnHasErrorsChanged()
             {
-                this._complexObject.RaisePropertyChanged("HasValidationErrors");
+                this._complexObject.RaisePropertyChanged(nameof(HasValidationErrors));
             }
             protected override void OnPropertyErrorsChanged(string propertyName)
             {

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/DomainContext.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/DomainContext.cs
@@ -137,7 +137,7 @@ namespace OpenRiaServices.DomainServices.Client
             private set
             {
                 this._isSubmitting = value;
-                this.RaisePropertyChanged("IsSubmitting");
+                this.RaisePropertyChanged(nameof(IsSubmitting));
             }
         }
 
@@ -830,7 +830,7 @@ namespace OpenRiaServices.DomainServices.Client
             if (string.CompareOrdinal(e.PropertyName, "HasChanges") == 0)
             {
                 // just pass the event on
-                this.RaisePropertyChanged("HasChanges");
+                this.RaisePropertyChanged(nameof(HasChanges));
             }
         }
 
@@ -1128,7 +1128,7 @@ namespace OpenRiaServices.DomainServices.Client
 
             if (this._activeLoadCount == 1)
             {
-                this.RaisePropertyChanged("IsLoading");
+                this.RaisePropertyChanged(nameof(IsLoading));
             }
         }
 
@@ -1140,7 +1140,7 @@ namespace OpenRiaServices.DomainServices.Client
 
             if (this._activeLoadCount == 0)
             {
-                this.RaisePropertyChanged("IsLoading");
+                this.RaisePropertyChanged(nameof(IsLoading));
             }
         }
 

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/Entity.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/Entity.cs
@@ -1108,26 +1108,18 @@ namespace OpenRiaServices.DomainServices.Client
         /// <summary>
         /// Called when an <see cref="Entity"/> property has changed.
         /// </summary>
-        /// <param name="e">The event arguments</param>
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
+        /// <param name="propertyName">name of the property</param>
+        protected virtual void OnPropertyChanged(string propertyName)
         {
-            if (e == null)
-            {
-                throw new ArgumentNullException("e");
-            }
-
             // if we're in an edit session, we want to postpone association updates
             // until the edits are commited (EndEdit is called). Note: we only want
             // to process association updates here when we're attached.
             if (!this.IsEditing && this.EntitySet != null)
             {
-                this.EntitySet.UpdateRelatedAssociations(this, e.PropertyName);
+                this.EntitySet.UpdateRelatedAssociations(this, propertyName);
             }
 
-            if (this._propChangedHandler != null)
-            {
-                this._propChangedHandler(this, e);
-            }
+            this._propChangedHandler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         /// <summary>
@@ -1145,7 +1137,7 @@ namespace OpenRiaServices.DomainServices.Client
 
             this.OnDataMemberChanged();
 
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+            this.OnPropertyChanged(propertyName);
 
             // Note, RaiseDataMemberChanged is called on every property update. We need to avoid as
             // much overhead as possible.
@@ -1223,7 +1215,7 @@ namespace OpenRiaServices.DomainServices.Client
         /// <param name="propertyName">The name of the property that has changed</param>
         protected internal void RaisePropertyChanged(string propertyName)
         {
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+            this.OnPropertyChanged(propertyName);
         }
 
         /// <summary>

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/Entity.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/Entity.cs
@@ -161,7 +161,7 @@ namespace OpenRiaServices.DomainServices.Client
                 if (this._conflict != value)
                 {
                     this._conflict = value;
-                    this.RaisePropertyChanged("EntityConflict");
+                    this.RaisePropertyChanged(nameof(EntityConflict));
                 }
             }
         }
@@ -266,7 +266,7 @@ namespace OpenRiaServices.DomainServices.Client
 
                     if (hasChangesChanged)
                     {
-                        this.RaisePropertyChanged("HasChanges");
+                        this.RaisePropertyChanged(nameof(HasChanges));
 
                         // if we're a composed entity we need to notify our parent
                         // that our state has changed
@@ -462,7 +462,7 @@ namespace OpenRiaServices.DomainServices.Client
 
                     if (wasReadOnly != this.IsReadOnly)
                     {
-                        this.RaisePropertyChanged("IsReadOnly");
+                        this.RaisePropertyChanged(nameof(IsReadOnly));
                     }
                 }
             }
@@ -482,7 +482,7 @@ namespace OpenRiaServices.DomainServices.Client
 
             if (IsReadOnly != wasReadOnly && !preventRaiseReadOnly)
             {
-                RaisePropertyChanged("IsReadOnly");
+                RaisePropertyChanged(nameof(IsReadOnly));
             }
         }
 
@@ -605,7 +605,7 @@ namespace OpenRiaServices.DomainServices.Client
                     this._isSubmitting = value;
                     if (wasReadOnly != this.IsReadOnly)
                     {
-                        this.RaisePropertyChanged("IsReadOnly");
+                        this.RaisePropertyChanged(nameof(IsReadOnly));
                     }
 
                     foreach (var entityAction in MetaType.GetEntityActions())
@@ -884,7 +884,7 @@ namespace OpenRiaServices.DomainServices.Client
             }
 
             if (wasReadOnly != this.IsReadOnly)
-                RaisePropertyChanged("IsReadOnly");
+                RaisePropertyChanged(nameof(IsReadOnly));
         }
 
         internal void UndoDelete()
@@ -1587,7 +1587,7 @@ namespace OpenRiaServices.DomainServices.Client
 
             if (wasReadOnly != this.IsReadOnly)
             {
-                this.RaisePropertyChanged("IsReadOnly");
+                this.RaisePropertyChanged(nameof(IsReadOnly));
             }
 
             // Perform any action state updates required
@@ -2023,12 +2023,12 @@ namespace OpenRiaServices.DomainServices.Client
 
             protected override void OnCollectionChanged()
             {
-                this._entity.RaisePropertyChanged("ValidationErrors");
+                this._entity.RaisePropertyChanged(nameof(ValidationErrors));
             }
 
             protected override void OnHasErrorsChanged()
             {
-                this._entity.RaisePropertyChanged("HasValidationErrors");
+                this._entity.RaisePropertyChanged(nameof(HasValidationErrors));
             }
 
             protected override void OnPropertyErrorsChanged(string propertyName)

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/EntityContainer.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/EntityContainer.cs
@@ -174,7 +174,7 @@ namespace OpenRiaServices.DomainServices.Client
                     {
                         // the set has changes and is the first dirty list
                         // in this container, so raise the change events
-                        this.RaisePropertyChanged("HasChanges");
+                        this.RaisePropertyChanged(nameof(HasChanges));
                     }
                 }
                 else if (this._dirtySetCount > 0)
@@ -184,7 +184,7 @@ namespace OpenRiaServices.DomainServices.Client
                         // if the set has just moved to HasChanges == false and it
                         // is the last dirty set in the this container, raise
                         // the change events
-                        this.RaisePropertyChanged("HasChanges");
+                        this.RaisePropertyChanged(nameof(HasChanges));
                     }
                 }
             }

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/EntitySet.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/EntitySet.cs
@@ -129,7 +129,7 @@ namespace OpenRiaServices.DomainServices.Client
             if (hadChanges)
             {
                 // if we had changes, we no longer do
-                this.RaisePropertyChanged("HasChanges");
+                this.RaisePropertyChanged(nameof(HasChanges));
             }
         }
 
@@ -207,7 +207,7 @@ namespace OpenRiaServices.DomainServices.Client
                     {
                         // this is the first interesting entity in this set
                         // so raise the change notifications
-                        this.RaisePropertyChanged("HasChanges");
+                        this.RaisePropertyChanged(nameof(HasChanges));
                     }
                 }
             }
@@ -221,7 +221,7 @@ namespace OpenRiaServices.DomainServices.Client
                     {
                         // if the last interesting entity has been removed, this set
                         // no longer has changes, so raise the change notifications
-                        this.RaisePropertyChanged("HasChanges");
+                        this.RaisePropertyChanged(nameof(HasChanges));
                     }
                 }
             }

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/EntitySet.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/EntitySet.cs
@@ -1013,28 +1013,11 @@ namespace OpenRiaServices.DomainServices.Client
         /// <param name="propertyName">The property that has changed</param>
         protected void RaisePropertyChanged(string propertyName)
         {
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
-        }
-
-        /// <summary>
-        /// Called when an <see cref="EntitySet"/> property has changed.
-        /// </summary>
-        /// <param name="e">The event arguments</param>
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
-            if (e == null)
-            {
-                throw new ArgumentNullException("e");
-            }
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
             if (this._entityContainer != null)
             {
-                this._entityContainer.SetPropertyChanged(this, e.PropertyName);
-            }
-
-            if (this.PropertyChanged != null)
-            {
-                this.PropertyChanged(this, e);
+                this._entityContainer.SetPropertyChanged(this, propertyName);
             }
         }
 

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/InvokeOperation.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/InvokeOperation.cs
@@ -172,7 +172,7 @@ namespace OpenRiaServices.DomainServices.Client
         internal void Complete(IEnumerable<ValidationResult> validationErrors)
         {
             this._validationErrors = validationErrors;
-            this.RaisePropertyChanged("ValidationErrors");
+            this.RaisePropertyChanged(nameof(ValidationErrors));
 
             string message = string.Format(CultureInfo.CurrentCulture, 
                 Resource.DomainContext_InvokeOperationFailed_Validation, 
@@ -224,7 +224,7 @@ namespace OpenRiaServices.DomainServices.Client
 
             if (this.Result != null && this.Result.ReturnValue != prevValue)
             {
-                this.RaisePropertyChanged("Value");
+                this.RaisePropertyChanged(nameof(Value));
             }
         }
 

--- a/OpenRiaServices.DomainServices.Client/Framework/Data/LoadOperation.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/Data/LoadOperation.cs
@@ -201,7 +201,7 @@ namespace OpenRiaServices.DomainServices.Client
             // events have been raised
             if (result.Entities.Any())
             {
-                this.RaisePropertyChanged("TotalEntityCount");
+                this.RaisePropertyChanged(nameof(TotalEntityCount));
             }
         }
 
@@ -242,7 +242,7 @@ namespace OpenRiaServices.DomainServices.Client
         internal void Complete(IEnumerable<ValidationResult> validationErrors)
         {
             this._validationErrors = validationErrors;
-            this.RaisePropertyChanged("ValidationErrors");
+            this.RaisePropertyChanged(nameof(ValidationErrors));
 
             string message = string.Format(CultureInfo.CurrentCulture,
                 Resource.DomainContext_LoadOperationFailed_Validation,

--- a/OpenRiaServices.DomainServices.Client/Framework/OperationBase.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/OperationBase.cs
@@ -34,9 +34,9 @@ namespace OpenRiaServices.DomainServices.Client
         /// </summary>
         public bool IsErrorHandled
         {
-            get 
-            { 
-                return this._isErrorHandled; 
+            get
+            {
+                return this._isErrorHandled;
             }
         }
 
@@ -179,7 +179,7 @@ namespace OpenRiaServices.DomainServices.Client
             if (!this._isErrorHandled)
             {
                 this._isErrorHandled = true;
-                this.RaisePropertyChanged("IsErrorHandled");
+                this.RaisePropertyChanged(nameof(IsErrorHandled));
             }
         }
 
@@ -206,7 +206,7 @@ namespace OpenRiaServices.DomainServices.Client
             // must flag completion before callbacks or events are raised
             this._completed = true;
             this._canceled = true;
-            
+
             // invoke the cancel action
             this.CancelCore();
 
@@ -218,9 +218,9 @@ namespace OpenRiaServices.DomainServices.Client
                 this._completedEventHandler(this, EventArgs.Empty);
             }
 
-            this.RaisePropertyChanged("IsCanceled");
-            this.RaisePropertyChanged("CanCancel");
-            this.RaisePropertyChanged("IsComplete");
+            this.RaisePropertyChanged(nameof(IsCanceled));
+            this.RaisePropertyChanged(nameof(CanCancel));
+            this.RaisePropertyChanged(nameof(IsComplete));
         }
 
         /// <summary>
@@ -252,10 +252,10 @@ namespace OpenRiaServices.DomainServices.Client
                 this._completedEventHandler(this, EventArgs.Empty);
             }
 
-            this.RaisePropertyChanged("IsComplete");
+            this.RaisePropertyChanged(nameof(IsComplete));
             if (prevCanCancel == true)
             {
-                this.RaisePropertyChanged("CanCancel");
+                this.RaisePropertyChanged(nameof(CanCancel));
             }
         }
 
@@ -286,12 +286,12 @@ namespace OpenRiaServices.DomainServices.Client
                 this._completedEventHandler(this, EventArgs.Empty);
             }
 
-            this.RaisePropertyChanged("Error");
-            this.RaisePropertyChanged("HasError");
-            this.RaisePropertyChanged("IsComplete");
+            this.RaisePropertyChanged(nameof(Error));
+            this.RaisePropertyChanged(nameof(HasError));
+            this.RaisePropertyChanged(nameof(IsComplete));
             if (prevCanCancel == true)
             {
-                this.RaisePropertyChanged("CanCancel");
+                this.RaisePropertyChanged(nameof(CanCancel));
             }
 
             if (!this.IsErrorHandled)
@@ -318,24 +318,12 @@ namespace OpenRiaServices.DomainServices.Client
         }
 
         /// <summary>
-        /// Called when an property has changed on the operation.
-        /// </summary>
-        /// <param name="e">The event arguments</param>
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
-            if (this._propChangedHandler != null)
-            {
-                this._propChangedHandler(this, e);
-            }
-        }
-
-        /// <summary>
         /// Called to raise the PropertyChanged event
         /// </summary>
         /// <param name="propertyName">The name of the property that has changed</param>
         protected void RaisePropertyChanged(string propertyName)
         {
-            this.OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+            this._propChangedHandler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         #region INotifyPropertyChanged Members

--- a/OpenRiaServices.DomainServices.Client/Test/Desktop/ApplicationServices/WebContextBaseTest.cs
+++ b/OpenRiaServices.DomainServices.Client/Test/Desktop/ApplicationServices/WebContextBaseTest.cs
@@ -27,11 +27,6 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices.Test
             {
                 base.RaisePropertyChanged(propertyName);
             }
-
-            public void OnPropertyChangedMock(PropertyChangedEventArgs e)
-            {
-                base.OnPropertyChanged(e);
-            }
         }
 
         private class IdentityMock : IIdentity

--- a/OpenRiaServices.DomainServices.Client/Test/Desktop/Data/ComplexTypeTests.cs
+++ b/OpenRiaServices.DomainServices.Client/Test/Desktop/Data/ComplexTypeTests.cs
@@ -2533,13 +2533,13 @@ namespace TestDomainServices
         public Action<PropertyChangedEventArgs> TestPropertyChangedCallback;
         public Action<ValidationContext, object> TestValidatePropertyCallback;
 
-        protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+        protected override void OnPropertyChanged(string propertyName)
         {
-            base.OnPropertyChanged(e);
+            base.OnPropertyChanged(propertyName);
 
             if (this.TestPropertyChangedCallback != null)
             {
-                this.TestPropertyChangedCallback(e);
+                this.TestPropertyChangedCallback(new PropertyChangedEventArgs(propertyName));
             }
         }
 

--- a/OpenRiaServices.DomainServices.Server/Framework/ApplicationServices/AuthenticationCodeProcessor.cs
+++ b/OpenRiaServices.DomainServices.Server/Framework/ApplicationServices/AuthenticationCodeProcessor.cs
@@ -211,7 +211,7 @@ namespace OpenRiaServices.DomainServices.Server.ApplicationServices
                 // Changes to Name need to raise change notification for IsAuthenticated. To accomplish this,
                 // we'll insert a change event at the end of the "if (this._name != value)" block.
                 //
-                // >> this.RaisePropertyChanged("IsAuthenticated");
+                // >> this.RaisePropertyChanged(nameof(IsAuthenticated));
                 CodeMemberProperty nameProperty = entityTypeDeclaration.Members.OfType<CodeMemberProperty>().Where(c => c.Name == "Name").First();
                 nameProperty.SetStatements.OfType<CodeConditionStatement>().First().TrueStatements.Add(
                     new CodeExpressionStatement(

--- a/VisualStudio/Templates/CSharp/BusinessApplication/Models/LoginInfo.cs
+++ b/VisualStudio/Templates/CSharp/BusinessApplication/Models/LoginInfo.cs
@@ -33,7 +33,7 @@
                 {
                     this.ValidateProperty("UserName", value);
                     this.userName = value;
-                    this.RaisePropertyChanged("UserName");
+                    this.RaisePropertyChanged(nameof(UserName));
                 }
             }
         }
@@ -61,7 +61,7 @@
                 // Do not store the password in a private field as it should not be stored in memory in plain-text.
                 // Instead, the supplied PasswordAccessor serves as the backing store for the value.
 
-                this.RaisePropertyChanged("Password");
+                this.RaisePropertyChanged(nameof(Password));
             }
         }
 
@@ -82,7 +82,7 @@
                 {
                     this.ValidateProperty("RememberMe", value);
                     this.rememberMe = value;
-                    this.RaisePropertyChanged("RememberMe");
+                    this.RaisePropertyChanged(nameof(RememberMe));
                 }
             }
         }
@@ -146,8 +146,8 @@
         /// </summary>
         private void CurrentLoginOperationChanged()
         {
-            this.RaisePropertyChanged("IsLoggingIn");
-            this.RaisePropertyChanged("CanLogIn");
+            this.RaisePropertyChanged(nameof(IsLoggingIn));
+            this.RaisePropertyChanged(nameof(CanLogIn));
         }
 
         /// <summary>

--- a/VisualStudio/Templates/CSharp/BusinessApplication/Models/RegistrationData.partial.cs
+++ b/VisualStudio/Templates/CSharp/BusinessApplication/Models/RegistrationData.partial.cs
@@ -40,7 +40,7 @@
                 // Do not store the password in a private field as it should not be stored in memory in plain-text.
                 // Instead, the supplied PasswordAccessor serves as the backing store for the value.
 
-                this.RaisePropertyChanged("Password");
+                this.RaisePropertyChanged(nameof(Password));
             }
         }
 
@@ -69,7 +69,7 @@
                 // Do not store the password in a private field as it should not be stored in memory in plain-text.  
                 // Instead, the supplied PasswordAccessor serves as the backing store for the value.
 
-                this.RaisePropertyChanged("PasswordConfirmation");
+                this.RaisePropertyChanged(nameof(PasswordConfirmation));
             }
         }
 
@@ -121,7 +121,7 @@
         /// </summary>
         private void CurrentOperationChanged()
         {
-            this.RaisePropertyChanged("IsRegistering");
+            this.RaisePropertyChanged(nameof(IsRegistering));
         }
 
         /// <summary>

--- a/VisualStudio/Templates/CSharp/BusinessApplication/Models/User.partial.cs
+++ b/VisualStudio/Templates/CSharp/BusinessApplication/Models/User.partial.cs
@@ -20,7 +20,7 @@
 
             if (e.PropertyName == "Name" || e.PropertyName == "FriendlyName")
             {
-                this.RaisePropertyChanged("DisplayName");
+                this.RaisePropertyChanged(nameof(DisplayName));
             }
         }
         #endregion

--- a/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicViewModel.cs
+++ b/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicViewModel.cs
@@ -111,7 +111,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
                 if (this._className != value)
                 {
                     this._className = value;
-                    this.RaisePropertyChanged("ClassName");
+                    this.RaisePropertyChanged(nameof(ClassName));
                 }
             }
         }
@@ -217,11 +217,11 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
                         this._currentContextViewModel.PropertyChanged += this.CurrentContextPropertyChanged;
                     }
 
-                    this.RaisePropertyChanged("CurrentContextViewModel");
+                    this.RaisePropertyChanged(nameof(CurrentContextViewModel));
 
                     // Also raise property changed events on calculated properties that depend on current context
-                    this.RaisePropertyChanged("IsMetadataClassGenerationRequested");
-                    this.RaisePropertyChanged("IsMetadataClassGenerationAllowed");
+                    this.RaisePropertyChanged(nameof(IsMetadataClassGenerationRequested));
+                    this.RaisePropertyChanged(nameof(IsMetadataClassGenerationAllowed));
                 }
             }
         }
@@ -257,8 +257,8 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
                 if (this._generateMetadataClasses != value)
                 {
                     this._generateMetadataClasses = value;
-                    this.RaisePropertyChanged("IsMetadataClassGenerationRequested");
-                    this.RaisePropertyChanged("IsMetadataClassGenerationAllowed");
+                    this.RaisePropertyChanged(nameof(IsMetadataClassGenerationRequested));
+                    this.RaisePropertyChanged(nameof(IsMetadataClassGenerationAllowed));
                 }
             }
         }

--- a/VisualStudio/Tools/Framework/DomainServiceWizard/ContextViewModel.cs
+++ b/VisualStudio/Tools/Framework/DomainServiceWizard/ContextViewModel.cs
@@ -80,7 +80,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
                 if (value != this.ContextData.IsClientAccessEnabled)
                 {
                     this.ContextData.IsClientAccessEnabled = value;
-                    this.RaisePropertyChanged("IsClientAccessEnabled");
+                    this.RaisePropertyChanged(nameof(IsClientAccessEnabled));
                 }
             }
         }
@@ -101,7 +101,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
                 if (value != this.ContextData.IsODataEndpointEnabled)
                 {
                     this.ContextData.IsODataEndpointEnabled = value;
-                    this.RaisePropertyChanged("IsODataEndpointEnabled");
+                    this.RaisePropertyChanged(nameof(IsODataEndpointEnabled));
                 }
             }
         }
@@ -138,8 +138,8 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         {
             // Raise a property change for our calculated properties
             // to force them to be re-evaluated by any UI bound to them
-            this.RaisePropertyChanged("IsMetadataClassGenerationAllowed");
-            this.RaisePropertyChanged("IsMetadataClassGenerationRequested");
+            this.RaisePropertyChanged(nameof(IsMetadataClassGenerationAllowed));
+            this.RaisePropertyChanged(nameof(IsMetadataClassGenerationRequested));
         }
 
         /// <summary>

--- a/VisualStudio/Tools/Framework/DomainServiceWizard/ContextViewModel.cs
+++ b/VisualStudio/Tools/Framework/DomainServiceWizard/ContextViewModel.cs
@@ -138,8 +138,8 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         {
             // Raise a property change for our calculated properties
             // to force them to be re-evaluated by any UI bound to them
-            this.RaisePropertyChanged(nameof(IsMetadataClassGenerationAllowed));
-            this.RaisePropertyChanged(nameof(IsMetadataClassGenerationRequested));
+            this.RaisePropertyChanged(nameof(BusinessLogicViewModel.IsMetadataClassGenerationAllowed));
+            this.RaisePropertyChanged(nameof(BusinessLogicViewModel.IsMetadataClassGenerationRequested));
         }
 
         /// <summary>

--- a/VisualStudio/Tools/Framework/DomainServiceWizard/EntityViewModel.cs
+++ b/VisualStudio/Tools/Framework/DomainServiceWizard/EntityViewModel.cs
@@ -77,7 +77,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
                 if (this.EntityData.IsIncluded != value)
                 {
                     this.EntityData.IsIncluded = value;
-                    this.RaisePropertyChanged("IsIncluded");
+                    this.RaisePropertyChanged(nameof(IsIncluded));
                 }
             }  
         }
@@ -100,7 +100,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
                 if (value != this.EntityData.IsEditable && (!value || this.EntityData.CanBeEdited))
                 {
                     this.EntityData.IsEditable = value;
-                    this.RaisePropertyChanged("IsEditable");
+                    this.RaisePropertyChanged(nameof(IsEditable));
 
                     // Setting editability also sets include for convenience
                     if (value)


### PR DESCRIPTION
Today each call to a property setter on an entity results in a PropertyChangedEventArgs  beeing allocated

- [x] Look if other OnPropertyChanged(PropertyChangedEventArgs ..) methods should be removed.