### PR TITLE
Async server

### DIFF
--- a/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
+++ b/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
@@ -17,18 +17,18 @@
       The package also includes a targets file and tools assembly that provides build-time validation of your DomainService classes.
     </description>
     <summary>Open RIA Services - Server-side assemblies, configuration, and build targets.</summary>
-    <releaseNotes>For release notes see https://github.com/OpenRIAServices/OpenRiaServices/releases
-
-4.5.1:
-* Improved startup performance
-* Improved performance for first request
-</releaseNotes>
-    <copyright>2018 Outercurve Foundation</copyright>
+    <releaseNotes>For release notes see https://github.com/OpenRIAServices/OpenRiaServices/releases</releaseNotes>
+    <copyright>2019 Outercurve Foundation</copyright>
     <language>en-US</language>
     <tags>WCF RIA Services RIAServices Server aspnet OpenRiaServices</tags>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework="net46" />
-    </frameworkAssemblies>
+    </frameworkAssemblies>	
+	<dependencies>
+		<group targetFramework="net46">
+			<dependency id="System.Threading.Tasks.Extensions" version="4.5.3"/>
+		</group>
+	</dependencies>
   </metadata>
   <files>
     <file src="content\web.config.transform" target="content\web.config.transform" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -67,6 +67,10 @@
   -->
   <ItemGroup Condition="'$(IsFrameworkProject)' == 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
 </Project>

--- a/src/OpenRiaServices.DomainServices.Client/Framework/Data/QueryResult.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/Data/QueryResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
 
@@ -60,13 +61,28 @@ namespace OpenRiaServices.DomainServices.Client
     [DataContract(Name = "QueryResultOf{0}", Namespace = "DomainServices")]
     public sealed class QueryResult<T> : QueryResult
     {
+
+#if SERVERFX
+        /// <summary>
+        /// Initializes a new instance of the QueryResult class where result is validation error
+        /// </summary>
+        public QueryResult(IEnumerable<ValidationResult> validationErrors)
+        {
+            ValidationErrors = validationErrors;
+        }
+
+        /// <summary>
+        /// Get the ValidationErros for a query (or <c>null</c> if query was successful)
+        /// </summary>
+        [IgnoreDataMember]
+        public IEnumerable<ValidationResult> ValidationErrors { get; }
+#endif
         /// <summary>
         /// Initializes a new instance of the QueryResult class
         /// </summary>
         public QueryResult()
         {
         }
-
         /// <summary>
         /// Initializes a new instance of the QueryResult class with the specified
         /// collection of result items.

--- a/src/OpenRiaServices.DomainServices.Client/Framework/Data/TypeUtility.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/Data/TypeUtility.cs
@@ -493,13 +493,13 @@ namespace OpenRiaServices.DomainServices
         }
 #endif
 
-            /// <summary>
-            /// Performs a check against an assembly to determine if it's a known
-            /// System assembly.
-            /// </summary>
-            /// <param name="assembly">The assembly to check.</param>
-            /// <returns><c>true</c> if the assembly is known to be a system assembly, otherwise <c>false</c>.</returns>
-            internal static bool IsSystemAssembly(this Assembly assembly)
+        /// <summary>
+        /// Performs a check against an assembly to determine if it's a known
+        /// System assembly.
+        /// </summary>
+        /// <param name="assembly">The assembly to check.</param>
+        /// <returns><c>true</c> if the assembly is known to be a system assembly, otherwise <c>false</c>.</returns>
+        internal static bool IsSystemAssembly(this Assembly assembly)
         {
             return IsSystemAssembly(assembly.FullName);
         }

--- a/src/OpenRiaServices.DomainServices.Client/Framework/Data/TypeUtility.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/Data/TypeUtility.cs
@@ -119,7 +119,12 @@ namespace OpenRiaServices.DomainServices
         public static bool IsTaskType(Type type)
         {
             return type == typeof(Task)
-                || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>));
+                || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>))
+#if SERVERFX
+                || type == typeof(ValueTask)
+                || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
+#endif
+                ;
         }
 
         public static Type GetTaskReturnType(Type type)
@@ -128,6 +133,12 @@ namespace OpenRiaServices.DomainServices
                 return typeof(void);
             else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Task<>))
                 return type.GetGenericArguments()[0];
+#if SERVERFX
+            if (type == typeof(ValueTask))
+                return typeof(void);
+            else if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ValueTask<>))
+                return type.GetGenericArguments()[0];
+#endif
             else
                 throw new ArgumentException("Type must be either Task, or Task<T>", "type");
         }
@@ -482,13 +493,13 @@ namespace OpenRiaServices.DomainServices
         }
 #endif
 
