### PR TITLE
Fix CodeGen error messages about incompatible Target frameworks

### DIFF
--- a/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
+++ b/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
@@ -147,6 +147,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <Name>OpenRiaServices Server Project Link</Name>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>False</Private>
+      <-- Fix error messages about incompatible Target frameworks -->
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <UndefineProperties>TargetFramework</UndefineProperties>
     </ProjectReference>
   </ItemGroup>
 


### PR DESCRIPTION
Fix error messages about incompatible Target frameworks when TargetFramework differs between client and server.

* Use workaround found at https://jaylee.org/archive/2019/01/25/create-a-buildreference-dependency-between-sdk-style-projects.html