### PR TITLE
Cache ChannelFactories

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,16 +28,16 @@ For better scalability (can be done afterwards):
 
 ## Client
 
-Most of the changes are **Brekaing changes**, even if many of them will only require changes in a small percentage of applicaitons.
+Most of the changes are **Brekaing changes**, even if many of them will only require changes in a small percentage of applications.
 
 1  Change DomainClient contract to Task based async methods (#153)
     * Performing multiple loads and waiting for the result is now faster
 	* Any custom DomainClient or code which interact with DomainClient will no longer compile.	
 2. Remove old target frameworks
-* Remove netstandard13 (#160)
-* Remove portable class library TargetFramework (#164)
-* Remove Silverlight (#174, #175 and more commits)
-* .Net Framework 4.5 requirement is replaced by 4.6 (will be 4.6.1+)
+  * Remove netstandard13 (#160)
+  * Remove portable class library TargetFramework (#164)
+  * Remove Silverlight (#174, #175 and more commits)
+  * .Net Framework 4.5 requirement is replaced by 4.6 (will be 4.6.1+)
 3. Move *EntityList* and *QueryBuilder* from OpenRiaServices...Data namespace to OpenRiaServices...Client namespace (#182)
 4. Dont allocate PropertyChangedEventArgs if not needed (#155)   
     * remove sevaral *OnPropertyChanged* methods and only keep RaisePropertyChanged
@@ -48,7 +48,12 @@ Most of the changes are **Brekaing changes**, even if many of them will only req
 7. Make WebDomainClient non sealed (#166) *non breaking*
    Make CallServiceOperation virtual so that the invoke behaviour can be modified in derived classes.
    This should simplify adding bearer based authentication
-8. Change from IEnumerable to IReadOnlyCollection in a few places (#183)
+8. Cache WCF ChannelFactories per DomainContext type for improved perf (#184)
+  * This significantly improves the performance for the first network operation per DominContext insteance.
+    The cost is only paid on the first access per DomainService *type* (not per instance).
+	Performance of overhead for E2E benchmark of loading some simple entity from a simple DomainService went from 200% to <10% 
+	(so the speedup for creating a new instance of this specific DomainContext is above 20 times) and will improve with more complex services.
+ 9. Change from IEnumerable to IReadOnlyCollection in a few places (#183)
   * Mostly *ValidationErrors* properties and for IEntityCollection
 
 *Behaviour changes*

--- a/Setup-TestDatabases.ps1
+++ b/Setup-TestDatabases.ps1
@@ -73,6 +73,9 @@ GO
 
 DBCC SHRINKDATABASE('$databaseName');
 GO
+
+ALTER DATABASE [$databaseName] SET READ_ONLY;
+go
 "@;
     Execute-SQL $SqlCommand
 }

--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WcfDomainClientFactory.cs
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WcfDomainClientFactory.cs
@@ -236,14 +236,14 @@ namespace OpenRiaServices.DomainServices.Client.Web
         /// </summary>
         private struct ChannelFactoryKey : IEquatable<ChannelFactoryKey>
         {
+            private readonly Uri _uri;
+            private readonly Type _contractType;
+
             public ChannelFactoryKey(Type contract, Uri serviceUri)
             {
                 _contractType = contract;
                 _uri = serviceUri;
             }
-
-            private Uri _uri;
-            private Type _contractType;
 
             public override bool Equals(object obj)
             {

--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WcfDomainClientFactory.cs
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WcfDomainClientFactory.cs
@@ -114,7 +114,7 @@ namespace OpenRiaServices.DomainServices.Client.Web
             where TContract : class
         {
             ChannelFactory<TContract> channelFactory;
-            ChannelFactoryKey key = new ChannelFactoryKey(typeof(TContract), endpoint);
+            ChannelFactoryKey key = new ChannelFactoryKey(typeof(TContract), endpoint, requiresSecureEndpoint);
 
             lock (_channelFactoryCacheLock)
             {
@@ -237,12 +237,14 @@ namespace OpenRiaServices.DomainServices.Client.Web
         private struct ChannelFactoryKey : IEquatable<ChannelFactoryKey>
         {
             private readonly Uri _uri;
+            private readonly bool _requiresSecureEndpoint;
             private readonly Type _contractType;
 
-            public ChannelFactoryKey(Type contract, Uri serviceUri)
+            public ChannelFactoryKey(Type contract, Uri serviceUri, bool requiresSecureEndpoint)
             {
                 _contractType = contract;
                 _uri = serviceUri;
+                _requiresSecureEndpoint = requiresSecureEndpoint;
             }
 
             public override bool Equals(object obj)
@@ -253,12 +255,14 @@ namespace OpenRiaServices.DomainServices.Client.Web
             public bool Equals(ChannelFactoryKey other)
             {
                 return EqualityComparer<Uri>.Default.Equals(_uri, other._uri) &&
+                       _requiresSecureEndpoint == other._requiresSecureEndpoint &&
                        EqualityComparer<Type>.Default.Equals(_contractType, other._contractType);
             }
 
             public override int GetHashCode()
             {
-                int hashCode = EqualityComparer<Uri>.Default.GetHashCode(_uri);
+                var hashCode = EqualityComparer<Uri>.Default.GetHashCode(_uri);
+                hashCode = hashCode * -1521134295 + _requiresSecureEndpoint.GetHashCode();
                 hashCode = hashCode * -1521134295 + EqualityComparer<Type>.Default.GetHashCode(_contractType);
                 return hashCode;
             }

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/InheritanceTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/InheritanceTests.cs
@@ -13,7 +13,7 @@ using OpenRiaServices.Silverlight.Testing;
 using TestDomainServices;
 using TestDomainServices.NamedUpdates;
 
-namespace OpenRiaServices.DomainServices.Client.Data.Test
+namespace OpenRiaServices.DomainServices.Client.Test
 {
     using Resource = SSmDsClient::OpenRiaServices.DomainServices.Client.Resource;
 

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/ReadOnlyObservableLoaderCollectionTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/ReadOnlyObservableLoaderCollectionTests.cs
@@ -6,7 +6,7 @@ using System.Collections.Specialized;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.DomainServices.Client.Data;
 
-namespace OpenRiaServices.DomainServices.Client.Test.Data
+namespace OpenRiaServices.DomainServices.Client.Test
 {
     [TestClass]
     public class ReadOnlyObservableLoaderCollectionTests

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/SharedEntitiesTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/SharedEntitiesTests.cs
@@ -8,7 +8,7 @@ using OpenRiaServices.Silverlight.Testing;
 using SharedEntities;
 using TestDescription = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
 
-namespace OpenRiaServices.DomainServices.Client.Test.Data
+namespace OpenRiaServices.DomainServices.Client.Test
 {
     using Resource = SSmDsClient::OpenRiaServices.DomainServices.Client.Resource;
 

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/TestHelpers.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/TestHelpers.cs
@@ -74,14 +74,14 @@ namespace OpenRiaServices.DomainServices.Client.Test
 
         #region IDisposable Members
 
-        void IDisposable.Dispose()
+        public void Dispose()
         {
             if (isInitialized)
             {
                 TestServicesClient ts = new TestServicesClient();
                 SetAddress(ts);
                 isInitialized = false;
-                ts.ReleaseNewDatabaseAsync(databaseName);
+                ts.ReleaseNewDatabase(databaseName);
             }
         }
         #endregion

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/UpdateTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/UpdateTests.cs
@@ -83,11 +83,6 @@ namespace OpenRiaServices.DomainServices.Client.Test
             return Guid.NewGuid().ToString().Substring(0, 20);
         }
 
-        [TestInitialize]
-        public void TestSetup()
-        {
-        }
-
         [TestMethod]
         [Asynchronous]
         [WorkItem(898909)]
@@ -4390,7 +4385,7 @@ TestContext testContext
             EnqueueConditional(() => so.IsComplete);
             EnqueueCallback(delegate
             {
-                Assert.AreEqual(Resource.DomainContext_SubmitOperationFailed_Conflicts, so.Error.Message);
+                Assert.AreEqual(Resource.DomainContext_SubmitOperationFailed_Conflicts, so.Error?.Message);
                 Entity[] entitiesInConflict = so.EntitiesInError.ToArray();
                 Assert.AreEqual(1, so.ChangeSet.RemovedEntities.Count);
                 Assert.AreEqual(1, entitiesInConflict.Length);
@@ -4517,13 +4512,6 @@ TestContext testContext
             TestDatabase.Initialize();
         }
 
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-            // make sure our test database is removed on the server after all unit tests
-            // have been run
-            ((IDisposable)TestDatabase).Dispose();
-        }
     }
 
     [TestClass]
@@ -4547,14 +4535,6 @@ TestContext testContext
             // ensure that our isolation DB has been created once and only once
             // at the test fixture level
             TestDatabase.Initialize();
-        }
-
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-            // make sure our test database is removed on the server after all unit tests
-            // have been run
-            ((IDisposable)TestDatabase).Dispose();
         }
     }
 

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/UpdateTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/UpdateTests.cs
@@ -3308,7 +3308,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
                     // its resolve method is called. Hence the conflict is resolved successfully the first round. When resubmit
                     // is called, the Product1's conflicts are generated. So client and store values should not be updated 
                     // even for Product0.
-                    Assert.IsNull(products[0].EntityConflict);
+                    Assert.AreEqual(null, products[0].EntityConflict, "Expected no entity conflict on product[0]");
                 }
                 else
                 {

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/UpdateTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/UpdateTests.cs
@@ -2133,7 +2133,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             EnqueueCallback(delegate
             {
                 Product[] products = nw2.Products.ToArray();
-                Assert.AreEqual(origUnitPrice, products[0].UnitPrice);
+                Assert.AreEqual(origUnitPrice, products[0].UnitPrice ?? 0);
                 nw2NewUnitPrice = origUnitPrice + 2;
                 products[0].UnitPrice = nw2NewUnitPrice;
                 newReorderLevel = products[1].ReorderLevel ?? 0;

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/EFCF_Northwind.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/EFCF_Northwind.cs
@@ -506,7 +506,7 @@ namespace TestDomainServices.EFCF
         {
             EFCFNorthwindEntities context = null;
 
-            string connection = ActiveConnections.Get("Northwind");
+            string connection = DBImager.GetNewDatabaseConnectionString("Northwind");
             if (!string.IsNullOrEmpty(connection))
             {
                 // if there is an active connection in scope use it

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/EFDbCtx_Northwind.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/EFDbCtx_Northwind.cs
@@ -516,7 +516,7 @@ namespace TestDomainServices.DbCtx
         {
             DbCtxNorthwindEntities context = null;
 
-            string connection = ActiveConnections.Get("Northwind");
+            string connection = DBImager.GetNewDatabaseConnectionString("Northwind");
             if (!string.IsNullOrEmpty(connection))
             {
                 // if there is an active connection in scope use it

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/EF_Northwind.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/EF_Northwind.cs
@@ -488,7 +488,7 @@ namespace TestDomainServices.EF
         {
             NorthwindEntities context = null;
 
-            string connection = ActiveConnections.Get("Northwind");
+            string connection = DBImager.GetNewDatabaseConnectionString("Northwind");
             if (!string.IsNullOrEmpty(connection))
             {
                 // if there is an active connection in scope use it

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/EF_Northwind_POCO.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/EF_Northwind_POCO.cs
@@ -91,7 +91,7 @@ namespace TestDomainServices.EF
         {
             NorthwindEntities context = null;
 
-            string connection = ActiveConnections.Get("Northwind");
+            string connection = DBImager.GetNewDatabaseConnectionString("Northwind");
             if (!string.IsNullOrEmpty(connection))
             {
                 // if there is an active connection in scope use it

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/LTS_Northwind.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Northwind/LTS_Northwind.cs
@@ -355,7 +355,7 @@ namespace TestDomainServices.LTS
         {
             NorthwindDataContext context = null;
 
-            string connection = ActiveConnections.Get("Northwind");
+            string connection = DBImager.GetNewDatabaseConnectionString("Northwind");
             if (!string.IsNullOrEmpty(connection))
             {
                 // if there is an active connection in scope use it

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
@@ -68,6 +68,10 @@ namespace OpenRiaServices.DomainServices.Client.Test
                         Assert.AreEqual(typeof(TException), ex.GetType());
                     }
                 }
+                else if (ex is AssertFailedException)
+                {
+                    throw;
+                }
                 else
                 {
                     Type tExpected = typeof(TException);

--- a/src/Test/WebsiteFullTrust/Services/TestServices.svc.cs
+++ b/src/Test/WebsiteFullTrust/Services/TestServices.svc.cs
@@ -19,8 +19,7 @@ namespace Website.Services
         [OperationContract]
         public void CreateNewDatabase(string databaseName)
         {
-            string connection = DBImager.CreateNewDatabase(databaseName);
-            ActiveConnections.Set(databaseName, connection);
+            DBImager.CreateNewDatabase(databaseName);
         }
 
         /// <summary>
@@ -31,7 +30,6 @@ namespace Website.Services
         [OperationContract]
         public void ReleaseNewDatabase(string databaseName)
         {
-            ActiveConnections.Set(databaseName, null);
             DBImager.CleanDB(databaseName);
         }
 


### PR DESCRIPTION
* This should significantly improve the time to create DomainContext after the first creation

Left to do
- [x] Investigate test results
- [x] Look into setting SyncContext to null and open the ChannelFactory after initialisation so it does not bind to the UI threads synccontext for callbacks