-        /// <summary>
-        /// Performs a check against an assembly to determine if it's a known
-        /// System assembly.
-        /// </summary>
-        /// <param name="assembly">The assembly to check.</param>
-        /// <returns><c>true</c> if the assembly is known to be a system assembly, otherwise <c>false</c>.</returns>
-        internal static bool IsSystemAssembly(this Assembly assembly)
+            /// <summary>
+            /// Performs a check against an assembly to determine if it's a known
+            /// System assembly.
+            /// </summary>
+            /// <param name="assembly">The assembly to check.</param>
+            /// <returns><c>true</c> if the assembly is known to be a system assembly, otherwise <c>false</c>.</returns>
+            internal static bool IsSystemAssembly(this Assembly assembly)
         {
             return IsSystemAssembly(assembly.FullName);
         }

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/DbDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/DbDomainService.cs
@@ -188,7 +188,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         {
             try
             {
-                await this.DbContext.SaveChangesAsync(cancellationToken);
+                await this.DbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (DbUpdateConcurrencyException ex)
             {
@@ -221,7 +221,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
                     }
 
                     // If all conflicts were resolved attempt a resubmit
-                    return await this.InvokeSaveChangesAsync(/* retryOnConflict */ false, cancellationToken);
+                    return await this.InvokeSaveChangesAsync(/* retryOnConflict */ false, cancellationToken).ConfigureAwait(false);
                 }
 
                 // if the conflict wasn't resolved, call the error handler

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/DbDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/DbDomainService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
@@ -8,6 +9,7 @@ using System.Data.Entity.Core.Objects;
 using System.Data.Entity.Infrastructure;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 
@@ -101,11 +103,35 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         /// </summary>
         /// <typeparam name="T">The element Type of the query.</typeparam>
         /// <param name="query">The query for which the count should be returned.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> which may be used by hosting layer to request cancellation</param>
         /// <returns>The total number of rows.</returns>
-        protected override int Count<T>(IQueryable<T> query)
+        protected override ValueTask<int> CountAsync<T>(IQueryable<T> query, CancellationToken cancellationToken)
         {
-            return query.Count();
+            return QueryHelper.CountAsync(query, cancellationToken);
         }
+
+        /// <summary>
+        /// Enumerates the specified enumerable to guarantee eager execution. 
+        /// If possible code similar to <c>ToListAsync</c> is used, but with optimizations to start with a larger initial capacity
+        /// </summary>
+        /// <typeparam name="T">The element type of the enumerable.</typeparam>
+        /// <param name="enumerable">The enumerable to enumerate.</param>
+        /// <param name="estimatedResultCount">The estimated number of items the enumerable will yield.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> which may be used by hosting layer to request cancellation</param>
+        /// <returns>A new enumerable with the results of the enumerated enumerable.</returns>
+        protected override ValueTask<IReadOnlyCollection<T>> EnumerateAsync<T>(IEnumerable enumerable, int estimatedResultCount, CancellationToken cancellationToken)
+        {
+            // EF will throw if provider is not a IDbAsyncEnumerable
+            if (enumerable is IDbAsyncEnumerable<T> asyncEnumerable)
+            {
+                return QueryHelper.EnumerateAsyncEnumerable(asyncEnumerable, estimatedResultCount, cancellationToken);
+            }
+            else
+            {
+                return base.EnumerateAsync<T>(enumerable, estimatedResultCount, cancellationToken);
+            }
+        }
+
 
         /// <summary>
         /// This method is called to finalize changes after all the operations in the specified changeset
@@ -113,9 +139,9 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         /// concurrency errors are processed.
         /// </summary>
         /// <returns><c>True</c> if the <see cref="ChangeSet"/> was persisted successfully, <c>false</c> otherwise.</returns>
-        protected override Task<bool> PersistChangeSetAsync()
+        protected override ValueTask<bool> PersistChangeSetAsync(CancellationToken cancellationToken)
         {
-            return this.InvokeSaveChangesAsync(true);
+            return new ValueTask<bool>(this.InvokeSaveChangesAsync(true, cancellationToken));
         }
 
         /// <summary>
@@ -157,11 +183,11 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         /// </summary>
         /// <param name="retryOnConflict">Flag indicating whether to retry after resolving conflicts.</param>
         /// <returns><c>true</c> if saved successfully and <c>false</c> otherwise.</returns>
-        private async Task<bool> InvokeSaveChangesAsync(bool retryOnConflict)
+        private async Task<bool> InvokeSaveChangesAsync(bool retryOnConflict, CancellationToken cancellationToken)
         {
             try
             {
-                await this.DbContext.SaveChangesAsync();
+                await this.DbContext.SaveChangesAsync(cancellationToken);
             }
             catch (DbUpdateConcurrencyException ex)
             {
@@ -194,7 +220,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
                     }
 
                     // If all conflicts were resolved attempt a resubmit
-                    return await this.InvokeSaveChangesAsync(/* retryOnConflict */ false);
+                    return await this.InvokeSaveChangesAsync(/* retryOnConflict */ false, cancellationToken);
                 }
 
                 // if the conflict wasn't resolved, call the error handler

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/DbDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/DbDomainService.cs
@@ -182,6 +182,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         /// Called by PersistChangeSet method to save the changes to the database.
         /// </summary>
         /// <param name="retryOnConflict">Flag indicating whether to retry after resolving conflicts.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns><c>true</c> if saved successfully and <c>false</c> otherwise.</returns>
         private async Task<bool> InvokeSaveChangesAsync(bool retryOnConflict, CancellationToken cancellationToken)
         {

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/DbDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/DbDomainService.cs
@@ -8,6 +8,7 @@ using System.Data.Entity.Core.Objects;
 using System.Data.Entity.Infrastructure;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 
 namespace OpenRiaServices.DomainServices.EntityFramework
@@ -112,9 +113,9 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         /// concurrency errors are processed.
         /// </summary>
         /// <returns><c>True</c> if the <see cref="ChangeSet"/> was persisted successfully, <c>false</c> otherwise.</returns>
-        protected override bool PersistChangeSet()
+        protected override Task<bool> PersistChangeSetAsync()
         {
-            return this.InvokeSaveChanges(true);
+            return this.InvokeSaveChangesAsync(true);
         }
 
         /// <summary>
@@ -156,11 +157,11 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         /// </summary>
         /// <param name="retryOnConflict">Flag indicating whether to retry after resolving conflicts.</param>
         /// <returns><c>true</c> if saved successfully and <c>false</c> otherwise.</returns>
-        private bool InvokeSaveChanges(bool retryOnConflict)
+        private async Task<bool> InvokeSaveChangesAsync(bool retryOnConflict)
         {
             try
             {
-                this.DbContext.SaveChanges();
+                await this.DbContext.SaveChangesAsync();
             }
             catch (DbUpdateConcurrencyException ex)
             {
@@ -193,7 +194,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
                     }
 
                     // If all conflicts were resolved attempt a resubmit
-                    return this.InvokeSaveChanges(/* retryOnConflict */ false);
+                    return await this.InvokeSaveChangesAsync(/* retryOnConflict */ false);
                 }
 
                 // if the conflict wasn't resolved, call the error handler

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/LinqToEntitiesDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/LinqToEntitiesDomainService.cs
@@ -170,7 +170,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         {
             try
             {
-                await this.ObjectContext.SaveChangesAsync(cancellationToken);
+                await this.ObjectContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (OptimisticConcurrencyException ex)
             {
@@ -203,7 +203,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
                     }
 
                     // If all conflicts were resolved attempt a resubmit
-                    return await this.InvokeSaveChanges(/* retryOnConflict */ false, cancellationToken);
+                    return await this.InvokeSaveChanges(/* retryOnConflict */ false, cancellationToken).ConfigureAwait(false);
                 }
 
                 // if the conflict wasn't resolved, call the error handler

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/LinqToEntitiesDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/LinqToEntitiesDomainService.cs
@@ -164,16 +164,16 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         /// concurrency errors are processed.
         /// </summary>
         /// <returns>True if the <see cref="ChangeSet"/> was persisted successfully, false otherwise.</returns>
-        protected override bool PersistChangeSet()
+        protected override Task<bool> PersistChangeSetAsync()
         {
             return this.InvokeSaveChanges(true);
         }
 
-        private bool InvokeSaveChanges(bool retryOnConflict)
+        private async Task<bool> InvokeSaveChanges(bool retryOnConflict)
         {
             try
             {
-                this.ObjectContext.SaveChanges();
+               await this.ObjectContext.SaveChangesAsync();
             }
             catch (OptimisticConcurrencyException ex)
             {
@@ -206,7 +206,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
                     }
 
                     // If all conflicts were resolved attempt a resubmit
-                    return this.InvokeSaveChanges(/* retryOnConflict */ false);
+                    return await this.InvokeSaveChanges(/* retryOnConflict */ false);
                 }
 
                 // if the conflict wasn't resolved, call the error handler

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/LinqToEntitiesDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/LinqToEntitiesDomainService.cs
@@ -163,10 +163,10 @@ namespace OpenRiaServices.DomainServices.EntityFramework
         /// <returns>True if the <see cref="ChangeSet"/> was persisted successfully, false otherwise.</returns>
         protected override ValueTask<bool> PersistChangeSetAsync(CancellationToken cancellationToken)
         {
-            return new ValueTask<bool>(this.InvokeSaveChanges(true, cancellationToken));
+            return new ValueTask<bool>(this.InvokeSaveChangesAsync(true, cancellationToken));
         }
 
-        private async Task<bool> InvokeSaveChanges(bool retryOnConflict, CancellationToken cancellationToken)
+        private async Task<bool> InvokeSaveChangesAsync(bool retryOnConflict, CancellationToken cancellationToken)
         {
             try
             {
@@ -203,7 +203,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
                     }
 
                     // If all conflicts were resolved attempt a resubmit
-                    return await this.InvokeSaveChanges(/* retryOnConflict */ false, cancellationToken).ConfigureAwait(false);
+                    return await this.InvokeSaveChangesAsync(/* retryOnConflict */ false, cancellationToken).ConfigureAwait(false);
                 }
 
                 // if the conflict wasn't resolved, call the error handler

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/QueryHelper.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/QueryHelper.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Data.Entity.Infrastructure;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenRiaServices.DomainServices.EntityFramework
+{
+    static class QueryHelper
+    {
+        public static ValueTask<int> CountAsync<T>(IQueryable<T> query, CancellationToken cancellationToken)
+        {
+            // EF will throw if provider is not a IDbAsyncQueryProvider
+            if (query.Provider is IDbAsyncQueryProvider)
+                return new ValueTask<int>(query.CountAsync(cancellationToken));
+            else
+                return new ValueTask<int>(query.Count());
+        }
+
+        public static async ValueTask<IReadOnlyCollection<T>> EnumerateAsyncEnumerable<T>(IDbAsyncEnumerable<T> asyncEnumerable, int estimatedResultCount, CancellationToken cancellationToken)
+        {
+            using (var enumerator = asyncEnumerable.GetAsyncEnumerator())
+            {
+                List<T> result = new List<T>(capacity: estimatedResultCount);
+                while (await enumerator.MoveNextAsync(cancellationToken))
+                {
+                    result.Add(enumerator.Current);
+                }
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/QueryHelper.cs
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/QueryHelper.cs
@@ -25,7 +25,7 @@ namespace OpenRiaServices.DomainServices.EntityFramework
             using (var enumerator = asyncEnumerable.GetAsyncEnumerator())
             {
                 List<T> result = new List<T>(capacity: estimatedResultCount);
-                while (await enumerator.MoveNextAsync(cancellationToken))
+                while (await enumerator.MoveNextAsync(cancellationToken).ConfigureAwait(false))
                 {
                     result.Add(enumerator.Current);
                 }

--- a/src/OpenRiaServices.DomainServices.Hosting.Local/Framework/Internal/DomainServiceProxyHelper.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.Local/Framework/Internal/DomainServiceProxyHelper.cs
@@ -47,12 +47,16 @@ namespace OpenRiaServices.DomainServices.Hosting.Local
                 throw new InvalidOperationException(errorMessage);
             }
 
-            int totalCount;
             IEnumerable<ValidationResult> validationErrors;
             object[] parameterValues = parameters ?? new object[0];
             QueryDescription queryDescription = new QueryDescription(queryOperation, parameterValues);
 
-            IEnumerable result = service.Query(queryDescription, out validationErrors, out totalCount);
+            // TODO: Look into removing this blocking Wait
+            var queryResult = service.QueryAsync(queryDescription)
+                .GetAwaiter().GetResult();
+
+            validationErrors = queryResult.ValidationErrors;
+            var result = queryResult.Result;
 
             if (validationErrors != null && validationErrors.Any())
             {

--- a/src/OpenRiaServices.DomainServices.Hosting.Local/Framework/Internal/DomainServiceProxyHelper.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.Local/Framework/Internal/DomainServiceProxyHelper.cs
@@ -112,7 +112,7 @@ namespace OpenRiaServices.DomainServices.Hosting.Local
 
             ChangeSet changeSet = new ChangeSet(new[] { changeSetEntry });
 
-            service.Submit(changeSet);
+            service.SubmitAsync(changeSet);
 
             if (changeSetEntry.HasError)
             {

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
@@ -93,17 +93,18 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
             /// <param name="inputs">Input parameters post conversion.</param>
             /// <param name="outputs">Optional out parameters.</param>
             /// <returns>Result of invocation.</returns>
+
             protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
             {
                 outputs = ServiceUtils.EmptyObjectArray;
 
-                IEnumerable<ValidationResult> validationErrors;
-                object result;
-
                 try
                 {
                     InvokeDescription description = new InvokeDescription(this.operation, inputs);
-                    result = ((DomainService)instance).Invoke(description, out validationErrors);
+                    // TODO: Verify it is completed or make async?
+                    var invokeResult = ((DomainService)instance).InvokeAsync(description).GetAwaiter().GetResult();
+                    DomainDataServiceException.HandleValidationErrors(invokeResult.ValidationErrors);
+                    return invokeResult.Result;
                 }
                 catch (UnauthorizedAccessException ex)
                 {
@@ -120,10 +121,6 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                         throw new DomainDataServiceException(Resource.DomainDataService_General_Error, ex);
                     }
                 }
-
-                DomainDataServiceException.HandleValidationErrors(validationErrors);
-
-                return result;
             }
 
             /// <summary>

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
@@ -7,6 +7,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
     using System.ServiceModel.Description;
+    using System.Threading;
     using OpenRiaServices.DomainServices.Server;
 
     #endregion
@@ -102,7 +103,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                 {
                     InvokeDescription description = new InvokeDescription(this.operation, inputs);
                     // TODO: Verify it is completed or make async?
-                    var invokeResult = ((DomainService)instance).InvokeAsync(description).GetAwaiter().GetResult();
+                    var invokeResult = ((DomainService)instance).InvokeAsync(description, CancellationToken.None).GetAwaiter().GetResult();
                     DomainDataServiceException.HandleValidationErrors(invokeResult.ValidationErrors);
                     return invokeResult.Result;
                 }

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
@@ -97,12 +97,11 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
 
             protected override async ValueTask<object> InvokeCoreAsync(object instance, object[] inputs)
             {
+                ServiceInvokeResult invokeResult;
                 try
                 {
                     InvokeDescription description = new InvokeDescription(this.operation, inputs);
-                    var invokeResult = await ((DomainService)instance).InvokeAsync(description, CancellationToken.None);
-                    DomainDataServiceException.HandleValidationErrors(invokeResult.ValidationErrors);
-                    return invokeResult.Result;
+                    invokeResult = await ((DomainService)instance).InvokeAsync(description, CancellationToken.None);
                 }
                 catch (UnauthorizedAccessException ex)
                 {
@@ -119,6 +118,10 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                         throw new DomainDataServiceException(Resource.DomainDataService_General_Error, ex);
                     }
                 }
+
+                // This will throw if there are any validation erros
+                DomainDataServiceException.HandleValidationErrors(invokeResult.ValidationErrors);
+                return invokeResult.Result;
             }
 
             /// <summary>

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
@@ -8,6 +8,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
     using System.Linq;
     using System.ServiceModel.Description;
     using System.Threading;
+    using System.Threading.Tasks;
     using OpenRiaServices.DomainServices.Server;
 
     #endregion
@@ -53,7 +54,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
         /// <param name="dispatchOperation">The run-time object that exposes customization properties for the operation described by operationDescription.</param>
         public void ApplyDispatchBehavior(OperationDescription operationDescription, System.ServiceModel.Dispatcher.DispatchOperation dispatchOperation)
         {
-                dispatchOperation.Invoker = new DomainDataServiceInvokeOperationInvoker(this.operation);
+            dispatchOperation.Invoker = new DomainDataServiceInvokeOperationInvoker(this.operation);
         }
 
         /// <summary>
@@ -92,17 +93,14 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
             /// </summary>
             /// <param name="instance">Instance to invoke the invoker against.</param>
             /// <param name="inputs">Input parameters post conversion.</param>
-            /// <param name="outputs">Optional out parameters.</param>
             /// <returns>Result of invocation.</returns>
 
-            protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
+            protected override async ValueTask<object> InvokeCoreAsync(object instance, object[] inputs)
             {
-                outputs = ServiceUtils.EmptyObjectArray;
-
                 try
                 {
                     InvokeDescription description = new InvokeDescription(this.operation, inputs);
-                    var invokeResult = ((DomainService)instance).InvokeAsync(description, CancellationToken.None).GetAwaiter().GetResult();
+                    var invokeResult = await ((DomainService)instance).InvokeAsync(description, CancellationToken.None);
                     DomainDataServiceException.HandleValidationErrors(invokeResult.ValidationErrors);
                     return invokeResult.Result;
                 }

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
@@ -102,7 +102,6 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                 try
                 {
                     InvokeDescription description = new InvokeDescription(this.operation, inputs);
-                    // TODO: Verify it is completed or make async?
                     var invokeResult = ((DomainService)instance).InvokeAsync(description, CancellationToken.None).GetAwaiter().GetResult();
                     DomainDataServiceException.HandleValidationErrors(invokeResult.ValidationErrors);
                     return invokeResult.Result;

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceInvokeOperationBehavior.cs
@@ -101,7 +101,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                 try
                 {
                     InvokeDescription description = new InvokeDescription(this.operation, inputs);
-                    invokeResult = await ((DomainService)instance).InvokeAsync(description, CancellationToken.None);
+                    invokeResult = await ((DomainService)instance).InvokeAsync(description, CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (UnauthorizedAccessException ex)
                 {

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceOperationInvoker.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceOperationInvoker.cs
@@ -1,17 +1,16 @@
 using System;
 using System.ServiceModel;
+using TaskExtensions = OpenRiaServices.DomainServices.Hosting.TaskExtensions;
+using System.ComponentModel;
+using System.Net;
+using System.Reflection;
+using System.ServiceModel.Dispatcher;
+using OpenRiaServices.DomainServices.Server;
+using System.Web;
+using System.Threading.Tasks;
 
 namespace OpenRiaServices.DomainServices.Hosting.OData
 {
-    #region Namespaces
-    using System.ComponentModel;
-    using System.Net;
-    using System.Reflection;
-    using System.ServiceModel.Dispatcher;
-    using OpenRiaServices.DomainServices.Server;
-    using System.Web;
-
-    #endregion
 
     /// <summary>Base class for all operation invokers supported on the domain data service endpoint.</summary>
     internal abstract class DomainDataServiceOperationInvoker : IOperationInvoker
@@ -29,13 +28,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
         /// <summary>
         /// Gets a value that specifies whether the Invoke or InvokeBegin method is called by the dispatcher.
         /// </summary>
-        public bool IsSynchronous
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool IsSynchronous => false;
 
         /// <summary>
         /// Returns an array of parameter objects.
@@ -43,14 +36,18 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
         /// <returns>The parameters that are to be used as arguments to the operation.</returns>
         public abstract object[] AllocateInputs();
 
+        object IOperationInvoker.Invoke(object instance, object[] inputs, out object[] outputs)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Returns an object and a set of output objects from an instance and set of input objects. 
         /// </summary>
         /// <param name="instance">The object to be invoked.</param>
         /// <param name="inputs">The inputs to the method.</param>
-        /// <param name="outputs">The outputs from the method.</param>
         /// <returns>The return value.</returns>
-        public object Invoke(object instance, object[] inputs, out object[] outputs)
+        public async ValueTask<object> InvokeAsync(object instance, object[] inputs)
         {
             object result = null;
             DomainService domainService = null;
@@ -65,7 +62,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
 
                 // Obtain the result.
                 this.ConvertInputs(inputs);
-                result = this.InvokeCore(domainService, inputs, out outputs);
+                result = await this.InvokeCoreAsync(domainService, inputs).ConfigureAwait(false);
                 result = this.ConvertReturnValue(result);
             }
             catch (DomainDataServiceException)
@@ -112,34 +109,20 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
         /// </summary>
         /// <param name="instance">Instance to invoke the invoker against.</param>
         /// <param name="inputs">Input parameters post conversion.</param>
-        /// <param name="outputs">Optional out parameters.</param>
         /// <returns>Result of invocation.</returns>
-        protected abstract object InvokeCore(object instance, object[] inputs, out object[] outputs);
+        protected abstract ValueTask<object> InvokeCoreAsync(object instance, object[] inputs);
 
-        /// <summary>
-        /// An asynchronous implementation of the Invoke method.
-        /// </summary>
-        /// <param name="instance">The object to be invoked.</param>
-        /// <param name="inputs">The inputs to the method.</param>
-        /// <param name="callback">The asynchronous callback object.</param>
-        /// <param name="state">Associated state data.</param>
-        /// <returns>A System.IAsyncResult used to complete the asynchronous call.</returns>
         public IAsyncResult InvokeBegin(object instance, object[] inputs, AsyncCallback callback, object state)
         {
-            throw new NotSupportedException();
+            return TaskExtensions.BeginApm(InvokeAsync(instance, inputs), callback, state);
         }
 
-        /// <summary>
-        /// The asynchronous end method.
-        /// </summary>
-        /// <param name="instance">The object invoked.</param>
-        /// <param name="outputs">The outputs from the method.</param>
-        /// <param name="result">The System.IAsyncResult object.</param>
-        /// <returns>The return value.</returns>
         public object InvokeEnd(object instance, out object[] outputs, IAsyncResult result)
         {
-            throw new NotSupportedException();
+            outputs = ServiceUtils.EmptyObjectArray;
+            return TaskExtensions.EndApm<object>(result);
         }
+
 
         /// <summary>
         /// Validate the current request.

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceOperationInvoker.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceOperationInvoker.cs
@@ -163,7 +163,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                 (DomainDataServiceContractBehavior.DomainDataServiceInstanceInfo)instance;
 
             IServiceProvider serviceProvider = (IServiceProvider)OperationContext.Current.Host;
-            DomainServiceContext context = new DomainServiceContext(serviceProvider, this.operationType);
+            DomainServiceContext context = new WcfDomainServiceContext(serviceProvider, this.operationType);
 
             try
             {

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceQueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceQueryOperationBehavior.cs
@@ -7,6 +7,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
     using System.ServiceModel.Description;
+    using System.Threading;
     using OpenRiaServices.DomainServices.Server;
 
     #endregion
@@ -106,7 +107,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                 IEnumerable<TEntity> result;
                 try
                 {
-                    var queryTask  = ((DomainService)instance).QueryAsync(queryDesc);
+                    var queryTask  = ((DomainService)instance).QueryAsync<TEntity>(queryDesc, CancellationToken.None);
                     var queryResult = queryTask.ConfigureAwait(false).GetAwaiter().GetResult();
                     validationErrors = queryResult.ValidationErrors;
                     result = (IEnumerable<TEntity>)queryResult.Result;

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceQueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceQueryOperationBehavior.cs
@@ -8,6 +8,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
     using System.Linq;
     using System.ServiceModel.Description;
     using System.Threading;
+    using System.Threading.Tasks;
     using OpenRiaServices.DomainServices.Server;
 
     #endregion
@@ -93,12 +94,10 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
             /// </summary>
             /// <param name="instance">Instance to invoke the invoker against.</param>
             /// <param name="inputs">Input parameters post conversion.</param>
-            /// <param name="outputs">Optional out parameters.</param>
             /// <returns>Result of invocation.</returns>
-            protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
+            protected override async ValueTask<object> InvokeCoreAsync(object instance, object[] inputs)
             {
-                outputs = ServiceUtils.EmptyObjectArray;
-
+                
                 // DEVNOTE(wbasheer): Need to perform query composition here for query options, potentially
                 // need to inject the query options in the message properties somewhere.
                 QueryDescription queryDesc = new QueryDescription(this.operation, inputs);
@@ -108,7 +107,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                 try
                 {
                     var queryTask  = ((DomainService)instance).QueryAsync<TEntity>(queryDesc, CancellationToken.None);
-                    var queryResult = queryTask.ConfigureAwait(false).GetAwaiter().GetResult();
+                    var queryResult = await queryTask.ConfigureAwait(false);
                     validationErrors = queryResult.ValidationErrors;
                     result = (IEnumerable<TEntity>)queryResult.Result;
                 }

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceQueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceQueryOperationBehavior.cs
@@ -106,8 +106,7 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                 IEnumerable<TEntity> result;
                 try
                 {
-                    var queryTask  = ((DomainService)instance).QueryAsync<TEntity>(queryDesc, CancellationToken.None);
-                    var queryResult = await queryTask.ConfigureAwait(false);
+                    var queryResult = await ((DomainService)instance).QueryAsync<TEntity>(queryDesc, CancellationToken.None).ConfigureAwait(false);
                     validationErrors = queryResult.ValidationErrors;
                     result = (IEnumerable<TEntity>)queryResult.Result;
                 }

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceQueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/DomainServices/DomainDataServiceQueryOperationBehavior.cs
@@ -103,11 +103,13 @@ namespace OpenRiaServices.DomainServices.Hosting.OData
                 QueryDescription queryDesc = new QueryDescription(this.operation, inputs);
 
                 IEnumerable<ValidationResult> validationErrors;
-                int totalCount;
                 IEnumerable<TEntity> result;
                 try
                 {
-                    result = (IEnumerable<TEntity>)((DomainService)instance).Query(queryDesc, out validationErrors, out totalCount);
+                    var queryTask  = ((DomainService)instance).QueryAsync(queryDesc);
+                    var queryResult = queryTask.ConfigureAwait(false).GetAwaiter().GetResult();
+                    validationErrors = queryResult.ValidationErrors;
+                    result = (IEnumerable<TEntity>)queryResult.Result;
                 }
                 catch (UnauthorizedAccessException ex)
                 {

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/OpenRiaServices.DomainServices.Hosting.OData.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/OpenRiaServices.DomainServices.Hosting.OData.csproj
@@ -26,6 +26,8 @@
     <Compile Include="..\..\OpenRiaServices.DomainServices.Client\Framework\Data\TypeUtility.cs" Link="Utils\TypeUtility.cs" />
     <Compile Include="..\..\OpenRiaServices.DomainServices.Client\Framework\ExceptionHandlingUtility.cs" Link="Utils\ExceptionHandlingUtility.cs" />
     <Compile Include="..\..\OpenRiaServices.DomainServices.Hosting\Framework\Services\SerializationUtility.cs" Link="Utils\SerializationUtility.cs" />
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Hosting\Framework\Services\TaskExtensions.cs" Link="Utils\TaskExtensions.cs" />
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Hosting\Framework\Services\WcfDomainServiceContext.cs" Link="Utils\WcfDomainServiceContext.cs" />
     <Compile Include="..\..\OpenRiaServices.DomainServices.Server\Framework\TypeDescriptorExtensions.cs" Link="DomainServices\TypeDescriptorExtensions.cs" />
     <Compile Update="Resource.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/DomainOperationInvoker.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/DomainOperationInvoker.cs
@@ -2,6 +2,8 @@
 using System.Reflection;
 using System.ServiceModel;
 using System.ServiceModel.Dispatcher;
+using System.Threading;
+using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 
 namespace OpenRiaServices.DomainServices.Hosting
@@ -9,6 +11,12 @@ namespace OpenRiaServices.DomainServices.Hosting
     internal abstract class DomainOperationInvoker : IOperationInvoker
     {
         private readonly DomainOperationType operationType;
+
+        protected struct InvokeResult
+        {
+            public object result;
+            public object[] outputs;
+        }
 
         public DomainOperationInvoker(DomainOperationType operationType)
         {
@@ -19,7 +27,7 @@ namespace OpenRiaServices.DomainServices.Hosting
         {
             get
             {
-                return true;
+                return false;
             }
         }
 
@@ -33,21 +41,20 @@ namespace OpenRiaServices.DomainServices.Hosting
         public object Invoke(object instance, object[] inputs, out object[] outputs)
         {
             string operationName = this.Name;
-            long startTicks = DateTime.UtcNow.Ticks;
-            object result = null;
-            DomainService domainService = null;
+            long startTicks = DiagnosticUtility.GetTicks();
             try
             {
                 DiagnosticUtility.OperationInvoked(operationName);
 
-                domainService = this.GetDomainService(instance);
+                var domainService = this.GetDomainService(instance);
 
                 // invoke the operation and process the result
                 this.ConvertInputs(inputs);
-                result = this.InvokeCore(domainService, inputs, out outputs);
+                var result = this.InvokeCore(domainService, inputs, out outputs);
                 result = this.ConvertReturnValue(result);
 
                 DiagnosticUtility.OperationCompleted(operationName, DiagnosticUtility.GetDuration(startTicks));
+                return result;
             }
             catch (FaultException)
             {
@@ -70,8 +77,6 @@ namespace OpenRiaServices.DomainServices.Hosting
                 // fault exception.
                 throw ServiceUtility.CreateFaultException(ex);
             }
-
-            return result;
         }
 
         protected virtual void ConvertInputs(object[] inputs)
@@ -83,16 +88,72 @@ namespace OpenRiaServices.DomainServices.Hosting
             return returnValue;
         }
 
-        protected abstract object InvokeCore(object instance, object[] inputs, out object[] outputs);
+        protected virtual object InvokeCore(object instance, object[] inputs, out object[] outputs)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected virtual Task<InvokeResult> InvokeCoreAsync(object instance, object[] inputs)
+        {
+            InvokeResult invokeResult;
+            invokeResult.result = InvokeCore(instance, inputs, out invokeResult.outputs);
+            return Task.FromResult(invokeResult);
+        }
 
         public IAsyncResult InvokeBegin(object instance, object[] inputs, AsyncCallback callback, object state)
         {
-            throw new NotSupportedException();
+            return TaskExtensions.BeginApm(InvokeAsync(instance, inputs), callback, state);
         }
 
         public object InvokeEnd(object instance, out object[] outputs, IAsyncResult result)
         {
-            throw new NotSupportedException();
+            var invokeResult = TaskExtensions.EndApm<InvokeResult>(result);
+
+            outputs = invokeResult.outputs;
+            return invokeResult.result;
+        }
+
+        private async Task<InvokeResult> InvokeAsync(object instance, object[] inputs)
+        {
+            string operationName = this.Name;
+            long startTicks = DiagnosticUtility.GetTicks();
+
+            try
+            {
+                DiagnosticUtility.OperationInvoked(operationName);
+
+                DomainService domainService = this.GetDomainService(instance);
+
+                // invoke the operation and process the result
+                this.ConvertInputs(inputs);
+                var invokeResult = await this.InvokeCoreAsync(domainService, inputs).ConfigureAwait(false);
+                invokeResult.result = this.ConvertReturnValue(invokeResult.result);
+
+                DiagnosticUtility.OperationCompleted(operationName, DiagnosticUtility.GetDuration(startTicks));
+
+                return invokeResult;
+            }
+            catch (FaultException)
+            {
+                DiagnosticUtility.OperationFaulted(operationName, DiagnosticUtility.GetDuration(startTicks));
+
+                // if the exception has already been transformed to a fault
+                // just rethrow it
+                throw;
+            }
+            catch (Exception ex)
+            {
+                if (ex.IsFatal())
+                {
+                    throw;
+                }
+                DiagnosticUtility.OperationFailed(operationName, DiagnosticUtility.GetDuration(startTicks));
+
+                // We need to ensure that any time an exception is thrown by the
+                // service it is transformed to a properly sanitized/configured
+                // fault exception.
+                throw ServiceUtility.CreateFaultException(ex);
+            }
         }
 
         private DomainService GetDomainService(object instance)

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/DomainOperationInvoker.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/DomainOperationInvoker.cs
@@ -11,9 +11,6 @@ namespace OpenRiaServices.DomainServices.Hosting
     internal abstract class DomainOperationInvoker : IOperationInvoker
     {
         private readonly DomainOperationType operationType;
-        private readonly int isCustomErrorEnabled = 0;
-
-        protected bool IsCustomErrorEnabled => isCustomErrorEnabled != 0;
 
         public DomainOperationInvoker(DomainOperationType operationType)
         {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/DomainOperationInvoker.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/DomainOperationInvoker.cs
@@ -62,7 +62,7 @@ namespace OpenRiaServices.DomainServices.Hosting
             return TaskExtensions.EndApm<object>(result);
         }
 
-        private async Task<object> InvokeAsync(object instance, object[] inputs)
+        private async ValueTask<object> InvokeAsync(object instance, object[] inputs)
         {
             long startTicks = DiagnosticUtility.GetTicks();
             bool disableStackTraces = true;

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
@@ -60,7 +60,7 @@ namespace OpenRiaServices.DomainServices.Hosting
             }
 
             //protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
-            protected async override Task<InvokeResult> InvokeCoreAsync(object instance, object[] inputs)
+            protected async override ValueTask<object> InvokeCoreAsync(object instance, object[] inputs)
             {
                 try
                 {
@@ -72,11 +72,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     }
                     else
                     {
-                        return new InvokeResult()
-                        {
-                            result = invokeResult.Result,
-                            outputs = ServiceUtility.EmptyObjectArray
-                        };
+                        return invokeResult.Result;
                     }
                 }
                 catch (Exception ex)

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
@@ -63,22 +63,11 @@ namespace OpenRiaServices.DomainServices.Hosting
 
             protected async override ValueTask<object> InvokeCoreAsync(DomainService instance, object[] inputs, bool disableStackTraces)
             {
+                ServiceInvokeResult invokeResult;
                 try
                 {
                     InvokeDescription invokeDescription = new InvokeDescription(this.operation, inputs);
-                    ServiceInvokeResult invokeResult = await instance.InvokeAsync(invokeDescription, CancellationToken.None);
-                    if (invokeResult.HasValidationErrors)
-                    {
-                        throw ServiceUtility.CreateFaultException(invokeResult.ValidationErrors, disableStackTraces);
-                    }
-                    else
-                    {
-                        return invokeResult.Result;
-                    }
-                }
-                catch(FaultException<DomainServiceFault>) // from validation error
-                {
-                    throw;
+                    invokeResult = await instance.InvokeAsync(invokeDescription, CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -87,6 +76,15 @@ namespace OpenRiaServices.DomainServices.Hosting
                         throw;
                     }
                     throw ServiceUtility.CreateFaultException(ex, disableStackTraces);
+                }
+
+                if (invokeResult.HasValidationErrors)
+                {
+                    throw ServiceUtility.CreateFaultException(invokeResult.ValidationErrors, disableStackTraces);
+                }
+                else
+                {
+                    return invokeResult.Result;
                 }
             }
 

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
@@ -6,6 +6,7 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 
@@ -66,7 +67,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                 try
                 {
                     InvokeDescription invokeDescription = new InvokeDescription(this.operation, inputs);
-                    ServiceInvokeResult invokeResult = await instance.InvokeAsync(invokeDescription);
+                    ServiceInvokeResult invokeResult = await instance.InvokeAsync(invokeDescription, CancellationToken.None);
                     if (invokeResult.HasValidationErrors)
                     {
                         throw ServiceUtility.CreateFaultException(invokeResult.ValidationErrors, disableStackTrace);

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
@@ -61,8 +61,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                 return new object[this.operation.Parameters.Count];
             }
 
-            //protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
-            protected async override ValueTask<object> InvokeCoreAsync(DomainService instance, object[] inputs, bool disableStackTrace)
+            protected async override ValueTask<object> InvokeCoreAsync(DomainService instance, object[] inputs, bool disableStackTraces)
             {
                 try
                 {
@@ -70,7 +69,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     ServiceInvokeResult invokeResult = await instance.InvokeAsync(invokeDescription, CancellationToken.None);
                     if (invokeResult.HasValidationErrors)
                     {
-                        throw ServiceUtility.CreateFaultException(invokeResult.ValidationErrors, disableStackTrace);
+                        throw ServiceUtility.CreateFaultException(invokeResult.ValidationErrors, disableStackTraces);
                     }
                     else
                     {
@@ -87,7 +86,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     {
                         throw;
                     }
-                    throw ServiceUtility.CreateFaultException(ex, disableStackTrace);
+                    throw ServiceUtility.CreateFaultException(ex, disableStackTraces);
                 }
             }
 

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
@@ -65,7 +66,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                 try
                 {
                     InvokeDescription invokeDescription = new InvokeDescription(this.operation, inputs);
-                    var invokeResult = await ((DomainService)instance).InvokeAsync(invokeDescription);
+                    ServiceInvokeResult invokeResult = await ((DomainService)instance).InvokeAsync(invokeDescription);
                     if (invokeResult.HasValidationErrors)
                     {
                         throw ServiceUtility.CreateFaultException(invokeResult.ValidationErrors);
@@ -74,6 +75,10 @@ namespace OpenRiaServices.DomainServices.Hosting
                     {
                         return invokeResult.Result;
                     }
+                }
+                catch(FaultException<DomainServiceFault>) // from validation error
+                {
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/InvokeOperationBehavior.cs
@@ -61,15 +61,15 @@ namespace OpenRiaServices.DomainServices.Hosting
             }
 
             //protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
-            protected async override ValueTask<object> InvokeCoreAsync(object instance, object[] inputs)
+            protected async override ValueTask<object> InvokeCoreAsync(DomainService instance, object[] inputs, bool disableStackTrace)
             {
                 try
                 {
                     InvokeDescription invokeDescription = new InvokeDescription(this.operation, inputs);
-                    ServiceInvokeResult invokeResult = await ((DomainService)instance).InvokeAsync(invokeDescription);
+                    ServiceInvokeResult invokeResult = await instance.InvokeAsync(invokeDescription);
                     if (invokeResult.HasValidationErrors)
                     {
-                        throw ServiceUtility.CreateFaultException(invokeResult.ValidationErrors);
+                        throw ServiceUtility.CreateFaultException(invokeResult.ValidationErrors, disableStackTrace);
                     }
                     else
                     {
@@ -86,7 +86,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     {
                         throw;
                     }
-                    throw ServiceUtility.CreateFaultException(ex);
+                    throw ServiceUtility.CreateFaultException(ex, disableStackTrace);
                 }
             }
 

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
@@ -97,7 +97,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                 try
                 {
                     QueryOperationInvoker.SetOutputCachingPolicy(httpContext, this.operation);
-                    QueryResult<TEntity> result = await QueryProcessor.Process<TEntity>((DomainService)instance, this.operation, inputs, serviceQuery);
+                    QueryResult<TEntity> result = await QueryProcessor.Process<TEntity>(instance, this.operation, inputs, serviceQuery);
 
                     if (result.ValidationErrors != null && result.ValidationErrors.Any())
                     {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
@@ -150,6 +150,9 @@ namespace OpenRiaServices.DomainServices.Hosting
             /// <param name="domainOperationEntry">The domain operation entry we need to define the cache policy for.</param>
             private static void SetOutputCachingPolicy(HttpContext context, DomainOperationEntry domainOperationEntry)
             {
+                if (context == null)
+                    return;
+
                 if (QueryOperationInvoker.SupportsCaching(context, domainOperationEntry))
                 {
                     OutputCacheAttribute outputCacheInfo = QueryOperationInvoker.GetOutputCacheInformation(domainOperationEntry);

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
@@ -78,7 +78,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                 return new object[this.operation.Parameters.Count];
             }
 
-            protected override async Task<InvokeResult> InvokeCoreAsync(object instance, object[] inputs)
+            protected override async ValueTask<object> InvokeCoreAsync(object instance, object[] inputs)
             {
                 ServiceQuery serviceQuery = null;
                 QueryAttribute queryAttribute = (QueryAttribute)this.operation.OperationAttribute;
@@ -112,11 +112,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     throw ServiceUtility.CreateFaultException(result.ValidationErrors);
                 }
 
-                return new InvokeResult()
-                {
-                    result = result,
-                    outputs = ServiceUtility.EmptyObjectArray,
-                };
+                return result;
             }
 
             protected override void ConvertInputs(object[] inputs)

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
@@ -94,21 +94,11 @@ namespace OpenRiaServices.DomainServices.Hosting
                     }
                 }
 
+                QueryResult<TEntity> result;
                 try
                 {
                     QueryOperationInvoker.SetOutputCachingPolicy(httpContext, this.operation);
-                    QueryResult<TEntity> result = await QueryProcessor.ProcessAsync<TEntity>(instance, this.operation, inputs, serviceQuery);
-
-                    if (result.ValidationErrors != null && result.ValidationErrors.Any())
-                    {
-                        throw ServiceUtility.CreateFaultException(result.ValidationErrors, disableStackTraces);
-                    }
-
-                    return result;
-                }
-                catch (FaultException<DomainServiceFault>) // from validation error
-                {
-                    throw;
+                    result = await QueryProcessor.ProcessAsync<TEntity>(instance, this.operation, inputs, serviceQuery);
                 }
                 catch (Exception ex)
                 {
@@ -119,6 +109,14 @@ namespace OpenRiaServices.DomainServices.Hosting
                     QueryOperationInvoker.ClearOutputCachingPolicy(httpContext);
                     throw ServiceUtility.CreateFaultException(ex, disableStackTraces);
                 }
+
+
+                if (result.ValidationErrors != null && result.ValidationErrors.Any())
+                {
+                    throw ServiceUtility.CreateFaultException(result.ValidationErrors, disableStackTraces);
+                }
+
+                return result;
             }
 
             protected override void ConvertInputs(object[] inputs)

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/QueryOperationBehavior.cs
@@ -97,7 +97,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                 try
                 {
                     QueryOperationInvoker.SetOutputCachingPolicy(httpContext, this.operation);
-                    QueryResult<TEntity> result = await QueryProcessor.Process<TEntity>(instance, this.operation, inputs, serviceQuery);
+                    QueryResult<TEntity> result = await QueryProcessor.ProcessAsync<TEntity>(instance, this.operation, inputs, serviceQuery);
 
                     if (result.ValidationErrors != null && result.ValidationErrors.Any())
                     {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/SubmitOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/SubmitOperationBehavior.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
+using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 
 namespace OpenRiaServices.DomainServices.Hosting
@@ -48,11 +49,11 @@ namespace OpenRiaServices.DomainServices.Hosting
                 }
             }
 
-            protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
+            //protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
+            protected override async ValueTask<object> InvokeCoreAsync(object instance, object[] inputs)
             {
                 DomainService domainService = (DomainService)instance;
                 IEnumerable<ChangeSetEntry> changeSetEntries = (IEnumerable<ChangeSetEntry>)inputs[0];
-                outputs = ServiceUtility.EmptyObjectArray;
 
                 try
                 {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/SubmitOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/SubmitOperationBehavior.cs
@@ -48,9 +48,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     return ServiceUtility.SubmitOperationName;
                 }
             }
-
-            //protected override object InvokeCore(object instance, object[] inputs, out object[] outputs)
-            protected override async ValueTask<object> InvokeCoreAsync(object instance, object[] inputs)
+            protected override async ValueTask<object> InvokeCoreAsync(DomainService instance, object[] inputs, bool disableStackTraces)
             {
                 DomainService domainService = (DomainService)instance;
                 IEnumerable<ChangeSetEntry> changeSetEntries = (IEnumerable<ChangeSetEntry>)inputs[0];
@@ -65,7 +63,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     {
                         throw;
                     }
-                    throw ServiceUtility.CreateFaultException(ex);
+                    throw ServiceUtility.CreateFaultException(ex, disableStackTraces);
                 }
             }
 

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/SubmitOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/SubmitOperationBehavior.cs
@@ -57,7 +57,7 @@ namespace OpenRiaServices.DomainServices.Hosting
 
                 try
                 {
-                    return ChangeSetProcessor.Process(domainService, changeSetEntries);
+                    return await ChangeSetProcessor.ProcessAsync(domainService, changeSetEntries);
                 }
                 catch (Exception ex)
                 {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/SubmitOperationBehavior.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/Behaviors/SubmitOperationBehavior.cs
@@ -50,12 +50,11 @@ namespace OpenRiaServices.DomainServices.Hosting
             }
             protected override async ValueTask<object> InvokeCoreAsync(DomainService instance, object[] inputs, bool disableStackTraces)
             {
-                DomainService domainService = (DomainService)instance;
                 IEnumerable<ChangeSetEntry> changeSetEntries = (IEnumerable<ChangeSetEntry>)inputs[0];
 
                 try
                 {
-                    return await ChangeSetProcessor.ProcessAsync(domainService, changeSetEntries);
+                    return await ChangeSetProcessor.ProcessAsync(instance, changeSetEntries);
                 }
                 catch (Exception ex)
                 {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
@@ -29,11 +29,10 @@ namespace OpenRiaServices.DomainServices.Hosting
         {
             // TODO:
             // Consider making logic extensible (move to domainservice?)
-            ChangeSet changeSet = CreateChangeSet(changeSetEntries);
+            // * Remove this method and "manually inline" the code where used?
 
-            // TODO:
-            // * Remove this method and "manually inline" the code where used
-            await domainService.SubmitAsync(changeSet, CancellationToken.None);
+            ChangeSet changeSet = CreateChangeSet(changeSetEntries);
+            await domainService.SubmitAsync(changeSet, CancellationToken.None).ConfigureAwait(false);
 
             // Process the submit results and build the result list to be sent back
             // to the client

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using OpenRiaServices.DomainServices;
 using OpenRiaServices.DomainServices.Server;
 using System.Web;
+using System.Threading.Tasks;
 
 namespace OpenRiaServices.DomainServices.Hosting
 {
@@ -23,11 +24,15 @@ namespace OpenRiaServices.DomainServices.Hosting
         /// <param name="domainService">The domain service that will process the changeset.</param>
         /// <param name="changeSetEntries">The change set entries to be processed.</param>
         /// <returns>Collection of results from the submit operation.</returns>
-        public static IEnumerable<ChangeSetEntry> Process(DomainService domainService, IEnumerable<ChangeSetEntry> changeSetEntries)
+        internal static async ValueTask<IEnumerable<ChangeSetEntry>> ProcessAsync(DomainService domainService, IEnumerable<ChangeSetEntry> changeSetEntries)
         {
+            // TODO:
+            // Consider making logic extensible (move to domainservice?)
             ChangeSet changeSet = CreateChangeSet(changeSetEntries);
             
-            domainService.Submit(changeSet);
+            // TODO:
+            // * Remove this method and "manually inline" the code where used
+            await domainService.SubmitAsync(changeSet);
 
             // Process the submit results and build the result list to be sent back
             // to the client

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
@@ -36,7 +36,7 @@ namespace OpenRiaServices.DomainServices.Hosting
 
             // Process the submit results and build the result list to be sent back
             // to the client
-            return GetSubmitResults(changeSet);
+            return GetSubmitResults(changeSet, domainService.GetDisableStackTraces());
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace OpenRiaServices.DomainServices.Hosting
         /// </summary>
         /// <param name="changeSet">The change set processed.</param>
         /// <returns>The results list.</returns>
-        private static List<ChangeSetEntry> GetSubmitResults(ChangeSet changeSet)
+        private static List<ChangeSetEntry> GetSubmitResults(ChangeSet changeSet, bool isCustomErrorEnabled)
         {
             List<ChangeSetEntry> results = new List<ChangeSetEntry>();
             foreach (ChangeSetEntry changeSetEntry in changeSet.ChangeSetEntries)
@@ -57,8 +57,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     // if customErrors is turned on, clear out the stacktrace.
                     // This is an additional step here so that ValidationResultInfo
                     // and DomainService can remain agnostic to http-concepts
-                    HttpContext context = HttpContext.Current;
-                    if (context != null && context.IsCustomErrorEnabled)
+                    if (isCustomErrorEnabled)
                     {
                         if (changeSetEntry.ValidationErrors != null)
                         {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
@@ -30,7 +30,7 @@ namespace OpenRiaServices.DomainServices.Hosting
             // TODO:
             // Consider making logic extensible (move to domainservice?)
             ChangeSet changeSet = CreateChangeSet(changeSetEntries);
-            
+
             // TODO:
             // * Remove this method and "manually inline" the code where used
             await domainService.SubmitAsync(changeSet, CancellationToken.None);
@@ -45,8 +45,9 @@ namespace OpenRiaServices.DomainServices.Hosting
         /// be sent back to the client.
         /// </summary>
         /// <param name="changeSet">The change set processed.</param>
+        /// <param name="disableStackTraces">true to omit sending stack traces to clients (the secure approach)</param>
         /// <returns>The results list.</returns>
-        private static List<ChangeSetEntry> GetSubmitResults(ChangeSet changeSet, bool isCustomErrorEnabled)
+        private static List<ChangeSetEntry> GetSubmitResults(ChangeSet changeSet, bool disableStackTraces)
         {
             List<ChangeSetEntry> results = new List<ChangeSetEntry>();
             foreach (ChangeSetEntry changeSetEntry in changeSet.ChangeSetEntries)
@@ -58,14 +59,11 @@ namespace OpenRiaServices.DomainServices.Hosting
                     // if customErrors is turned on, clear out the stacktrace.
                     // This is an additional step here so that ValidationResultInfo
                     // and DomainService can remain agnostic to http-concepts
-                    if (isCustomErrorEnabled)
+                    if (disableStackTraces && changeSetEntry.ValidationErrors != null)
                     {
-                        if (changeSetEntry.ValidationErrors != null)
+                        foreach (ValidationResultInfo error in changeSetEntry.ValidationErrors.Where(e => e.StackTrace != null))
                         {
-                            foreach (ValidationResultInfo error in changeSetEntry.ValidationErrors.Where(e => e.StackTrace != null))
-                            {
-                                error.StackTrace = null;
-                            }
+                            error.StackTrace = null;
                         }
                     }
                 }

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ChangeSetProcessor.cs
@@ -10,6 +10,7 @@ using OpenRiaServices.DomainServices;
 using OpenRiaServices.DomainServices.Server;
 using System.Web;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace OpenRiaServices.DomainServices.Hosting
 {
@@ -32,7 +33,7 @@ namespace OpenRiaServices.DomainServices.Hosting
             
             // TODO:
             // * Remove this method and "manually inline" the code where used
-            await domainService.SubmitAsync(changeSet);
+            await domainService.SubmitAsync(changeSet, CancellationToken.None);
 
             // Process the submit results and build the result list to be sent back
             // to the client

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/DiagnosticUtility.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/DiagnosticUtility.cs
@@ -100,9 +100,14 @@ namespace OpenRiaServices.DomainServices.Hosting
             }
         }
 
+        public static long GetTicks()
+        {
+            return DateTime.UtcNow.Ticks;
+        }
+
         public static long GetDuration(long startTicks)
         {
-            return (long)new TimeSpan(DateTime.UtcNow.Ticks - startTicks).TotalMilliseconds;
+            return (long)new TimeSpan(GetTicks() - startTicks).TotalMilliseconds;
         }
 
         private static string GetCallerInfo()

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/DomainServiceExtensions.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/DomainServiceExtensions.cs
@@ -15,7 +15,7 @@ namespace OpenRiaServices.DomainServices.Hosting
         /// </summary>
         public static bool GetDisableStackTraces(this DomainService domainService)
         {
-            return ((WcfDomainServiceContext)domainService.ServiceContext).DisableStackTraces;
+            return (domainService.ServiceContext as WcfDomainServiceContext)?.DisableStackTraces ?? true;
         }
     }
 }

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/DomainServiceExtensions.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/DomainServiceExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenRiaServices.DomainServices.Server;
+
+namespace OpenRiaServices.DomainServices.Hosting
+{
+    static class DomainServiceExtensions
+    {
+        /// <summary>
+        /// Same as <see cref="System.Web.HttpContext.IsCustomErrorEnabled"/>; <c>true</c> means 
+        /// that stack traces should not be sent to clients (secure).
+        /// </summary>
+        public static bool GetDisableStackTraces(this DomainService domainService)
+        {
+            return ((WcfDomainServiceContext)domainService.ServiceContext).DisableStackTraces;
+        }
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/DomainServiceHost.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/DomainServiceHost.cs
@@ -77,7 +77,10 @@ namespace OpenRiaServices.DomainServices.Hosting
 
             if (serviceType == typeof(IPrincipal))
             {
-                return HttpContext.Current.User;
+                if (HttpContext.Current != null)
+                    return HttpContext.Current.User;
+                else
+                    return OperationContext.Current.ClaimsPrincipal;
             }
 
             if (serviceType == typeof(HttpContext))

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/QueryProcessor.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/QueryProcessor.cs
@@ -6,6 +6,8 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Linq.Dynamic;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 
@@ -36,8 +38,7 @@ namespace OpenRiaServices.DomainServices.Hosting
 
             // invoke the query operation
             QueryDescription queryDescription = new QueryDescription(queryOperation, parameters, includeTotalCount, query);
-            var res = await domainService.QueryAsync(queryDescription);
-
+            var res = await domainService.QueryAsync<TEntity>(queryDescription,  CancellationToken.None);
 
             if (res.HasValidationErrors)
             {

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/QueryProcessor.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/QueryProcessor.cs
@@ -23,7 +23,7 @@ namespace OpenRiaServices.DomainServices.Hosting
         // keyed by entity type, returns a bool that indicates whether a query result of that type requires flattening
         private static ConcurrentDictionary<Type, bool> requiresFlatteningByType = new ConcurrentDictionary<Type, bool>();
 
-        public async static ValueTask<QueryResult<TEntity>> Process<TEntity>(DomainService domainService, DomainOperationEntry queryOperation, object[] parameters, ServiceQuery serviceQuery)
+        public static async ValueTask<QueryResult<TEntity>> ProcessAsync<TEntity>(DomainService domainService, DomainOperationEntry queryOperation, object[] parameters, ServiceQuery serviceQuery)
         {
             DomainServiceDescription domainServiceDescription = DomainServiceDescription.GetDescription(domainService.GetType());
 

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/QueryProcessor.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/QueryProcessor.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Linq.Dynamic;
+using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 
 namespace OpenRiaServices.DomainServices.Hosting
@@ -20,7 +21,7 @@ namespace OpenRiaServices.DomainServices.Hosting
         // keyed by entity type, returns a bool that indicates whether a query result of that type requires flattening
         private static ConcurrentDictionary<Type, bool> requiresFlatteningByType = new ConcurrentDictionary<Type, bool>();
 
-        public static QueryResult<TEntity> Process<TEntity>(DomainService domainService, DomainOperationEntry queryOperation, object[] parameters, ServiceQuery serviceQuery, out IEnumerable<ValidationResult> validationErrors, out int totalCount)
+        public async static ValueTask<QueryResult<TEntity>> Process<TEntity>(DomainService domainService, DomainOperationEntry queryOperation, object[] parameters, ServiceQuery serviceQuery)
         {
             DomainServiceDescription domainServiceDescription = DomainServiceDescription.GetDescription(domainService.GetType());
 
@@ -35,7 +36,15 @@ namespace OpenRiaServices.DomainServices.Hosting
 
             // invoke the query operation
             QueryDescription queryDescription = new QueryDescription(queryOperation, parameters, includeTotalCount, query);
-            IEnumerable<TEntity> results = (IEnumerable<TEntity>)domainService.Query(queryDescription, out validationErrors, out totalCount);
+            var res = await domainService.QueryAsync(queryDescription);
+
+
+            if (res.HasValidationErrors)
+            {
+                return new QueryResult<TEntity>(res.ValidationErrors);
+            }
+            IEnumerable<TEntity> results = (IEnumerable<TEntity>)res.Result;
+            int totalCount = res.TotalCount;
 
             // Performance optimization: if there are no included associations, we can assume we don't need to flatten.
             if (!QueryProcessor.RequiresFlattening(domainServiceDescription, typeof(TEntity)))

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ServiceUtility.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ServiceUtility.cs
@@ -194,7 +194,7 @@ namespace OpenRiaServices.DomainServices.Hosting
             OperationDescription operationDesc = ServiceUtility.CreateBasicOperationDescription(declaringContract, ServiceUtility.SubmitOperationName);
 
             // Propagate behaviors.
-            MethodInfo submitMethod = declaringContract.ContractType.GetMethod("Submit");
+            MethodInfo submitMethod = declaringContract.ContractType.GetMethod( nameof(DomainService.SubmitAsync));
             foreach (IOperationBehavior behavior in submitMethod.GetCustomAttributes(/* inherit */ true).OfType<IOperationBehavior>())
             {
                 operationDesc.Behaviors.Add(behavior);

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ServiceUtility.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/ServiceUtility.cs
@@ -533,7 +533,7 @@ namespace OpenRiaServices.DomainServices.Hosting
                     fault.ErrorCode = dpe.ErrorCode;
                     fault.ErrorMessage = FormatExceptionMessage(dpe);
                     fault.IsDomainException = true;
-                    if (hideStackTrace == false)
+                    if (!hideStackTrace)
                     {
                         // also send the stack trace if custom errors is disabled
                         fault.StackTrace = dpe.StackTrace;
@@ -559,7 +559,7 @@ namespace OpenRiaServices.DomainServices.Hosting
 
             // set error code. Also set error message if custom errors is disabled
             fault.ErrorCode = errorCode;
-            if (hideStackTrace == false)
+            if (!hideStackTrace)
             {
                 fault.ErrorMessage = FormatExceptionMessage(e);
                 fault.StackTrace = e.StackTrace;

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/TaskExtensions.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/TaskExtensions.cs
@@ -36,5 +36,22 @@ namespace OpenRiaServices.DomainServices.Hosting
         {
             return ((Task<T>)asyncResult).GetAwaiter().GetResult();
         }
+
+        public static IAsyncResult BeginApm<T>(ValueTask<T> task,
+                                    AsyncCallback callback,
+                                    object state)
+        {
+            if(task.IsCompletedSuccessfully)
+            {
+                var tcs = new TaskCompletionSource<T>(state);
+                tcs.TrySetResult(task.Result);
+                callback.Invoke(tcs.Task);
+                return tcs.Task;
+            }
+            else
+            {
+                return BeginApm<T>(task.AsTask(), callback, state);
+            }
+        }
     }
 }

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/TaskExtensions.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/TaskExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OpenRiaServices.DomainServices.Hosting
+{
+    static class TaskExtensions
+    {
+        /// <summary>
+        /// Helper method to convert from Task async method to "APM" (IAsyncResult with Begin/End calls)
+        /// Copied from 
+        /// https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/interop-with-other-asynchronous-patterns-and-types#TapToApm
+        /// </summary>
+        public static IAsyncResult BeginApm<T>(Task<T> task,
+                                    AsyncCallback callback,
+                                    object state)
+        {
+            var tcs = new TaskCompletionSource<T>(state);
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    tcs.TrySetException(t.Exception.InnerExceptions);
+                else if (t.IsCanceled)
+                    tcs.TrySetCanceled();
+                else
+                    tcs.TrySetResult(t.Result);
+
+                callback?.Invoke(tcs.Task);
+            }, TaskScheduler.Default);
+            return tcs.Task;
+        }
+
+        public static T EndApm<T>(IAsyncResult asyncResult)
+        {
+            return ((Task<T>)asyncResult).GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/WcfDomainServiceContext.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/WcfDomainServiceContext.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using OpenRiaServices.DomainServices.Server;
+using System.Web;
+using System.Security.Principal;
+using System.ServiceModel;
+
+namespace OpenRiaServices.DomainServices.Hosting
+{
+    /// <summary>
+    /// Context with extra WCF specific per-request properties
+    /// </summary>
+    class WcfDomainServiceContext : DomainServiceContext
+    {
+        private readonly HttpContext _httpContext;
+
+        /// <summary>
+        /// Initializes a new instance of the DomainServiceContext class
+        /// </summary>
+        /// <param name="serviceProvider">A service provider.</param>
+        /// <param name="operationType">The type of operation that is being executed.</param>
+        public WcfDomainServiceContext(IServiceProvider serviceProvider, DomainOperationType operationType)
+            : base(serviceProvider, operationType, GetPrincipal())
+        {
+            _httpContext = HttpContext.Current;
+
+            this.DisableStackTraces = _httpContext?.IsCustomErrorEnabled ?? true;
+        }
+
+
+        /// <summary>
+        /// Same as <see cref="HttpContext.IsCustomErrorEnabled"/>; <c>true</c> means 
+        /// that stack traces should not be sent (secure).
+        /// </summary>
+        public bool DisableStackTraces { get; }
+
+        /// <summary>
+        /// Expose HttpContext related "services", since the HttpContext will and 
+        /// can change on async/await etc.
+        /// </summary>
+        /// <param name="serviceType">type of service reqeusted</param>
+        /// <returns></returns>
+        public override object GetService(Type serviceType)
+        {
+            if (serviceType == typeof(IPrincipal))
+            {
+                return base.User;
+            }
+
+            if (serviceType == typeof(HttpContext))
+            {
+                return _httpContext;
+            }
+
+            if (serviceType == typeof(HttpContextBase))
+            {
+                return new HttpContextWrapper(_httpContext);
+            }
+
+            return base.GetService(serviceType);
+        }
+
+        private static IPrincipal GetPrincipal()
+        {
+            if (HttpContext.Current != null)
+                return HttpContext.Current.User;
+            else
+                return OperationContext.Current.ClaimsPrincipal;
+        }
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/WcfDomainServiceContext.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/WcfDomainServiceContext.cs
@@ -19,7 +19,7 @@ namespace OpenRiaServices.DomainServices.Hosting
         /// <param name="serviceProvider">A service provider.</param>
         /// <param name="operationType">The type of operation that is being executed.</param>
         public WcfDomainServiceContext(IServiceProvider serviceProvider, DomainOperationType operationType)
-            : base(serviceProvider, operationType, GetPrincipal())
+            : base(serviceProvider, operationType)
         {
             _httpContext = HttpContext.Current;
 
@@ -57,14 +57,6 @@ namespace OpenRiaServices.DomainServices.Hosting
             }
 
             return base.GetService(serviceType);
-        }
-
-        private static IPrincipal GetPrincipal()
-        {
-            if (HttpContext.Current != null)
-                return HttpContext.Current.User;
-            else
-                return OperationContext.Current.ClaimsPrincipal;
         }
     }
 }

--- a/src/OpenRiaServices.DomainServices.LinqToSql/Framework/LinqToSqlDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.LinqToSql/Framework/LinqToSqlDomainService.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Data.Linq;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 using ChangeSet = OpenRiaServices.DomainServices.Server.ChangeSet;
 
@@ -95,7 +96,7 @@ namespace OpenRiaServices.DomainServices.LinqToSql
         /// </remarks>
         /// </summary>
         /// <returns>Returns <c>true</c> if the <see cref="ChangeSet"/> was persisted successfully, <c>false</c> otherwise.</returns>
-        protected override bool PersistChangeSet()
+        protected override async Task<bool> PersistChangeSetAsync()
         {
             return this.InvokeSubmitChanges(true);
         }

--- a/src/OpenRiaServices.DomainServices.LinqToSql/Framework/LinqToSqlDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.LinqToSql/Framework/LinqToSqlDomainService.cs
@@ -70,6 +70,7 @@ namespace OpenRiaServices.DomainServices.LinqToSql
         /// </summary>
         /// <typeparam name="T">The element Type of the query.</typeparam>
         /// <param name="query">The query for which the count should be returned.</param>
+        /// <param name="cancellationToken">unused</param>
         /// <returns>The total number of rows.</returns>
         protected override ValueTask<int> CountAsync<T>(IQueryable<T> query, CancellationToken cancellationToken)
         {

--- a/src/OpenRiaServices.DomainServices.LinqToSql/Framework/LinqToSqlDomainService.cs
+++ b/src/OpenRiaServices.DomainServices.LinqToSql/Framework/LinqToSqlDomainService.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Data.Linq;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenRiaServices.DomainServices.Server;
 using ChangeSet = OpenRiaServices.DomainServices.Server.ChangeSet;
@@ -70,9 +71,9 @@ namespace OpenRiaServices.DomainServices.LinqToSql
         /// <typeparam name="T">The element Type of the query.</typeparam>
         /// <param name="query">The query for which the count should be returned.</param>
         /// <returns>The total number of rows.</returns>
-        protected override int Count<T>(IQueryable<T> query)
+        protected override ValueTask<int> CountAsync<T>(IQueryable<T> query, CancellationToken cancellationToken)
         {
-            return query.Count();
+            return new ValueTask<int>(query.Count());
         }
 
         /// <summary>
@@ -96,9 +97,9 @@ namespace OpenRiaServices.DomainServices.LinqToSql
         /// </remarks>
         /// </summary>
         /// <returns>Returns <c>true</c> if the <see cref="ChangeSet"/> was persisted successfully, <c>false</c> otherwise.</returns>
-        protected override async Task<bool> PersistChangeSetAsync()
+        protected override ValueTask<bool> PersistChangeSetAsync(CancellationToken cancellationToken)
         {
-            return this.InvokeSubmitChanges(true);
+            return new ValueTask<bool>(this.InvokeSubmitChanges(true));
         }
 
         private bool InvokeSubmitChanges(bool retryOnConflict)

--- a/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -515,13 +515,13 @@ namespace OpenRiaServices.DomainServices.Server.UnitTesting
             OperationContext context = this.CreateOperationContext(DomainOperationType.Query);
 
             QueryDescription queryDescription = Utility.GetQueryDescription(context, queryOperation);
-            IEnumerable<ValidationResult> validationErrors;
-            int totalCount;
 
-            IEnumerable entities = context.DomainService.Query(queryDescription, out validationErrors, out totalCount);
+            var queryTask = context.DomainService.QueryAsync(queryDescription);
+            // TODO: Remove blocking wait
+            var queryResult = queryTask.GetAwaiter().GetResult();
+            ErrorUtility.AssertNoValidationErrors(context, queryResult.ValidationErrors);
 
-            ErrorUtility.AssertNoValidationErrors(context, validationErrors);
-
+            IEnumerable entities = queryResult.Result;
             return (entities == null) ? null : entities.Cast<TEntity>();
         }
 
@@ -540,9 +540,12 @@ namespace OpenRiaServices.DomainServices.Server.UnitTesting
 
             QueryDescription queryDescription = Utility.GetQueryDescription(context, queryOperation);
             IEnumerable<ValidationResult> validationErrors;
-            int totalCount;
 
-            IEnumerable entities = context.DomainService.Query(queryDescription, out validationErrors, out totalCount);
+            var queryTask = context.DomainService.QueryAsync(queryDescription);
+            // TODO: Remove blocking wait
+            var queryResult = queryTask.GetAwaiter().GetResult();
+            IEnumerable entities = queryResult.Result;
+            validationErrors = queryResult.ValidationErrors;
 
             results = (entities == null) ? null : entities.Cast<TEntity>();
             validationResults = (validationErrors == null) ? null : validationErrors.ToList();

--- a/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -648,7 +648,7 @@ namespace OpenRiaServices.DomainServices.Server.UnitTesting
         {
             // TODO: Remove blocking await
             context.DomainService.SubmitAsync(changeSet, CancellationToken.None)
-                .GetAwaiter().GetResult(); ;
+                .GetAwaiter().GetResult();
 
             ErrorUtility.AssertNoChangeSetErrors(context, changeSet);
         }

--- a/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -645,7 +645,7 @@ namespace OpenRiaServices.DomainServices.Server.UnitTesting
         /// <exception cref="DomainServiceTestHostException">is thrown if there are any <see cref="ChangeSet"/> errors</exception>
         private static void SubmitChangeSetCore(OperationContext context, ChangeSet changeSet)
         {
-            context.DomainService.Submit(changeSet);
+            context.DomainService.SubmitAsync(changeSet);
 
             ErrorUtility.AssertNoChangeSetErrors(context, changeSet);
         }
@@ -659,7 +659,7 @@ namespace OpenRiaServices.DomainServices.Server.UnitTesting
         /// <param name="validationResults">The validation errors that occurred</param>
         private static bool TrySubmitChangeSetCore(OperationContext context, ChangeSet changeSet, out IList<ValidationResult> validationResults)
         {
-            context.DomainService.Submit(changeSet);
+            context.DomainService.SubmitAsync(changeSet);
 
             validationResults = GetValidationResults(changeSet);
             return !changeSet.HasError;

--- a/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -676,11 +676,11 @@ namespace OpenRiaServices.DomainServices.Server.UnitTesting
             OperationContext context = this.CreateOperationContext(DomainOperationType.Invoke);
 
             InvokeDescription invokeDescription = Utility.GetInvokeDescription(context, invokeOperation);
-            IEnumerable<ValidationResult> validationErrors;
 
-            TResult result = (TResult)context.DomainService.Invoke(invokeDescription, out validationErrors);
-
-            ErrorUtility.AssertNoValidationErrors(context, validationErrors);
+            // TODO: Remove blocking wait
+            var invokeResult = context.DomainService.InvokeAsync(invokeDescription).GetAwaiter().GetResult();
+            ErrorUtility.AssertNoValidationErrors(context, invokeResult.ValidationErrors);
+            TResult result = (TResult)invokeResult.Result;
 
             return result;
         }
@@ -701,11 +701,12 @@ namespace OpenRiaServices.DomainServices.Server.UnitTesting
             InvokeDescription invokeDescription = Utility.GetInvokeDescription(context, invokeOperation);
             IEnumerable<ValidationResult> validationErrors;
 
-            result = (TResult)context.DomainService.Invoke(invokeDescription, out validationErrors);
+            // TODO: Remove blocking wait
+            var invokeResult = context.DomainService.InvokeAsync(invokeDescription).GetAwaiter().GetResult();
+            result = (TResult)invokeResult.Result;
+            validationResults = invokeResult.HasValidationErrors ? invokeResult.ValidationErrors.ToList() : null;
 
-            validationResults = (validationErrors == null) ? null : validationErrors.ToList();
-
-            return (validationResults == null) || (validationResults.Count == 0);
+            return (!invokeResult.HasValidationErrors);
         }
 
         #endregion

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainOperationEntry.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainOperationEntry.cs
@@ -375,7 +375,6 @@ namespace OpenRiaServices.DomainServices.Server
         /// <param name="domainService">The <see cref="DomainService"/> instance the operation is being invoked on.</param>
         /// <param name="parameters">The parameters to pass to the method.</param>
         /// <returns>The return value of the invoked method.</returns>
-        // TODO; Change into "InvokeAsync" and return ValueTask<object>
         public abstract object Invoke(DomainService domainService, object[] parameters);
 
         /// <summary>

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainOperationEntry.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainOperationEntry.cs
@@ -28,7 +28,7 @@ namespace OpenRiaServices.DomainServices.Server
         private readonly Type _domainServiceType;
         private bool? _requiresValidation;
         private bool? _requiresAuthorization;
-        private Func<object, object> _unwrapTaskResultFunc;
+        private Func<object, ValueTask<object>> _unwrapTaskResultFunc;
 
         /// <summary>
         /// Initializes a new instance of the DomainOperationEntry class
@@ -375,6 +375,7 @@ namespace OpenRiaServices.DomainServices.Server
         /// <param name="domainService">The <see cref="DomainService"/> instance the operation is being invoked on.</param>
         /// <param name="parameters">The parameters to pass to the method.</param>
         /// <returns>The return value of the invoked method.</returns>
+        // TODO; Change into "InvokeAsync" and return ValueTask<object>
         public abstract object Invoke(DomainService domainService, object[] parameters);
 
         /// <summary>
@@ -463,10 +464,10 @@ namespace OpenRiaServices.DomainServices.Server
             }
         }
 
-        internal object UnwrapTaskResult(object result)
+        internal ValueTask<object> UnwrapTaskResult(object result)
         {
             if (!IsTaskAsync)
-                return result;
+                return new ValueTask<object>(result);
 
             if (_unwrapTaskResultFunc == null)
             {
@@ -474,7 +475,7 @@ namespace OpenRiaServices.DomainServices.Server
                     _unwrapTaskResultFunc = UnwrapVoidResult;
                 else
                 {
-                    _unwrapTaskResultFunc = (Func<object, object>)Delegate.CreateDelegate(typeof(Func<object, object>),
+                    _unwrapTaskResultFunc = (Func<object, ValueTask<object>>)Delegate.CreateDelegate(typeof(Func<object, ValueTask<object>>),
                                                     typeof(DomainOperationEntry).GetMethod(nameof(UnwrapGenericResult), BindingFlags.Static | BindingFlags.NonPublic)
                                                     .MakeGenericMethod(this.ReturnType));
                 }
@@ -482,22 +483,30 @@ namespace OpenRiaServices.DomainServices.Server
             return _unwrapTaskResultFunc(result);
         }
 
-        private static object UnwrapVoidResult(object result)
+        private static async ValueTask<object> UnwrapVoidResult(object result)
         {
             if(result == null)
                 throw new InvalidOperationException("Task method returned null");
 
-            ((Task) result).Wait();
+            if (result is Task t)
+                await t.ConfigureAwait(false);
+
+            if (result is ValueTask vt)
+                await vt.ConfigureAwait(false);
+
             return null;
         }
 
 #pragma warning disable S1144 // Unused private types or members should be removed, this is used by reflection
-        private static object UnwrapGenericResult<T>(object result)
+        private static async ValueTask<object> UnwrapGenericResult<T>(object result)
         {
             if(result == null)
                 throw new InvalidOperationException("Task method returned null");
 
-            return ((Task<T>) result).Result;
+            if (result is Task<T> t)
+                return await t.ConfigureAwait(false);
+            else
+                return await ((ValueTask<T>)result).ConfigureAwait(false);
         }
 #pragma warning restore S1144 // Unused private types or members should be removed
 

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainService.cs
@@ -82,7 +82,7 @@ namespace OpenRiaServices.DomainServices.Server
         /// <summary>
         /// Gets the active <see cref="DomainServiceContext"/> for this <see cref="DomainService"/>.
         /// </summary>
-        protected DomainServiceContext ServiceContext
+        public DomainServiceContext ServiceContext
         {
             get
             {

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainService.cs
@@ -306,10 +306,7 @@ namespace OpenRiaServices.DomainServices.Server
                     try
                     {
                         result = queryDescription.Method.Invoke(this, parameters, out totalCount);
-
-                        // TODO: ValueTask support
                         // TODO: Should add support to a type with both result and count
-                        // Wait for result to be availible before unwrapping
                         if (queryDescription.Method.IsTaskAsync)
                         {
                             result = await queryDescription.Method.UnwrapTaskResult(result).ConfigureAwait(false);

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainService.cs
@@ -423,7 +423,6 @@ namespace OpenRiaServices.DomainServices.Server
         /// Invokes the specified invoke operation.
         /// </summary>
         /// <param name="invokeDescription">The description of the invoke operation to perform.</param>
-        /// will be added. This will be set to <c>null</c> if no validation errors are encountered.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> which may be used by hosting layer to request cancellation</param>
         /// <returns>The return value of the invocation.</returns>
         public virtual async ValueTask<ServiceInvokeResult> InvokeAsync(InvokeDescription invokeDescription, CancellationToken cancellationToken)

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainServiceContext.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainServiceContext.cs
@@ -20,17 +20,6 @@ namespace OpenRiaServices.DomainServices.Server
         /// <param name="serviceProvider">A service provider.</param>
         /// <param name="operationType">The type of operation that is being executed.</param>
         public DomainServiceContext(IServiceProvider serviceProvider, DomainOperationType operationType)
-            : this(serviceProvider, operationType, (IPrincipal)serviceProvider?.GetService(typeof(IPrincipal)))
-        {
-            
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the DomainServiceContext class
-        /// </summary>
-        /// <param name="serviceProvider">A service provider.</param>
-        /// <param name="operationType">The type of operation that is being executed.</param>
-        public DomainServiceContext(IServiceProvider serviceProvider, DomainOperationType operationType, IPrincipal user)
         {
             if (serviceProvider == null)
             {
@@ -38,7 +27,7 @@ namespace OpenRiaServices.DomainServices.Server
             }
             this._serviceProvider = serviceProvider;
             this.OperationType = operationType;
-            this.User = user;
+            this.User = (IPrincipal)serviceProvider?.GetService(typeof(IPrincipal));
         }
         /// <summary>
         /// Copy constructor that creates a new context of the specified type copying

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainServiceContext.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainServiceContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Design;
 using System.Globalization;
 using System.Security.Principal;
+using System.Threading;
 
 namespace OpenRiaServices.DomainServices.Server
 {
@@ -60,6 +61,11 @@ namespace OpenRiaServices.DomainServices.Server
         /// The user for this context instance.
         /// </summary>
         public IPrincipal User { get; }
+
+        /// <summary>
+        /// <see cref="CancellationToken"/> which may be used by hosting layer to request cancellation.
+        /// </summary>
+        public CancellationToken CancellationToken { get; internal set; }
 
         #region IServiceProvider Members
 

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainServiceContext.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/DomainServiceContext.cs
@@ -11,8 +11,6 @@ namespace OpenRiaServices.DomainServices.Server
     /// </summary>
     public class DomainServiceContext : IServiceProvider
     {
-        private DomainOperationEntry _operation;
-        private readonly DomainOperationType _operationType;
         private IServiceContainer _serviceContainer;
         private readonly IServiceProvider _serviceProvider;
 
@@ -22,15 +20,26 @@ namespace OpenRiaServices.DomainServices.Server
         /// <param name="serviceProvider">A service provider.</param>
         /// <param name="operationType">The type of operation that is being executed.</param>
         public DomainServiceContext(IServiceProvider serviceProvider, DomainOperationType operationType)
+            : this(serviceProvider, operationType, (IPrincipal)serviceProvider?.GetService(typeof(IPrincipal)))
+        {
+            
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the DomainServiceContext class
+        /// </summary>
+        /// <param name="serviceProvider">A service provider.</param>
+        /// <param name="operationType">The type of operation that is being executed.</param>
+        public DomainServiceContext(IServiceProvider serviceProvider, DomainOperationType operationType, IPrincipal user)
         {
             if (serviceProvider == null)
             {
                 throw new ArgumentNullException("serviceProvider");
             }
             this._serviceProvider = serviceProvider;
-            this._operationType = operationType;
+            this.OperationType = operationType;
+            this.User = user;
         }
-
         /// <summary>
         /// Copy constructor that creates a new context of the specified type copying
         /// the rest of the context from the provided instance.
@@ -44,45 +53,24 @@ namespace OpenRiaServices.DomainServices.Server
                 throw new ArgumentNullException("serviceContext");
             }
             this._serviceProvider = serviceContext._serviceProvider;
-            this._operationType = operationType;
+            this.OperationType = operationType;
+            this.User = (IPrincipal)_serviceProvider.GetService(typeof(IPrincipal));
         }
 
         /// <summary>
         /// Gets the operation that is being executed.
         /// </summary>
-        public DomainOperationEntry Operation
-        {
-            get
-            {
-                return this._operation;
-            }
-            internal set
-            {
-                this._operation = value;
-            }
-        }
+        public DomainOperationEntry Operation { get; internal set; }
 
         /// <summary>
         /// Gets the type of operation that is being executed.
         /// </summary>
-        public DomainOperationType OperationType
-        {
-            get
-            {
-                return this._operationType;
-            }
-        }
+        public DomainOperationType OperationType { get; }
 
         /// <summary>
         /// The user for this context instance.
         /// </summary>
-        public IPrincipal User
-        {
-            get
-            {
-                return (IPrincipal)this._serviceProvider.GetService(typeof(IPrincipal));
-            }
-        }
+        public IPrincipal User { get; }
 
         #region IServiceProvider Members
 
@@ -96,7 +84,7 @@ namespace OpenRiaServices.DomainServices.Server
         /// </summary>
         /// <param name="serviceType">The type of the service needed.</param>
         /// <returns>An instance of that service or null if it is not available.</returns>
-        public object GetService(Type serviceType)
+        public virtual object GetService(Type serviceType)
         {
             object service = null;
 

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/Resource.Designer.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/Resource.Designer.cs
@@ -19,7 +19,7 @@ namespace OpenRiaServices.DomainServices.Server {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resource {
@@ -993,6 +993,15 @@ namespace OpenRiaServices.DomainServices.Server {
         internal static string RequiresRoleAttribute_MustSpecifyRole {
             get {
                 return ResourceManager.GetString("RequiresRoleAttribute_MustSpecifyRole", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No validation errors specified.
+        /// </summary>
+        internal static string ValidationErrorsCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("ValidationErrorsCannotBeEmpty", resourceCulture);
             }
         }
         

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/Resource.resx
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/Resource.resx
@@ -429,6 +429,9 @@
   <data name="RequiresRoleAttribute_MustSpecifyRole" xml:space="preserve">
     <value>One or more roles must be specified.</value>
   </data>
+  <data name="ValidationErrorsCannotBeEmpty" xml:space="preserve">
+    <value>No validation errors specified</value>
+  </data>
   <data name="ValidationUtilities_AmbiguousMatch" xml:space="preserve">
     <value>Ambiguous match for method '{0}'.</value>
   </data>

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/ServiceInvokeResult.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/ServiceInvokeResult.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace OpenRiaServices.DomainServices.Server
+{
+    public struct ServiceInvokeResult
+    {
+        public ServiceInvokeResult(object result)
+        {
+            Result = result;
+            ValidationErrors = null;
+        }
+
+        public ServiceInvokeResult(List<ValidationResult> validationErrors)
+        {
+            ValidationErrors = validationErrors.AsReadOnly();
+            Result = null;
+        }
+
+        public object Result { get; }
+        public IReadOnlyCollection<ValidationResult> ValidationErrors { get; }
+        public bool HasValidationErrors => ValidationErrors != null;
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/ServiceInvokeResult.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/ServiceInvokeResult.cs
@@ -1,25 +1,55 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace OpenRiaServices.DomainServices.Server
 {
+    /// <summary>
+    /// Represents the result of a query from <see cref="DomainService.InvokeAsync"/>
+    /// Which is either the return value, or one or more validation errors
+    /// </summary>
     public struct ServiceInvokeResult
     {
+        /// <summary>
+        /// Create a <see cref="ServiceInvokeResult"/> with the result of an successfully invoked Invoke operation
+        /// </summary>
+        /// <param name="result">the result from the invoked operation (or <c>null</c> if it was a void method)</param>
         public ServiceInvokeResult(object result)
         {
             Result = result;
             ValidationErrors = null;
         }
 
-        public ServiceInvokeResult(List<ValidationResult> validationErrors)
+        /// <summary>
+        /// Create a <see cref="ServiceInvokeResult"/> where there were validation errors which prevented a result from beein returned
+        /// </summary>
+        /// <param name="validationErrors">the validation errors, should <c>never</c> be modified after beeing passed in</param>
+        public ServiceInvokeResult(IReadOnlyCollection<ValidationResult> validationErrors)
         {
-            ValidationErrors = validationErrors.AsReadOnly();
+            if (validationErrors == null)
+                throw new ArgumentNullException(nameof(validationErrors));
+            if (validationErrors.Count == 0)
+                throw new ArgumentException(Resource.ValidationErrorsCannotBeEmpty, nameof(validationErrors));
+
+            ValidationErrors = validationErrors;
             Result = null;
         }
 
+        /// <summary>
+        /// The result of the invocation, or <c>null</c> if <see cref="HasValidationErrors"/> is true
+        /// </summary>
         public object Result { get; }
-        public IReadOnlyCollection<ValidationResult> ValidationErrors { get; }
+
+        /// <summary>
+        /// <c>true</c> if the query unsuccessfull and <see cref="ValidationErrors"/> contains the errors.
+        /// <c>false</c> means that the query was successfull with results in <see cref="Result"/>
+        /// </summary>
         public bool HasValidationErrors => ValidationErrors != null;
+
+        /// <summary>
+        /// Gets the validation erros if any, or <c>null</c> if there were no validation errors.
+        /// </summary>
+        public IReadOnlyCollection<ValidationResult> ValidationErrors { get; }
     }
 }

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/ServiceQueryResult.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/ServiceQueryResult.cs
@@ -1,11 +1,21 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace OpenRiaServices.DomainServices.Server
 {
+    /// <summary>
+    /// Represents the result of a query from <see cref="DomainService.QueryAsync"/>
+    /// Which is either an IEnumerable/IQueryable with optionally a specific count, or one or more validation errors
+    /// </summary>
     public struct ServiceQueryResult
     {
+        /// <summary>
+        /// Create a <see cref="ServiceQueryResult"/> which represents the result of a successfully executed query
+        /// </summary>
+        /// <param name="result">the result of the query (before filtering from the client is applied)</param>
+        /// <param name="totalResult">the total number of items for the type of entity returned by the query, or <c>null</c></param>
         public ServiceQueryResult(IEnumerable result, int? totalResult)
         {
             Result = result;
@@ -13,16 +23,43 @@ namespace OpenRiaServices.DomainServices.Server
             ValidationErrors = null;
         }
 
-        public ServiceQueryResult(List<ValidationResult> validationErrors)
+        /// <summary>
+        /// Create a <see cref="ServiceQueryResult"/> where there were validation errors which prevented a result from beein returned
+        /// </summary>
+        /// <param name="validationErrors">the validation errors, should <c>never</c> be modified after beeing passed in</param>
+        public ServiceQueryResult(IReadOnlyCollection<ValidationResult> validationErrors)
         {
-            ValidationErrors = validationErrors.AsReadOnly();
+            if (validationErrors == null)
+                throw new ArgumentNullException(nameof(validationErrors));
+            if (validationErrors.Count == 0)
+                throw new ArgumentException(Resource.ValidationErrorsCannotBeEmpty, nameof(validationErrors));
+
+            ValidationErrors = validationErrors;
             TotalCount = DomainService.TotalCountUndefined;
             Result = null;
         }
 
+        /// <summary>
+        /// The result of the query, or <c>null</c> if <see cref="HasValidationErrors"/> is true
+        /// </summary>
         public IEnumerable Result { get; }
+
+        /// <summary>
+        /// Total number of items for the entity type returned, or any of the special values 
+        /// <see cref="DomainService.TotalCountUndefined"/> or <see cref="DomainService.TotalCountEqualsResultSetCount"/>
+        /// </summary>
         public int TotalCount { get; }
-        public IReadOnlyCollection<ValidationResult> ValidationErrors { get; }
+
+        /// <summary>
+        /// <c>true</c> if the query unsuccessfull and <see cref="ValidationErrors"/> contains the errors.
+        /// <c>false</c> means that the query was successfull with results in <see cref="Result"/>
+        /// </summary>
         public bool HasValidationErrors => ValidationErrors != null;
+
+
+        /// <summary>
+        /// Gets the validation erros if any, or <c>null</c> if there were no validation errors.
+        /// </summary>
+        public IReadOnlyCollection<ValidationResult> ValidationErrors { get; }
     }
 }

--- a/src/OpenRiaServices.DomainServices.Server/Framework/Data/ServiceQueryResult.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/Data/ServiceQueryResult.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace OpenRiaServices.DomainServices.Server
+{
+    public struct ServiceQueryResult
+    {
+        public ServiceQueryResult(IEnumerable result, int? totalResult)
+        {
+            Result = result;
+            TotalCount = totalResult ?? DomainService.TotalCountUndefined;
+            ValidationErrors = null;
+        }
+
+        public ServiceQueryResult(List<ValidationResult> validationErrors)
+        {
+            ValidationErrors = validationErrors.AsReadOnly();
+            TotalCount = DomainService.TotalCountUndefined;
+            Result = null;
+        }
+
+        public IEnumerable Result { get; }
+        public int TotalCount { get; }
+        public IReadOnlyCollection<ValidationResult> ValidationErrors { get; }
+        public bool HasValidationErrors => ValidationErrors != null;
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Server/Framework/OpenRiaServices.DomainServices.Server.csproj
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/OpenRiaServices.DomainServices.Server.csproj
@@ -49,6 +49,6 @@
     <Compile Condition=" '$(RunCodeAnalysis)' != 'true' " Remove="GlobalSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
   </ItemGroup>
 </Project>

--- a/src/OpenRiaServices.DomainServices.Server/Framework/OpenRiaServices.DomainServices.Server.csproj
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/OpenRiaServices.DomainServices.Server.csproj
@@ -48,4 +48,7 @@
   <ItemGroup>
     <Compile Condition=" '$(RunCodeAnalysis)' != 'true' " Remove="GlobalSuppressions.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
+  </ItemGroup>
 </Project>

--- a/src/OpenRiaServices.DomainServices.Server/Test/AuthorizationTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/AuthorizationTests.cs
@@ -35,7 +35,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             // Validate a null principal is denied
             MockUser user = null;
             MockDataService dataService = new MockDataService(user);
-            cities.Initialize(new DomainServiceContext(dataService, DomainOperationType.Query));
+            cities.Initialize(new WcfDomainServiceContext(dataService, DomainOperationType.Query));
             Exception expectedException = null;
             ServiceQueryResult result;
 
@@ -55,7 +55,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             user = new MockUser("mathew");
             dataService = new MockDataService(user);
             cities = new CityDomainService();
-            cities.Initialize(new DomainServiceContext(dataService, DomainOperationType.Query));
+            cities.Initialize(new WcfDomainServiceContext(dataService, DomainOperationType.Query));
 
             expectedException = null;
             try
@@ -81,7 +81,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             user = new MockUser("mathew", new string[] { "clerk" });
             user.IsAuthenticated = true;
             dataService = new MockDataService(user);
-            cities.Initialize(new DomainServiceContext(dataService, DomainOperationType.Query));
+            cities.Initialize(new WcfDomainServiceContext(dataService, DomainOperationType.Query));
             try
             {
                 result = await cities.QueryAsync(new QueryDescription(getZipsIfInRole));
@@ -97,7 +97,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             user = new MockUser("mathew", new string[] { "manager" });
             user.IsAuthenticated = true;
             dataService = new MockDataService(user);
-            cities.Initialize(new DomainServiceContext(dataService, DomainOperationType.Query));
+            cities.Initialize(new WcfDomainServiceContext(dataService, DomainOperationType.Query));
             result = await cities.QueryAsync(new QueryDescription(getZipsIfInRole));
             Assert.IsNotNull(result);
         }
@@ -113,7 +113,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             // The attribute permits only a user named mathew to access the query
             MockUser user = new MockUser("NotZipGuy");
             MockDataService dataService = new MockDataService(user);
-            cities.Initialize(new DomainServiceContext(dataService, DomainOperationType.Query));
+            cities.Initialize(new WcfDomainServiceContext(dataService, DomainOperationType.Query));
 
             // not authenticated should be denied cleanly because there is no user name
             Exception expectedException = null;
@@ -137,7 +137,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             user = new MockUser("NotZipGuy", new string[] { "clerk" });
             user.IsAuthenticated = true;
             dataService = new MockDataService(user);
-            cities.Initialize(new DomainServiceContext(dataService, DomainOperationType.Query));
+            cities.Initialize(new WcfDomainServiceContext(dataService, DomainOperationType.Query));
             try
             {
                 result = cities.QueryAsync(new QueryDescription(getZipsIfUser))
@@ -155,7 +155,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             user = new MockUser("ZipGuy");
             user.IsAuthenticated = true;
             dataService = new MockDataService(user);
-            cities.Initialize(new DomainServiceContext(dataService, DomainOperationType.Query));
+            cities.Initialize(new WcfDomainServiceContext(dataService, DomainOperationType.Query));
             var queryResult = cities.QueryAsync(new QueryDescription(getZipsIfUser))
                 .GetAwaiter().GetResult();
             Assert.IsNotNull(queryResult.Result);
@@ -182,7 +182,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             using (CityDomainService cities = new CityDomainService())
             {
                 // Now prepare for a query to find a Zip in WA
-                ctxt = new DomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Query);
+                ctxt = new WcfDomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Query);
                 cities.Initialize(ctxt);
                 IEnumerable result = (await cities.QueryAsync(new QueryDescription(getZipsQuery))).Result;
 
@@ -194,7 +194,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             using (CityDomainService cities = new CityDomainService())
             {
                 // Now prepare for a query to find a Zip in WA
-                ctxt = new DomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Submit);
+                ctxt = new WcfDomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Submit);
                 cities.Initialize(ctxt);
 
                 // Prepare an attempt to delete this with a user whose name is not WAGuy
@@ -223,7 +223,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 waGuy.IsAuthenticated = true;
 
                 // Now try a submit where the user *is* Mathew to validate we succeed
-                ctxt = new DomainServiceContext(new MockDataService(waGuy), DomainOperationType.Submit);
+                ctxt = new WcfDomainServiceContext(new MockDataService(waGuy), DomainOperationType.Submit);
                 cities.Initialize(ctxt);
                 List<ChangeSetEntry> entries = new List<ChangeSetEntry>();
 
@@ -260,7 +260,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 DomainOperationEntry getCitiesQuery = serviceDescription.GetQueryMethod("GetCities");
 
                 // Now prepare for a query to find a Zip in WA
-                DomainServiceContext ctxt = new DomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Query);
+                DomainServiceContext ctxt = new WcfDomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Query);
                 cities.Initialize(ctxt);
 
                 IEnumerable result = (await cities.QueryAsync(new QueryDescription(getCitiesQuery))).Result;
@@ -273,7 +273,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             using (CityDomainService cities = new CityDomainService())
             {
                 // Now prepare for a submit to invoke AssignCityZoneIfAuthorized as a named update method
-                DomainServiceContext ctxt = new DomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Submit);
+                DomainServiceContext ctxt = new WcfDomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Submit);
                 cities.Initialize(ctxt);
 
                 // Prepare an attempt to delete this with a user whose name is not WAGuy
@@ -307,7 +307,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 waGuy.IsAuthenticated = true;
 
                 // Now prepare for a submit to invoke AssignCityZoneIfAuthorized as a named update method
-                DomainServiceContext ctxt = new DomainServiceContext(new MockDataService(waGuy), DomainOperationType.Submit);
+                DomainServiceContext ctxt = new WcfDomainServiceContext(new MockDataService(waGuy), DomainOperationType.Submit);
                 cities.Initialize(ctxt);
 
                 // Prepare an attempt to delete this with a user whose name is not WAGuy
@@ -356,7 +356,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             using (CityDomainService cities = new CityDomainService())
             {
                 // Now prepare for a query to find a Zip in WA
-                DomainServiceContext ctxt = new DomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Query);
+                DomainServiceContext ctxt = new WcfDomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Query);
                 cities.Initialize(ctxt);
 
                 IEnumerable result = cities.QueryAsync(new QueryDescription(getCitiesQuery))
@@ -371,7 +371,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             using (CityDomainService cities = new CityDomainService())
             {
                 // Prepare an invoke to call a method that has a custom auth attribute
-                DomainServiceContext ctxt = new DomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Invoke);
+                DomainServiceContext ctxt = new WcfDomainServiceContext(new MockDataService(notWaGuy), DomainOperationType.Invoke);
                 cities.Initialize(ctxt);
 
                 // verify that even top level exceptions go through
@@ -399,7 +399,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 waGuy.IsAuthenticated = true;
 
                 // Prepare an invoke to call a method that has a custom auth attribute
-                DomainServiceContext ctxt = new DomainServiceContext(new MockDataService(waGuy), DomainOperationType.Invoke);
+                DomainServiceContext ctxt = new WcfDomainServiceContext(new MockDataService(waGuy), DomainOperationType.Invoke);
                 cities.Initialize(ctxt);
 
                 // verify that even top level exceptions go through

--- a/src/OpenRiaServices.DomainServices.Server/Test/AuthorizationTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/AuthorizationTests.cs
@@ -206,7 +206,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 UnauthorizedAccessException exception = null;
                 try
                 {
-                    ChangeSetProcessor.Process(cities, entries);
+                    await ChangeSetProcessor.ProcessAsync(cities, entries);
                 }
                 catch (UnauthorizedAccessException ex)
                 {
@@ -232,7 +232,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 Exception exception = null;
                 try
                 {
-                    ChangeSetProcessor.Process(cities, entries);
+                    await ChangeSetProcessor.ProcessAsync(cities, entries);
                 }
                 catch (UnauthorizedAccessException ex)
                 {
@@ -290,7 +290,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 UnauthorizedAccessException exception = null;
                 try
                 {
-                    ChangeSetProcessor.Process(cities, entries);
+                    await ChangeSetProcessor.ProcessAsync(cities, entries);
                 }
                 catch (UnauthorizedAccessException ex)
                 {
@@ -326,7 +326,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 Exception exception = null;
                 try
                 {
-                    ChangeSetProcessor.Process(cities, entries);
+                    await ChangeSetProcessor.ProcessAsync(cities, entries);
                 }
                 catch (UnauthorizedAccessException ex)
                 {

--- a/src/OpenRiaServices.DomainServices.Server/Test/AuthorizationTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/AuthorizationTests.cs
@@ -37,7 +37,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             MockDataService dataService = new MockDataService(user);
             cities.Initialize(new DomainServiceContext(dataService, DomainOperationType.Query));
             Exception expectedException = null;
-            DomainService.ServiceQueryResult result;
+            ServiceQueryResult result;
 
             try
             {
@@ -338,7 +338,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
         [TestMethod]
         [Description("Attempting an Invoke operation marked with a custom authorization attribute is denied and allowed appropriately")]
-        public void Authorization_Custom_Authorization_On_Invoke()
+        public async Task Authorization_Custom_Authorization_On_Invoke()
         {
             // Specifically, the City data is marked so that no one can delete a Zip code
             // from WA unless their user name is WAGuy
@@ -376,12 +376,11 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
                 // verify that even top level exceptions go through
                 // the OnError handler
-                IEnumerable<ValidationResult> validationErrors;
                 UnauthorizedAccessException expectedException = null;
                 try
                 {
                     // cause a domain service not initialized exception
-                    cities.Invoke(new InvokeDescription(invokeOperation, new object[] { city }), out validationErrors);
+                    await cities.InvokeAsync(new InvokeDescription(invokeOperation, new object[] { city }));
                 }
                 catch (UnauthorizedAccessException e)
                 {
@@ -405,12 +404,11 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
                 // verify that even top level exceptions go through
                 // the OnError handler
-                IEnumerable<ValidationResult> validationErrors;
                 UnauthorizedAccessException expectedException = null;
                 try
                 {
                     // cause a domain service not initialized exception
-                    cities.Invoke(new InvokeDescription(invokeOperation, new object[] { city }), out validationErrors);
+                    await cities.InvokeAsync(new InvokeDescription(invokeOperation, new object[] { city }));
                 }
                 catch (UnauthorizedAccessException e)
                 {

--- a/src/OpenRiaServices.DomainServices.Server/Test/DirectServiceTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DirectServiceTests.cs
@@ -308,7 +308,6 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
             DomainServiceDescription serviceDescription = DomainServiceDescription.GetDescription(service.GetType());
             DomainOperationEntry method = serviceDescription.DomainOperationEntries.Single(p => p.Name == "InvokeOperationWithParamValidation");
-            IEnumerable<ValidationResult> validationErrors;
             InvokeDescription invokeDescription = new InvokeDescription(method, new object[] { -3, "ABC", new TestDomainServices.CityWithCacheData() });
             var invokeResult = await service.InvokeAsync(invokeDescription);
 

--- a/src/OpenRiaServices.DomainServices.Server/Test/DirectServiceTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DirectServiceTests.cs
@@ -170,13 +170,13 @@ namespace OpenRiaServices.DomainServices.Server.Test
             DomainServiceDescription dsd = DomainServiceDescription.GetDescription(typeof(TestDomainServices.EF.Northwind));
             DomainOperationEntry entry = dsd.GetQueryMethod(nameof(TestDomainServices.EF.Northwind.GetOrderDetails));
             QueryDescription qd = new QueryDescription(entry);
-            await ExceptionHelper.ExpectException<InvalidOperationException>(() =>
+            await ExceptionHelper.ExpectExceptionAsync<InvalidOperationException>(() =>
             {
                 return nw.QueryAsync<NorthwindModel.Order_Detail>(qd, CancellationToken.None).AsTask();
             }, string.Format(Resource.DomainService_InvalidOperationType, DomainOperationType.Submit, DomainOperationType.Query));
 
             InvokeDescription id = new InvokeDescription(entry, null);
-            await ExceptionHelper.ExpectException<InvalidOperationException>(() =>
+            await ExceptionHelper.ExpectExceptionAsync<InvalidOperationException>(() =>
             {
                 return nw.InvokeAsync(id, CancellationToken.None).AsTask();
             }, string.Format(Resource.DomainService_InvalidOperationType, DomainOperationType.Submit, DomainOperationType.Invoke));
@@ -191,9 +191,9 @@ namespace OpenRiaServices.DomainServices.Server.Test
                     Operation = DomainOperation.Insert
                 }
             });
-            await ExceptionHelper.ExpectException<InvalidOperationException>(() =>
+            await ExceptionHelper.ExpectExceptionAsync<InvalidOperationException>(async ()=>
             {
-                return (Task)nw.SubmitAsync(cs, CancellationToken.None);
+                await nw.SubmitAsync(cs, CancellationToken.None);
             }, string.Format(Resource.DomainService_InvalidOperationType, DomainOperationType.Query, DomainOperationType.Submit));
         }
 
@@ -352,7 +352,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             DomainServiceDescription serviceDescription = DomainServiceDescription.GetDescription(provider.GetType());
             DomainOperationEntry method = serviceDescription.DomainOperationEntries.First(p => p.Name == "GetEntities" && p.Operation == DomainOperation.Query);
             QueryDescription qd = new QueryDescription(method, new object[0]);
-            await ExceptionHelper.ExpectException<Exception>(async () =>
+            await ExceptionHelper.ExpectExceptionAsync<Exception>(async () =>
             {
                 try
                 {

--- a/src/OpenRiaServices.DomainServices.Server/Test/DirectServiceTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DirectServiceTests.cs
@@ -65,7 +65,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
         }
 
         [TestMethod]
-        public void TestDirectChangeset_Cities()
+        public async Task TestDirectChangeset_Cities()
         {
             for (int i = 0; i < 100; i++)
             {
@@ -80,14 +80,14 @@ namespace OpenRiaServices.DomainServices.Server.Test
                     entries.Add(new ChangeSetEntry(j, newCity, null, DomainOperation.Insert));
                 }
 
-                ChangeSetProcessor.ProcessAsync(ds, entries);
+                await ChangeSetProcessor.ProcessAsync(ds, entries);
 
                 Assert.IsFalse(entries.Any(p => p.HasError));
             }
         }
 
         [TestMethod]
-        public void TestDirectChangeset_Simple()
+        public async Task TestDirectChangeset_Simple()
         {
             for (int i = 0; i < 100; i++)
             {
@@ -110,7 +110,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                     entries.Add(new ChangeSetEntry(j, e, null, DomainOperation.Insert));
                 }
 
-                ChangeSetProcessor.ProcessAsync(ds, entries);
+                await ChangeSetProcessor.ProcessAsync(ds, entries);
 
                 Assert.IsFalse(entries.Any(p => p.HasError));
             }
@@ -133,7 +133,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
         /// </summary>
         [TestMethod]
         [TestCategory("DatabaseTest")]
-        public void DomainService_DirectQuery()
+        public async Task DomainService_DirectQuery()
         {
             DomainServiceDescription description = DomainServiceDescription.GetDescription(typeof(TestDomainServices.EF.Catalog));
 
@@ -150,8 +150,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 new ServiceQueryPart("take", "1")
             };
 
-            QueryResult<AdventureWorksModel.PurchaseOrder> result = QueryProcessor.Process<AdventureWorksModel.PurchaseOrder>(service, queryOperation, new object[0], serviceQuery)
-                .GetAwaiter().GetResult();
+            QueryResult<AdventureWorksModel.PurchaseOrder> result = await QueryProcessor.ProcessAsync<AdventureWorksModel.PurchaseOrder>(service, queryOperation, new object[0], serviceQuery);
 
             Assert.AreEqual(1, result.RootResults.Count());
         }

--- a/src/OpenRiaServices.DomainServices.Server/Test/DirectServiceTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DirectServiceTests.cs
@@ -80,7 +80,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                     entries.Add(new ChangeSetEntry(j, newCity, null, DomainOperation.Insert));
                 }
 
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries);
 
                 Assert.IsFalse(entries.Any(p => p.HasError));
             }
@@ -110,7 +110,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                     entries.Add(new ChangeSetEntry(j, e, null, DomainOperation.Insert));
                 }
 
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries);
 
                 Assert.IsFalse(entries.Any(p => p.HasError));
             }
@@ -193,7 +193,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             });
             ExceptionHelper.ExpectException<InvalidOperationException>(delegate
             {
-                nw.Submit(cs);
+                nw.SubmitAsync(cs).GetAwaiter().GetResult();
             }, string.Format(Resource.DomainService_InvalidOperationType, DomainOperationType.Query, DomainOperationType.Submit));
         }
 
@@ -264,7 +264,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             ds = new ServiceContext_CurrentOperation_DomainService(DomainOperationType.Submit);
             DomainOperationEntry insertOp = dsd.GetSubmitMethod(typeof(ServiceContext_CurrentOperation_Entity), DomainOperation.Insert);
             Assert.IsNotNull(insertOp);
-            ds.Submit(new ChangeSet(new ChangeSetEntry[] {
+            await ds.SubmitAsync(new ChangeSet(new ChangeSetEntry[] {
                 new ChangeSetEntry() { 
                     Entity = new ServiceContext_CurrentOperation_Entity() { Key = 1 },
                     Operation = DomainOperation.Insert

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainMethodServerTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainMethodServerTest.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using OpenRiaServices.DomainServices.Client.Test;
 using Cities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace OpenRiaServices.DomainServices.Server.Test
 {
@@ -58,7 +60,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
         [TestMethod]
         [Description("Verify that calling submit with a domain method invocation in the changeset will invoke the method methods accordingly")]
-        public void DomainService_CallSubmitDirectly()
+        public async Task DomainService_CallSubmitDirectly()
         {
             DomainServiceDescription description = DomainServiceDescription.GetDescription(typeof(DomainMethod_ValidProvider_MultipleMethods));
             List<ChangeSetEntry> changeSetEntries = new List<ChangeSetEntry>();
@@ -72,7 +74,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
             ChangeSet changeset = new ChangeSet(changeSetEntries);
             DomainMethod_ValidProvider_MultipleMethods myTestProvider = ServerTestHelper.CreateInitializedDomainService<DomainMethod_ValidProvider_MultipleMethods>(DomainOperationType.Submit);
-            myTestProvider.SubmitAsync(changeset);
+            await myTestProvider.SubmitAsync(changeset, CancellationToken.None);
 
             // check that the domain services have invoked the domain method correctly by checking the internal variables set
             Assert.AreEqual<string>("ProcessCity_", myTestProvider.Invoked);
@@ -82,7 +84,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
         [TestMethod]
         [Description("Verify that calling submit with 2 domain method invocations in the changeset will invoke the method methods accordingly")]
-        public void DomainService_CallSubmitWithMultipleInvocations()
+        public async Task DomainService_CallSubmitWithMultipleInvocationsAsync()
         {
             DomainServiceDescription description = DomainServiceDescription.GetDescription(typeof(DomainMethod_ValidProvider_MultipleMethods));
             List<ChangeSetEntry> changeSetEntries = new List<ChangeSetEntry>();
@@ -105,7 +107,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
             ChangeSet changeset = new ChangeSet(changeSetEntries);
             DomainMethod_ValidProvider_MultipleMethods myTestProvider = ServerTestHelper.CreateInitializedDomainService<DomainMethod_ValidProvider_MultipleMethods>(DomainOperationType.Submit);
-            myTestProvider.SubmitAsync(changeset);
+            await myTestProvider.SubmitAsync(changeset, CancellationToken.None);
 
             // check that the domain services have invoked the domain method correctly by checking the internal variables set
             Assert.AreEqual<string>("ProcessCounty_ProcessCity_", myTestProvider.Invoked);

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainMethodServerTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainMethodServerTest.cs
@@ -72,7 +72,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
             ChangeSet changeset = new ChangeSet(changeSetEntries);
             DomainMethod_ValidProvider_MultipleMethods myTestProvider = ServerTestHelper.CreateInitializedDomainService<DomainMethod_ValidProvider_MultipleMethods>(DomainOperationType.Submit);
-            myTestProvider.Submit(changeset);
+            myTestProvider.SubmitAsync(changeset);
 
             // check that the domain services have invoked the domain method correctly by checking the internal variables set
             Assert.AreEqual<string>("ProcessCity_", myTestProvider.Invoked);
@@ -105,7 +105,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
             ChangeSet changeset = new ChangeSet(changeSetEntries);
             DomainMethod_ValidProvider_MultipleMethods myTestProvider = ServerTestHelper.CreateInitializedDomainService<DomainMethod_ValidProvider_MultipleMethods>(DomainOperationType.Submit);
-            myTestProvider.Submit(changeset);
+            myTestProvider.SubmitAsync(changeset);
 
             // check that the domain services have invoked the domain method correctly by checking the internal variables set
             Assert.AreEqual<string>("ProcessCounty_ProcessCity_", myTestProvider.Invoked);

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
@@ -3662,10 +3662,11 @@ namespace OpenRiaServices.DomainServices.Server.Test
         {
             return base.Submit(changeSet);
         }
-        public override object Invoke(InvokeDescription invokeDescription, out IEnumerable<ValidationResult> validationErrors)
+        public override ValueTask<ServiceInvokeResult> InvokeAsync(InvokeDescription invokeDescription)
         {
-            return base.Invoke(invokeDescription, out validationErrors);
+            return base.InvokeAsync(invokeDescription);
         }
+
         public override void Initialize(DomainServiceContext context)
         {
             base.Initialize(context);

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
@@ -29,8 +29,9 @@ using TheTypeDescriptorExtensions = SystemWebDomainServices::OpenRiaServices.Dom
 
 namespace OpenRiaServices.DomainServices.Server.Test
 {
+    using System.Threading.Tasks;
     using MetaType = SystemWebDomainServices::OpenRiaServices.DomainServices.Server.MetaType;
-    
+
 
     /// <summary>
     /// DomainServiceDescription tests
@@ -3652,10 +3653,11 @@ namespace OpenRiaServices.DomainServices.Server.Test
     [EnableClientAccess]
     public class DomainService_BaseMethodOverrides : DomainService
     {
-        public override IEnumerable Query(QueryDescription queryDescription, out IEnumerable<ValidationResult> validationErrors, out int totalCount)
+        public override ValueTask<ServiceQueryResult> QueryAsync(QueryDescription queryDescription)
         {
-            return base.Query(queryDescription, out validationErrors, out totalCount);
+            return base.QueryAsync(queryDescription);
         }
+
         public override bool Submit(ChangeSet changeSet)
         {
             return base.Submit(changeSet);

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
@@ -3658,7 +3658,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             return base.QueryAsync<T>(queryDescription, cancellationToken);
         }
 
-        public override Task<bool> SubmitAsync(ChangeSet changeSet, CancellationToken cancellationToken)
+        public override ValueTask<bool> SubmitAsync(ChangeSet changeSet, CancellationToken cancellationToken)
         {
             return base.SubmitAsync(changeSet, cancellationToken);
         }

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
@@ -3658,10 +3658,11 @@ namespace OpenRiaServices.DomainServices.Server.Test
             return base.QueryAsync(queryDescription);
         }
 
-        public override bool Submit(ChangeSet changeSet)
+        public override Task<bool> SubmitAsync(ChangeSet changeSet)
         {
-            return base.Submit(changeSet);
+            return base.SubmitAsync(changeSet);
         }
+
         public override ValueTask<ServiceInvokeResult> InvokeAsync(InvokeDescription invokeDescription)
         {
             return base.InvokeAsync(invokeDescription);

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceDescriptionTest.cs
@@ -3653,19 +3653,19 @@ namespace OpenRiaServices.DomainServices.Server.Test
     [EnableClientAccess]
     public class DomainService_BaseMethodOverrides : DomainService
     {
-        public override ValueTask<ServiceQueryResult> QueryAsync(QueryDescription queryDescription)
+        public override ValueTask<ServiceQueryResult> QueryAsync<T>(QueryDescription queryDescription, CancellationToken cancellationToken)
         {
-            return base.QueryAsync(queryDescription);
+            return base.QueryAsync<T>(queryDescription, cancellationToken);
         }
 
-        public override Task<bool> SubmitAsync(ChangeSet changeSet)
+        public override Task<bool> SubmitAsync(ChangeSet changeSet, CancellationToken cancellationToken)
         {
-            return base.SubmitAsync(changeSet);
+            return base.SubmitAsync(changeSet, cancellationToken);
         }
 
-        public override ValueTask<ServiceInvokeResult> InvokeAsync(InvokeDescription invokeDescription)
+        public override ValueTask<ServiceInvokeResult> InvokeAsync(InvokeDescription invokeDescription, CancellationToken cancellationToken)
         {
-            return base.InvokeAsync(invokeDescription);
+            return base.InvokeAsync(invokeDescription, cancellationToken);
         }
 
         public override void Initialize(DomainServiceContext context)

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceTests.cs
@@ -200,15 +200,13 @@ namespace OpenRiaServices.DomainServices.Server.Test
         [WorkItem(688352)]
         public async Task Query_ResultLimit()
         {
-            Func<string, int, Task<QueryResult<Cities.City>>> executeQuery = async (queryName, pageSize) =>
+            Func<string, int, Task<QueryResult<Cities.City>>> executeQueryAsync = async (queryName, pageSize) =>
             {
                 ResultLimitDomainService ds = new ResultLimitDomainService();
-
                 DomainServiceContext dsc = new DomainServiceContext(new MockDataService(new MockUser("mathew")), DomainOperationType.Query);
                 ds.Initialize(dsc);
 
                 DomainServiceDescription desc = DomainServiceDescription.GetDescription(typeof(ResultLimitDomainService));
-
                 IQueryable<City> filter = null;
 
                 if (pageSize > -1)
@@ -218,7 +216,6 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
                 DomainOperationEntry queryOperation = desc.GetQueryMethod(queryName);
                 QueryDescription query = new QueryDescription(queryOperation, new object[0], true, filter);
-                ;
                 var queryResult = await ds.QueryAsync<City>(query, CancellationToken.None);
                 return new QueryResult<City>()
                 {
@@ -227,27 +224,27 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 };
             };
 
-            var allResults = await executeQuery("GetCities", -1);
+            var allResults = await executeQueryAsync("GetCities", -1);
             int totalCities = allResults.Results.Count();
 
             // Verify that ResultLimit=0 is the same as not having a ResultLimit at all.
-            var results = await executeQuery("GetCities0", -1);
+            var results = await executeQueryAsync("GetCities0", -1);
             Assert.AreEqual(totalCities, results.Results.Count(), "Expected to get back all cities.");
             Assert.AreEqual(allResults.Results.Count(), results.TotalCount, "Unexpected total count.");
 
             // Verify that ResultLimit=-1 is the same as not having a ResultLimit at all.
-            results = await executeQuery("GetCitiesM1", -1);
+            results = await executeQueryAsync("GetCitiesM1", -1);
             Assert.AreEqual(totalCities, results.Results.Count(), "Expected to get back all cities.");
             Assert.AreEqual(allResults.Results.Count(), results.TotalCount, "Unexpected total count.");
 
             // Verify that ResultLimit=10 gives us back only the first 10 cities.
-            results = await executeQuery("GetCities10", -1);
+            results = await executeQueryAsync("GetCities10", -1);
             Assert.AreEqual(10, results.Results.Count());
             Assert.IsTrue(results.Results.SequenceEqual(allResults.Results.Take(10)), "Expected the first 10 cities.");
             Assert.AreEqual(allResults.Results.Count(), results.TotalCount, "Unexpected total count.");
 
             // Verify that ResultLimit=10 with a page size of 2 gives us back only the first 2 cities, and it gives us back the proper total count.
-            results = await executeQuery("GetCities10", 2);
+            results = await executeQueryAsync("GetCities10", 2);
             Assert.AreEqual(2, results.Results.Count());
             Assert.IsTrue(results.Results.SequenceEqual(allResults.Results.Take(2)), "Expected the first 2 cities.");
             Assert.AreEqual(allResults.Results.Count(), results.TotalCount, "Unexpected total count.");
@@ -2061,11 +2058,11 @@ namespace OpenRiaServices.DomainServices.Server.Test
             return new ValueTask<bool>(!this.ChangeSet.HasError);
         }
 
-        protected override async ValueTask<bool> ValidateChangeSet(CancellationToken cancellationToken)
+        protected override async ValueTask<bool> ValidateChangeSetAsync(CancellationToken cancellationToken)
         {
             ValidateCount++;
 
-            await base.ValidateChangeSet(cancellationToken);
+            await base.ValidateChangeSetAsync(cancellationToken);
 
             return IsValid;
         }

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceTests.cs
@@ -15,6 +15,7 @@ using Cities;
 using OpenRiaServices.DomainServices.LinqToSql;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestDomainServices;
+using System.Threading.Tasks;
 
 namespace OpenRiaServices.DomainServices.Server.Test
 {
@@ -361,7 +362,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
         /// for invoke operations.
         /// </summary>
         [TestMethod]
-        public void OnErrorHandling_Invoke()
+        public async Task OnErrorHandling_Invoke()
         {
             OnErrorDomainService ds = new OnErrorDomainService();
 
@@ -373,12 +374,11 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
             // verify that even top level exceptions go through
             // the OnError handler
-            IEnumerable<ValidationResult> validationErrors;
             Exception expectedException = null;
             try
             {
                 // cause a domain service not initialized exception
-                ds.Invoke(new InvokeDescription(operation, new object[] { 1 }), out validationErrors);
+                await ds.InvokeAsync(new InvokeDescription(operation, new object[] { 1 }));
             }
             catch (TargetInvocationException tie)
             {
@@ -396,7 +396,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             try
             {
                 // pass a null parameter
-                ds.Invoke(null, out validationErrors);
+                await ds.InvokeAsync(null);
             }
             catch (TargetInvocationException tie)
             {
@@ -415,7 +415,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             ds.Initialize(dsc);
             try
             {
-                ds.Invoke(new InvokeDescription(operation, new object[] { 1 }), out validationErrors);
+                await ds.InvokeAsync(new InvokeDescription(operation, new object[] { 1 }));
             }
             catch (TargetInvocationException tie)
             {
@@ -434,7 +434,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             ds.Initialize(dsc);
             try
             {
-                ds.Invoke(new InvokeDescription(operation, new object[] { 1 }), out validationErrors);
+                await ds.InvokeAsync(new InvokeDescription(operation, new object[] { 1 }));
             }
             catch (TargetInvocationException tie)
             {
@@ -451,9 +451,9 @@ namespace OpenRiaServices.DomainServices.Server.Test
             expectedException = null;
             ds = new OnErrorDomainService();
             ds.Initialize(dsc);
-            ds.Invoke(new InvokeDescription(operation, new object[] { 10 }), out validationErrors);
-            Assert.IsNotNull(validationErrors);
-            Assert.AreEqual(1, validationErrors.Count());
+            var invokeResult = await ds.InvokeAsync(new InvokeDescription(operation, new object[] { 10 }));
+            Assert.IsNotNull(invokeResult.ValidationErrors);
+            Assert.AreEqual(1, invokeResult.ValidationErrors.Count);
             Assert.IsNull(ds.LastError);
         }
 

--- a/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceTests.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/DomainServiceTests.cs
@@ -71,7 +71,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             ChangeSetEntry entry = new ChangeSetEntry();
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
-                ChangeSetProcessor.Process(ds, new ChangeSetEntry[] { entry });
+                ChangeSetProcessor.ProcessAsync(ds, new ChangeSetEntry[] { entry }).GetAwaiter().GetResult();
             },
             string.Format(CultureInfo.CurrentCulture, Resource.InvalidChangeSet, Resource.InvalidChangeSet_NullEntity));
 
@@ -81,7 +81,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             entries.Add(new ChangeSetEntry { Entity = new City(), Id = 1 });
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries).GetAwaiter().GetResult();
             },
             string.Format(CultureInfo.CurrentCulture, Resource.InvalidChangeSet, Resource.InvalidChangeSet_DuplicateId));
 
@@ -92,7 +92,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             entries.Add(new ChangeSetEntry { Entity = new City(), Id = 1, Associations = associations });
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries).GetAwaiter().GetResult();
             }, string.Format(Resource.InvalidChangeSet,
                 string.Format(Resource.InvalidChangeSet_InvalidAssociationMember, typeof(City), "invalid")));
 
@@ -103,7 +103,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             entries.Add(new ChangeSetEntry { Entity = new City(), Id = 1, Associations = associations });
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries).GetAwaiter().GetResult();
             }, string.Format(Resource.InvalidChangeSet,
                 string.Format(Resource.InvalidChangeSet_InvalidAssociationMember, typeof(City), "StateName")));
 
@@ -114,7 +114,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             entries.Add(new ChangeSetEntry { Entity = new City(), Id = 1, Associations = associations });
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries).GetAwaiter().GetResult();
             }, string.Format(Resource.InvalidChangeSet,
                 string.Format(Resource.InvalidChangeSet_AssociatedIdsCannotBeNull, typeof(City).FullName, "ZipCodes")));
 
@@ -126,7 +126,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             entries.Add(new ChangeSetEntry { Entity = new City(), Id = 2 });
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries).GetAwaiter().GetResult();
             }, string.Format(Resource.InvalidChangeSet,
                 string.Format(Resource.InvalidChangeSet_AssociatedIdNotInChangeset, 9, typeof(City).FullName, "ZipCodes")));
 
@@ -135,7 +135,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             entries.Add(new ChangeSetEntry { Entity = new City(), OriginalEntity = new Zip(), Id = 1 });
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries).GetAwaiter().GetResult();
             }, string.Format(Resource.InvalidChangeSet, Resource.InvalidChangeSet_MustBeSameType));
 
             entries.Clear();
@@ -144,7 +144,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             entries.Add(new ChangeSetEntry { Entity = entity, Id = 2 });
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
-                ChangeSetProcessor.Process(ds, entries);
+                ChangeSetProcessor.ProcessAsync(ds, entries).GetAwaiter().GetResult();
             },
             string.Format(CultureInfo.CurrentCulture, Resource.InvalidChangeSet, Resource.InvalidChangeSet_DuplicateEntity));
         }
@@ -462,7 +462,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
         /// for submit.
         /// </summary>
         [TestMethod]
-        public void OnErrorHandling_Submit()
+        public async Task OnErrorHandling_Submit()
         {
             OnErrorDomainService ds = new OnErrorDomainService();
 
@@ -494,7 +494,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             try
             {
                 // cause a domain service not initialize exception
-                ds.Submit(cs);
+                await ds.SubmitAsync(cs);
             }
             catch (InvalidOperationException e)
             {
@@ -508,7 +508,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             try
             {
                 // pass a null parameter
-                ds.Submit(null);
+                await ds.SubmitAsync(null);
             }
             catch (ArgumentNullException e)
             {
@@ -523,7 +523,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             ds.Initialize(dsc);
             try
             {
-                ds.Submit(cs);
+                await ds.SubmitAsync(cs);
             }
             catch (Exception e)
             {
@@ -538,7 +538,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             ds.Initialize(dsc);
             try
             {
-                ds.Submit(cs);
+                await ds.SubmitAsync(cs);
             }
             catch (Exception e)
             {
@@ -552,7 +552,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             ds = new OnErrorDomainService();
             ds.Initialize(dsc);
             ((City)updateOperation.Entity).StateName = "ASDF"; // Too long
-            ds.Submit(cs);
+            await ds.SubmitAsync(cs);
             Assert.IsTrue(cs.HasError);
             Assert.AreEqual(1, cs.ChangeSetEntries.Count(p => p.HasError));
             Assert.IsNull(ds.LastError);
@@ -615,7 +615,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             // Verify that the validation exception is handled and is associated
             // with the right ChangeSetEntry
             ChangeSet cs = new ChangeSet(new ChangeSetEntry[] { updateOp });
-            ds.Submit(cs);
+            ds.SubmitAsync(cs);
             ChangeSetEntry resultOp = cs.ChangeSetEntries.First();
             Assert.IsTrue(resultOp.HasError);
             var error = resultOp.ValidationErrors.Single();
@@ -804,7 +804,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
 
             // verify success for valid changeset
             dp = new TestDomainService_OverloadTests();
-            dp.Submit(cs);
+            dp.SubmitAsync(cs);
             Assert.AreEqual(1, dp.ValidateCount);
             Assert.AreEqual(1, dp.UpdateCount);
             Assert.AreEqual(1, dp.SubmitCount);
@@ -812,7 +812,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             // verify that if validation fails, the changeset isn't processed
             dp = new TestDomainService_OverloadTests();
             dp.IsValid = false;
-            dp.Submit(cs);
+            dp.SubmitAsync(cs);
             Assert.AreEqual(1, dp.ValidateCount);
             Assert.AreEqual(0, dp.UpdateCount);
             Assert.AreEqual(0, dp.SubmitCount);
@@ -1258,7 +1258,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             service.Initialize(context);
             var updateOp = new ChangeSetEntry() { Entity = pmEntity1, Operation = DomainOperation.Update, HasMemberChanges = true };
             var changeSet = new ChangeSet(new[] { updateOp });
-            service.Submit(changeSet);
+            service.SubmitAsync(changeSet);
 
             Assert.AreEqual("UpdatedFirst1 UpdatedLast1", pmEntity1.Name);
             Assert.AreEqual("Value1.1", pmEntity1.Message);
@@ -1292,7 +1292,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             };
             var changeSet = new ChangeSet(new[] { customOp });
             pmEntity1.Message = "ReplaceInTransform";
-            service.Submit(changeSet);
+            service.SubmitAsync(changeSet);
 
             // No changes
             var entityInChangeSet = customOp.Entity as PresentationCustomer;
@@ -1334,7 +1334,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             pmEntity1.Message = "UseEntityNotInChangeSet";
 
             ExceptionHelper.ExpectArgumentException(
-                () => service.Submit(changeSet),
+                () => service.SubmitAsync(changeSet).GetAwaiter().GetResult(),
                 Resource.ChangeSet_ChangeSetEntryNotFound,
                 "entity");
         }
@@ -1990,7 +1990,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             throw new ValidationException("Invalid City Update!", null, city);
         }
 
-        protected override bool PersistChangeSet()
+        protected override async Task<bool> PersistChangeSetAsync()
         {
             // verify that validation exceptions thrown from PersistChangeSet
             // are handled by the framework properly
@@ -2042,7 +2042,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             UpdateCount++;
         }
 
-        protected override bool PersistChangeSet()
+        protected override async Task<bool> PersistChangeSetAsync()
         {
             SubmitCount++;
 
@@ -2059,18 +2059,18 @@ namespace OpenRiaServices.DomainServices.Server.Test
             return !this.ChangeSet.HasError;
         }
 
-        protected override bool ValidateChangeSet()
+        protected override async Task<bool> ValidateChangeSetAsync()
         {
             ValidateCount++;
 
-            base.ValidateChangeSet();
+            await base.ValidateChangeSetAsync();
 
             return IsValid;
         }
 
-        protected override bool ExecuteChangeSet()
+        protected override Task<bool> ExecuteChangeSetAsync()
         {
-            return base.ExecuteChangeSet();
+            return base.ExecuteChangeSetAsync();
         }
     }
 
@@ -2290,7 +2290,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
                 });
         }
 
-        protected override bool PersistChangeSet()
+        protected override async Task<bool> PersistChangeSetAsync()
         {
             // Check if we should fake an optimistic concurrency exception and 
             // return conflict members

--- a/src/OpenRiaServices.DomainServices.Server/Test/InvokeOperationServerTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/InvokeOperationServerTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.DomainServices.Client.Test;
@@ -128,7 +129,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             {
                 BID1 = 1
             };
-            var invokeResult = await provider.InvokeAsync(new InvokeDescription(incrementBid1ForAByMethod, new object[] { inputA, 2 }));
+            var invokeResult = await provider.InvokeAsync(new InvokeDescription(incrementBid1ForAByMethod, new object[] { inputA, 2 }), CancellationToken.None);
             Assert.IsNull(invokeResult.Result);
             Assert.IsNotNull(invokeResult.ValidationErrors);
             Assert.AreEqual(2, invokeResult.ValidationErrors.Count);
@@ -145,7 +146,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             DomainOperationEntry throwValidationExceptionMethod = serviceDescription.GetInvokeOperation("ThrowValidationException");
             Assert.IsNotNull(throwValidationExceptionMethod);
 
-            var invokeResult = await provider.InvokeAsync(new InvokeDescription(throwValidationExceptionMethod, new object[0]));
+            var invokeResult = await provider.InvokeAsync(new InvokeDescription(throwValidationExceptionMethod, new object[0]), CancellationToken.None);
             Assert.IsNull(invokeResult.Result);
             Assert.IsNotNull(invokeResult.ValidationErrors);
             Assert.AreEqual(1, invokeResult.ValidationErrors.Count);

--- a/src/OpenRiaServices.DomainServices.Tools/Test/TestWap/TestWap.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/TestWap/TestWap.csproj
@@ -106,6 +106,11 @@
       <Name>OpenRiaServices.DomainServices.Hosting</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions">
+      <Version>4.5.3</Version>
+    </PackageReference>
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/CompositionAndInheritanceScenarios.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/CompositionAndInheritanceScenarios.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading.Tasks;
 using OpenRiaServices;
 using OpenRiaServices.DomainServices.Hosting;
 using OpenRiaServices.DomainServices.Server;
@@ -120,7 +121,7 @@ namespace TestDomainServices
         /// <summary>
         /// Overridden to do some pre-validation of the changeset
         /// </summary>
-        protected override bool ExecuteChangeSet()
+        protected override Task<bool> ExecuteChangeSetAsync()
         {
             foreach (ChangeSetEntry operation in this.ChangeSet.ChangeSetEntries.Where(p => p.Entity.GetType() == typeof(CI_Parent)))
             {
@@ -134,7 +135,7 @@ namespace TestDomainServices
                 this.VerifyUniqueCollection(parent.Children);
             }
 
-            return base.ExecuteChangeSet();
+            return base.ExecuteChangeSetAsync();
         }
 
         /// <summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/CompositionAndInheritanceScenarios.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/CompositionAndInheritanceScenarios.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenRiaServices;
 using OpenRiaServices.DomainServices.Hosting;
@@ -121,7 +122,7 @@ namespace TestDomainServices
         /// <summary>
         /// Overridden to do some pre-validation of the changeset
         /// </summary>
-        protected override Task<bool> ExecuteChangeSetAsync()
+        protected override ValueTask<bool> ExecuteChangeSetAsync(CancellationToken cancellationToken)
         {
             foreach (ChangeSetEntry operation in this.ChangeSet.ChangeSetEntries.Where(p => p.Entity.GetType() == typeof(CI_Parent)))
             {
@@ -135,7 +136,7 @@ namespace TestDomainServices
                 this.VerifyUniqueCollection(parent.Children);
             }
 
-            return base.ExecuteChangeSetAsync();
+            return base.ExecuteChangeSetAsync(cancellationToken);
         }
 
         /// <summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/CompositionScenarios.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/CompositionScenarios.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.ServiceModel;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenRiaServices;
 using OpenRiaServices.DomainServices.Hosting;
@@ -149,7 +150,7 @@ namespace TestDomainServices
         /// <summary>
         /// Overridden to do some pre-validation of the changeset
         /// </summary>
-        protected override Task<bool> ExecuteChangeSetAsync()
+        protected override ValueTask<bool> ExecuteChangeSetAsync(CancellationToken cancellationToken)
         {
             foreach (ChangeSetEntry operation in this.ChangeSet.ChangeSetEntries.Where(p => p.Entity.GetType() == typeof(Parent)))
             {
@@ -167,7 +168,7 @@ namespace TestDomainServices
                 }
             }
 
-            return base.ExecuteChangeSetAsync();
+            return base.ExecuteChangeSetAsync(cancellationToken);
         }
 
         /// <summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/CompositionScenarios.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/CompositionScenarios.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.ServiceModel;
+using System.Threading.Tasks;
 using OpenRiaServices;
 using OpenRiaServices.DomainServices.Hosting;
 using OpenRiaServices.DomainServices.Server;
@@ -148,7 +149,7 @@ namespace TestDomainServices
         /// <summary>
         /// Overridden to do some pre-validation of the changeset
         /// </summary>
-        protected override bool ExecuteChangeSet()
+        protected override Task<bool> ExecuteChangeSetAsync()
         {
             foreach (ChangeSetEntry operation in this.ChangeSet.ChangeSetEntries.Where(p => p.Entity.GetType() == typeof(Parent)))
             {
@@ -166,7 +167,7 @@ namespace TestDomainServices
                 }
             }
 
-            return base.ExecuteChangeSet();
+            return base.ExecuteChangeSetAsync();
         }
 
         /// <summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/MockDomainServices.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/MockDomainServices.cs
@@ -18,6 +18,7 @@ using DataTests.AdventureWorks.LTS;
 using OpenRiaServices.DomainServices.LinqToSql;
 using TestDomainServices.Saleテ;
 using System.Threading.Tasks;
+using System.Threading;
 
 [assembly: ContractNamespace("http://TestNamespace/ForNoClrNamespace")]
 
@@ -122,9 +123,9 @@ namespace TestDomainServices
     {
         private static Cities.CityData s_cities = new Cities.CityData();
 
-        protected override int Count<T>(IQueryable<T> query)
+        protected override ValueTask<int> CountAsync<T>(IQueryable<T> query, CancellationToken cancellationToken)
         {
-            return query.Count();
+            return new ValueTask<int>(query.Count());
         }
 
         public IEnumerable<Cities.City> GetCities()
@@ -936,7 +937,7 @@ namespace TestDomainServices
 
         private string query = string.Empty;
 
-        public override ValueTask<ServiceQueryResult> QueryAsync(QueryDescription queryDescription)
+        public override ValueTask<ServiceQueryResult> QueryAsync<T>(QueryDescription queryDescription, CancellationToken cancellationToken)
         {
             if (queryDescription.Method.Name == "GetRoundtripQueryEntities" && queryDescription.Query != null)
             {
@@ -944,7 +945,7 @@ namespace TestDomainServices
                 this.query = queryDescription.Query.ToString();
             }
 
-            return base.QueryAsync(queryDescription);
+            return base.QueryAsync<T>(queryDescription, cancellationToken);
         }
 
         public IQueryable<RoundtripQueryEntity> GetRoundtripQueryEntities()
@@ -2079,7 +2080,7 @@ namespace TestDomainServices
             return null;
         }
 
-        protected override Task<bool> PersistChangeSetAsync()
+        protected override ValueTask<bool> PersistChangeSetAsync(CancellationToken cancellationToken)
         {
             // Below is some test code to generate concurrency conflicts based
             // on client input
@@ -2095,7 +2096,7 @@ namespace TestDomainServices
                 }
             }
 
-            return base.PersistChangeSetAsync();
+            return base.PersistChangeSetAsync(cancellationToken);
         }
     }
 

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/MockDomainServices.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/MockDomainServices.cs
@@ -2079,7 +2079,7 @@ namespace TestDomainServices
             return null;
         }
 
-        protected override bool PersistChangeSet()
+        protected override Task<bool> PersistChangeSetAsync()
         {
             // Below is some test code to generate concurrency conflicts based
             // on client input
@@ -2095,7 +2095,7 @@ namespace TestDomainServices
                 }
             }
 
-            return base.PersistChangeSet();
+            return base.PersistChangeSetAsync();
         }
     }
 

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/MockDomainServices.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/MockDomainServices.cs
@@ -17,6 +17,7 @@ using DataModels.ScenarioModels;
 using DataTests.AdventureWorks.LTS;
 using OpenRiaServices.DomainServices.LinqToSql;
 using TestDomainServices.Saleテ;
+using System.Threading.Tasks;
 
 [assembly: ContractNamespace("http://TestNamespace/ForNoClrNamespace")]
 
@@ -935,15 +936,15 @@ namespace TestDomainServices
 
         private string query = string.Empty;
 
-        public override System.Collections.IEnumerable Query(QueryDescription queryDescription, out IEnumerable<ValidationResult> validationErrors, out int totalCount)
+        public override ValueTask<ServiceQueryResult> QueryAsync(QueryDescription queryDescription)
         {
             if (queryDescription.Method.Name == "GetRoundtripQueryEntities" && queryDescription.Query != null)
-            {   
+            {
                 // This test query is used to test server query deserialization through the entire pipeline.
                 this.query = queryDescription.Query.ToString();
             }
 
-            return base.Query(queryDescription, out validationErrors, out totalCount);
+            return base.QueryAsync(queryDescription);
         }
 
         public IQueryable<RoundtripQueryEntity> GetRoundtripQueryEntities()

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Net;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
 #if !SILVERLIGHT
 using System.Web;
 #endif
@@ -12,6 +13,7 @@ using System.Web;
 namespace OpenRiaServices.DomainServices.Client.Test
 {
     public delegate void GenericDelegate();
+    public delegate Task AsyncDelegate();
 
     [DebuggerStepThrough]
     [System.Security.SecuritySafeCritical]  // Because our assembly is [APTCA] and we are used from partial trust tests
@@ -80,6 +82,50 @@ namespace OpenRiaServices.DomainServices.Client.Test
         {
             return ExpectException<TException>(del, false);
         }
+
+
+#if !SILVERLIGHT
+        private static Task ExecuteDelegate(AsyncDelegate asyncDelegate)
+        {
+            try
+            {
+                return asyncDelegate();
+            }
+            catch (Exception ex)
+            {
+                var tcs = new TaskCompletionSource<int>();
+                tcs.SetException(ex);
+                return tcs.Task;
+            }
+        }
+
+        public static Task<TException> ExpectException<TException>(AsyncDelegate asyncDel) where TException : Exception
+        {
+            return ExecuteDelegate(asyncDel)
+                .ContinueWith(res =>
+                {
+                    return ExpectException<TException>(() => res.GetAwaiter().GetResult(), false);
+                });
+        }
+
+        public static Task<TException> ExpectException<TException>(AsyncDelegate del, string exceptionMessage)
+                                                       where TException : Exception
+        {
+            var task = ExpectException<TException>(del);
+            // Only check exception message on English build and OS, since some exception messages come from the OS
+            // and will be in the native language.
+            if (UnitTestHelper.EnglishBuildAndOS)
+            {
+                task = task.ContinueWith(res =>
+                {
+                    var ex = res.GetAwaiter().GetResult();
+                    Assert.AreEqual(exceptionMessage, ex.Message, "Incorrect exception message.");
+                    return ex;
+                });
+            }
+            return task;
+        }
+#endif
 
         public static TException ExpectException<TException>(GenericDelegate del, bool allowDerivedExceptions)
             where TException : Exception

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
@@ -85,7 +85,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
 
 
 #if !SILVERLIGHT
-        private static Task ExecuteDelegate(AsyncDelegate asyncDelegate)
+        private static Task ExecuteDelegateAsync(AsyncDelegate asyncDelegate)
         {
             try
             {
@@ -99,19 +99,19 @@ namespace OpenRiaServices.DomainServices.Client.Test
             }
         }
 
-        public static Task<TException> ExpectException<TException>(AsyncDelegate asyncDel) where TException : Exception
+        public static Task<TException> ExpectExceptionAsync<TException>(AsyncDelegate asyncDel) where TException : Exception
         {
-            return ExecuteDelegate(asyncDel)
+            return ExecuteDelegateAsync(asyncDel)
                 .ContinueWith(res =>
                 {
                     return ExpectException<TException>(() => res.GetAwaiter().GetResult(), false);
                 });
         }
 
-        public static Task<TException> ExpectException<TException>(AsyncDelegate del, string exceptionMessage)
+        public static Task<TException> ExpectExceptionAsync<TException>(AsyncDelegate del, string exceptionMessage)
                                                        where TException : Exception
         {
-            var task = ExpectException<TException>(del);
+            var task = ExpectExceptionAsync<TException>(del);
             // Only check exception message on English build and OS, since some exception messages come from the OS
             // and will be in the native language.
             if (UnitTestHelper.EnglishBuildAndOS)


### PR DESCRIPTION
The goal is to make the Server part truly async in order to have it *scale better while using fewer threads* and to prepare it for working well when running on aspnetcore (in any form).

- [x] Make query async
- [x] Make Invoke async
- [x] Make submit async
- [x] Support returning ValueTask<..> (for invoke & queries)?
Is it a good idea even (due to reflection boxing it seems like there are no gains)
- [ ] Need to add corresponding tests for ValueTask<..> methods before officially supporting them
- [x] Go through tests and ensure they await the result on query/invoke etc

- [ ] Consider adding new Exception `DomainServiceValidationException` which takes IEnumerable<ValidationErrror>`
- [x] Add `CancellationToken` to async methods (usable by asp.net core …)

questions to look into
* detect and prevent async query returning total item count via out parameter ? (it can be easy to get it wrong and assign value after await)
* should validataion & authorisation be moved out from invoke/query/submit so it works more similar to aspnetcore filters (future thinking)
* Should CancellationToken be passed by parameter to all async method should they in some/all cases use CancellationToken DomainServiceContext

Other changes
* Query method is now generic so as to not require much reflection
* User identity on DomainServiceContext now works across "await" points in the code
* User identity is now taken from OperationContext (WCF) if three is no HttpContext.Current availible

**Performance** under load of simple DomainService ìn Benhmarks repo which has a query with `Task:Delay(10 ms)` and then returns a single `City` entity has increased significantly under load (tested on laptop with cooldown time  between). Notice that it is burst performance which ismeasured and not steady state (it takes a while before the sync version has created enought threads to process the load). 

![sync_async_perf_1_city_5ms_delay](https://user-images.githubusercontent.com/3167509/64016162-8b6ec900-cb26-11e9-8e40-9ac68004e37f.jpg)

Left is master , right is this PR

Running on a workstation with low turbo boost and 10ms delay for each request gives the following numbers (but examples run at 0-2% CPU and is **limited by the load testing applications**):

![getcities_delay_1_asyncleft_sync_right](https://user-images.githubusercontent.com/3167509/63653794-c2815b00-c771-11e9-8804-8211489f2c49.png)
Left is async (PR), left is master
Notice how max latency is much better for the async code


