### PR TITLE
Add additional logging to SimpleUpdate test and fix SyncContext leak

### DIFF
--- a/OpenRiaServices.DomainServices.Client/Test/Desktop/ApplicationServices/AuthenticationServiceTest.cs
+++ b/OpenRiaServices.DomainServices.Client/Test/Desktop/ApplicationServices/AuthenticationServiceTest.cs
@@ -433,12 +433,21 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices.UnitTests
         // PropertyChanged/RaisePropertyChanged/OnPropertyChanged
 
 #if !SILVERLIGHT
+        SynchronizationContext _origSyncContext;
+
         [TestInitialize]
         public void TestInitialize()
         {
+            _origSyncContext = SynchronizationContext.Current;
             // Make sure all callbacks for async cancellation happens directly
             // Otherwise we have race conditions for tests with cancel directly after invoke
             SynchronizationContext.SetSynchronizationContext(new TestSynchronizationContext());
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            SynchronizationContext.SetSynchronizationContext(_origSyncContext);
         }
 #endif
 


### PR DESCRIPTION
* Fix AuthenticationService tests so that they should no longer change SyncronizationContext for other tests
* Add additional logging on failure for SimpleUpdate test since it often fails when running all tests, but not when running alone