### PR TITLE
Have client test start webserver if it is not already running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ $RECYCLE.BIN/
 # Mac crap
 .DS_Store
 /VisualStudio/Tools/Test/DomainServiceToolsPath.txt
+/OpenRiaServices.DomainServices.Client/Test/Desktop/ClientTestProjectPath.txt

--- a/OpenRiaServices.DomainServices.Client/Test/Desktop/Data/UpdateTests.cs
+++ b/OpenRiaServices.DomainServices.Client/Test/Desktop/Data/UpdateTests.cs
@@ -37,7 +37,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
 
         }
 
-        protected static TestDatabase TestDatabase
+        public static TestDatabase TestDatabase
         {
             get
             {
@@ -3795,14 +3795,6 @@ TestContext testContext
             // ensure that our isolation DB has been created once and only once
             // at the test fixture level
             TestDatabase.Initialize();
-        }
-
-        [AssemblyCleanup]
-        public static void AssemblyCleanup()
-        {
-            // make sure our test database is removed on the server after all unit tests
-            // have been run
-            ((IDisposable)TestDatabase).Dispose();
         }
 
         /// <summary>

--- a/OpenRiaServices.DomainServices.Client/Test/Desktop/OpenRiaServices.DomainServices.Client.Test.csproj
+++ b/OpenRiaServices.DomainServices.Client/Test/Desktop/OpenRiaServices.DomainServices.Client.Test.csproj
@@ -17,6 +17,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data.Linq" />
+    <Reference Include="System.Management" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />
     <Reference Include="WindowsBase" />
@@ -132,20 +133,24 @@
     <None Include="Service References\Services\TestServices.xsd" />
     <None Include="Service References\Services\TestServices1.wsdl" />
     <None Include="Service References\Services\TestServices1.xsd" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Service References\Services\TestServices.disco" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Service References\Services\configuration91.svcinfo" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Service References\Services\configuration.svcinfo" />
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Service References\Services\Reference.svcmap">
       <Generator>WCF Proxy Generator</Generator>
       <LastGenOutput>Reference.cs</LastGenOutput>
     </None>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'!='sl5'">
+    <Content Include="ClientTestProjectPath.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
+    <Message Text="Writing project path" />
+    <WriteLinesToFile File="ClientTestProjectPath.txt" Lines="$(MSBuildProjectDirectory)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+  </Target>
+
 </Project>

--- a/OpenRiaServices.DomainServices.Client/Test/Desktop/Platforms/net45/Main.cs
+++ b/OpenRiaServices.DomainServices.Client/Test/Desktop/Platforms/net45/Main.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Management;
 using System.Net;
 using System.Text;
 using System.Threading;
@@ -11,6 +14,8 @@ namespace OpenRiaServices.DomainServices.Client.Test
     [TestClass()]
     public sealed class Main
     {
+        private static Process s_iisProcess = null;
+
         [AssemblyInitialize()]
         public static void AssemblyInit(TestContext context)
         {
@@ -18,12 +23,119 @@ namespace OpenRiaServices.DomainServices.Client.Test
                 = Thread.CurrentThread.CurrentCulture
                     = new System.Globalization.CultureInfo("en-US");
 
+            StartWebServer();
+
             DomainContext.DomainClientFactory = new Web.WebDomainClientFactory()
             {
                 ServerBaseUri = TestURIs.RootURI,
             };
 
             HttpWebRequest.DefaultCachePolicy = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.Default);
+        }
+
+        [AssemblyCleanup]
+        public static void AssemblyCleanup()
+        {
+            // make sure our test database is removed on the server after all unit tests
+            // have been run
+            ((IDisposable)UpdateTests.TestDatabase).Dispose();
+
+            StopWebserver();
+        }
+
+        private static string GetCommandLine(Process processs)
+        {
+            ManagementObjectSearcher commandLineSearcher = new ManagementObjectSearcher(
+                $"SELECT CommandLine FROM Win32_Process WHERE ProcessId = {processs.Id}");
+            foreach (ManagementObject commandLineObject in commandLineSearcher.Get())
+            {
+                return commandLineObject["CommandLine"]?.ToString() ?? string.Empty;
+            }
+
+            return string.Empty;
+        }
+
+
+        private static bool IsWebServerRunning(string commandlineArguments)
+        {
+            foreach(var process in Process.GetProcessesByName("iisexpress"))
+            {
+                var commandline = GetCommandLine(process);
+                if (commandline.Contains(commandlineArguments))
+                    return true;
+            }
+            return false;
+        }
+
+        private static void StartWebServer()
+        {
+            string projectPath = File.ReadAllLines("ClientTestProjectPath.txt")[0];
+            string webSitePath = Path.GetFullPath(Path.Combine(projectPath, @"..\..\..\Test\WebsiteFullTrust"));
+
+            if (!Directory.Exists(webSitePath))
+                throw new FileNotFoundException($"Website not found at {webSitePath}");
+
+            string iisexpress = System.Environment.ExpandEnvironmentVariables(@"%programfiles%\IIS Express\iisexpress.exe");
+
+            string portNumberText = "60002";
+            string arguments = $"/port:{portNumberText} /path:\"{webSitePath}\"";
+
+            // only start webserver if it is not already running
+            if (!IsWebServerRunning(arguments))
+            {
+                var startInfo = new ProcessStartInfo();
+                startInfo.FileName = iisexpress;
+                startInfo.Arguments = arguments;
+                startInfo.RedirectStandardInput = true;
+                startInfo.RedirectStandardOutput = true;
+                startInfo.UseShellExecute = false;
+                startInfo.CreateNoWindow = true;
+
+                s_iisProcess = Process.Start(startInfo);
+
+                // Wait for IIS start
+                string str;
+                while ((str = s_iisProcess.StandardOutput.ReadLine()) != null)
+                {
+                    if (str.Contains("IIS Express is running")
+                        || str.Contains("'Q'"))
+                        return;
+                }
+
+                throw new Exception("Failed to start IIS express");
+            }
+        }
+
+        /// <summary>Performs cleanup and ensures that there are no active web servers.</summary>
+        public static void StopWebserver()
+        {
+            if (s_iisProcess != null)
+            {
+                // The local web server does not respond to CloseMainWindow.
+                Trace.WriteLine("Closing web server process...");
+
+                if (!s_iisProcess.HasExited)
+                {
+                    try
+                    {
+                        s_iisProcess.StandardInput.WriteLine("Q");
+                        s_iisProcess.WaitForExit(1 * 1000); // wait 1 secs.
+
+                        if (!s_iisProcess.HasExited)
+                        {
+                            s_iisProcess.Kill();
+                            s_iisProcess.WaitForExit(60 * 1000); // wait 60 secs.
+                        }
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        Trace.WriteLine("Unable to kill local web server process.");
+                    }
+                }
+
+                s_iisProcess.Dispose();
+                s_iisProcess = null;
+            }
         }
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,16 +78,7 @@ steps:
    
    .\Setup-TestDatabases.ps1
    
-   $port = 60002
-   $iisExpressExe = "c:\Program Files (x86)\IIS Express\iisexpress.exe"
-   $path = (Resolve-path "Test\WebsiteFullTrust")
-   Write-Host $path
-   Write-host "Starting site on port: $port"
-   $params = "/port:$port /path:$path"
-   $command = """$iisExpressExe"" $params"
-   cmd /c start cmd /k "$command"
- 
-  displayName: 'Setup database and Start test webserver'
+  displayName: 'Setup database'
 
 - task: VSTest@2
   displayName: 'Run tests'


### PR DESCRIPTION
This should solve issues with hosted VS2019 image has started to hang on webserver start