### PR TITLE
Improve binary endpoint memory usage

### DIFF
--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
@@ -35,9 +35,7 @@
     <Compile Include="..\..\OpenRiaServices.DomainServices.Hosting\Framework\Services\Behaviors\WebHttpQueryStringConverter.cs">
       <Link>Web\Behaviors\WebHttpQueryStringConverter.cs</Link>
     </Compile>
-    <Compile Include="..\..\OpenRiaServices.DomainServices.Hosting\Framework\Services\MessageEncoders\PoxBinaryMessageEncodingBindingElement.cs">
-      <Link>Data\MessageEncoders\PoxBinaryMessageEncodingBindingElement.cs</Link>
-    </Compile>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Hosting\Framework\Services\MessageEncoders\*.cs" LinkBase="Data\MessageEncoders" />
   </ItemGroup>
 
   <!-- Remove ServiceModel.Web dependent parts (binary endpoint) -->

--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <PackageTags>WCF;RIA;Services;RIAServices;Silverlight;OpenRiaServices</PackageTags>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/OpenRiaServices.DomainServices.Hosting.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/OpenRiaServices.DomainServices.Hosting.csproj
@@ -3,6 +3,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TargetFramework>net46</TargetFramework>
     <DefineConstants>SERVERFX;$(DefineConstants)</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BinaryMessageWriter.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BinaryMessageWriter.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.ServiceModel.Channels;
+using System.Xml;
+
+#if SERVERFX
+namespace OpenRiaServices.DomainServices.Hosting
+#else
+namespace OpenRiaServices.DomainServices.Client
+#endif
+{
+    /// <summary>
+    /// Helper class to cache <see cref="XmlDictionaryWriter"/> and stream in order
+    /// to not have to allocated all memory used for the writer.
+    /// It also adds some estimates of the buffer size needde
+    /// </summary>
+    internal class BinaryMessageWriter
+    {
+        private BufferManagerStream _stream;
+        private XmlDictionaryWriter _writer;
+
+        private const int MaxStreamAllocationSize = 1024 * 1024;
+        // IMPORTANT: If this is changed then EstimateMessageSize should be changed as well
+        private const int MessageLengthHistorySize = 4;
+        private const int InitialBufferSize = 2048;
+        private readonly int[] _lastMessageLengths = new int[MessageLengthHistorySize] { InitialBufferSize, InitialBufferSize, InitialBufferSize, InitialBufferSize };
+        private int _messageLengthIndex = 0;
+
+        // Cache at most one writer per thread
+        [ThreadStatic]
+        private static BinaryMessageWriter s_threadInstance;
+
+        /// <summary>
+        ///  Prevent creation from outside of this class
+        /// </summary>
+        private BinaryMessageWriter()
+        {
+        }
+
+        /// <summary>
+        /// Writes the specified message to a byte array allocated by the specigied <paramref name="bufferManager"/>
+        /// </summary>
+        public static ArraySegment<byte> WriteMessage(Message message, BufferManager bufferManager, int messageOffset)
+        {
+            var messageWriter = s_threadInstance ?? new BinaryMessageWriter();
+            // Reentrancy is not expected, but if the operation throws we dont
+            // want to reuse the current messageWriter since XmlWriter might not be in starting state
+            s_threadInstance = null;
+
+            var result = messageWriter.WriteMessageCore(message, bufferManager, messageOffset);
+
+            // Save for later reuse
+            s_threadInstance = messageWriter;
+            return result;
+        }
+
+        /// <summary>
+        /// Writes the specified message to a byte array allocated by the specigied <paramref name="bufferManager"/>
+        /// </summary>
+        private ArraySegment<byte> WriteMessageCore(Message message, BufferManager bufferManager, int offset)
+        {
+            try
+            {
+                XmlDictionaryWriter writer = GetXmlWriter(bufferManager, offset);
+                message.WriteMessage(writer);
+                writer.Flush();
+
+                var result = _stream.GetArrayAndClear();
+
+                RecordMessageSize(result.Count);
+                return result;
+            }
+            catch
+            {
+                _stream.Clear();
+                throw;
+            }
+        }
+
+        private void RecordMessageSize(int count)
+        {
+            _lastMessageLengths[_messageLengthIndex] = count;
+            _messageLengthIndex = (_messageLengthIndex + 1) % MessageLengthHistorySize;
+        }
+
+        /// <summary>
+        /// Get mazimum buffer size of the last few messages.
+        /// </summary>
+        /// <returns></returns>
+        private int EstimateMessageSize()
+        {
+            int min1 = Math.Min(_lastMessageLengths[3], _lastMessageLengths[2]);
+            int min2 = Math.Min(_lastMessageLengths[1], _lastMessageLengths[0]);
+
+            return Math.Min(min2, min1) + 256;
+        }
+
+        private XmlDictionaryWriter GetXmlWriter(BufferManager bufferManager, int offset)
+        {
+            int startSize = EstimateMessageSize();
+            // Reuse created writer and stream if possible, they are created on first call 
+            if (_writer != null)
+            {
+                _stream.Reset(bufferManager, offset, startSize);
+            }
+            else
+            {
+                _stream = new BufferManagerStream(bufferManager, offset, startSize, MaxStreamAllocationSize);
+                _writer = XmlDictionaryWriter.CreateBinaryWriter(_stream);
+            }
+
+            return _writer;
+        }
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BinaryMessageWriter.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BinaryMessageWriter.cs
@@ -83,15 +83,14 @@ namespace OpenRiaServices.DomainServices.Client
         }
 
         /// <summary>
-        /// Get mazimum buffer size of the last few messages.
+        /// Get estimate based on maximum buffer size of the last few messages.
         /// </summary>
-        /// <returns></returns>
         private int EstimateMessageSize()
         {
-            int min1 = Math.Min(_lastMessageLengths[3], _lastMessageLengths[2]);
-            int min2 = Math.Min(_lastMessageLengths[1], _lastMessageLengths[0]);
+            int min1 = Math.Max(_lastMessageLengths[3], _lastMessageLengths[2]);
+            int min2 = Math.Max(_lastMessageLengths[1], _lastMessageLengths[0]);
 
-            return Math.Min(min2, min1) + 256;
+            return Math.Max(min2, min1) + 256;
         }
 
         private XmlDictionaryWriter GetXmlWriter(BufferManager bufferManager, int offset)

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BinaryMessageWriter.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BinaryMessageWriter.cs
@@ -65,7 +65,6 @@ namespace OpenRiaServices.DomainServices.Client
                 writer.Flush();
 
                 var result = _stream.GetArrayAndClear();
-
                 RecordMessageSize(result.Count);
                 return result;
             }
@@ -87,10 +86,10 @@ namespace OpenRiaServices.DomainServices.Client
         /// </summary>
         private int EstimateMessageSize()
         {
-            int min1 = Math.Max(_lastMessageLengths[3], _lastMessageLengths[2]);
-            int min2 = Math.Max(_lastMessageLengths[1], _lastMessageLengths[0]);
+            int max1 = Math.Max(_lastMessageLengths[3], _lastMessageLengths[2]);
+            int max2 = Math.Max(_lastMessageLengths[1], _lastMessageLengths[0]);
 
-            return Math.Max(min2, min1) + 256;
+            return Math.Max(max2, max1) + 256;
         }
 
         private XmlDictionaryWriter GetXmlWriter(BufferManager bufferManager, int offset)

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BufferManagerStream.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BufferManagerStream.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.ServiceModel.Channels;
-using System.Xml;
 
 #if SERVERFX
 namespace OpenRiaServices.DomainServices.Hosting
@@ -10,7 +9,7 @@ namespace OpenRiaServices.DomainServices.Client
 #endif
 {
     /// <summary>
-    /// Stream optimized for usage by <see cref="XmlDictionaryWriter"/> without unneccessary 
+    /// Stream optimized for usage by <see cref="System.Xml.XmlDictionaryWriter"/> without unneccessary 
     /// allocations on LOH.
     /// It writes directly to memory pooled by a <see cref="BufferManager"/> in order to 
     /// avoid allocations and be able to return memory directly without additional copies 

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BufferManagerStream.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/BufferManagerStream.cs
@@ -1,0 +1,235 @@
+﻿using System;
+using System.IO;
+using System.ServiceModel.Channels;
+using System.Xml;
+
+#if SERVERFX
+namespace OpenRiaServices.DomainServices.Hosting
+#else
+namespace OpenRiaServices.DomainServices.Client
+#endif
+{
+    /// <summary>
+    /// Stream optimized for usage by <see cref="XmlDictionaryWriter"/> without unneccessary 
+    /// allocations on LOH.
+    /// It writes directly to memory pooled by a <see cref="BufferManager"/> in order to 
+    /// avoid allocations and be able to return memory directly without additional copies 
+    /// (for small messages).
+    /// </summary>
+    internal class BufferManagerStream : Stream
+    {
+        private static readonly bool Is64BitProcess = Environment.Is64BitProcess;
+        private BufferManager _bufferManager;
+        private readonly int _maxSize;
+        // The offset into the final byte array where our content should start
+        private int _offset;
+        // number of bytes written to _buffer, used as offset into _buffer where we write next time
+        private int _bufferWritten;
+        // "Current" buffer where the next write should go
+        private byte[] _buffer;
+        // Any "previous" buffers already filled
+        private System.Collections.Generic.List<byte[]> _bufferList;
+        // String "position" (total size so far)
+        private int _position;
+
+
+        public BufferManagerStream(BufferManager bufferManager, int offset, int minAllocationSize, int maxAllocationSize)
+        {
+            _maxSize = maxAllocationSize;
+            Reset(bufferManager, offset, minAllocationSize);
+        }
+
+        public void Reset(BufferManager bufferManager, int offset, int minAllocationSize)
+        {
+            _bufferManager = bufferManager;
+            _offset = offset;
+            _bufferWritten = offset;
+            _position = 0;
+            _buffer = bufferManager.TakeBuffer(minAllocationSize + offset);
+        }
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position { get => _position; set => throw new NotImplementedException(); }
+
+        public override void Flush()
+        {
+            // Nothing to do
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            // Argument validation is skipped since it is only used by 
+            // BinaryXml writer which we trust to always give valid input
+
+            // Note: BinaryXml buffers up to 512 bytesso we should expect most writes to be around 
+            // 500+ bytes (smaller if the next write is a long string or byte array)
+            do
+            {
+                EnsureBufferCapacity();
+
+                // Write up to count bytes, but never more than the rest of the buffer
+                int toCopy = Math.Min(count, _buffer.Length - _bufferWritten);
+                FastCopy(buffer, offset, _buffer, _bufferWritten, toCopy);
+                _position += toCopy;
+                _bufferWritten += toCopy;
+                offset += toCopy;
+                count -= toCopy;
+            } while (count > 0);
+        }
+
+        /// <summary>
+        /// Allocate more space if buffer is full.
+        /// Ensures _buffer is non null and has space to write more bytes
+        /// </summary>
+        private void EnsureBufferCapacity()
+        {
+            // There is space left
+            if (_bufferWritten < _buffer.Length)
+                return;
+
+            // Save current buffer in list before allocating a new buffer
+            if (_bufferList == null)
+                _bufferList = new System.Collections.Generic.List<byte[]>(capacity: 16);
+            _bufferList.Add(_buffer);
+            // Ensure we never return buffer twice in case TakeBuffer below throws
+            _buffer = null;
+
+            int nextSize = Math.Min(_position * 2, _maxSize);
+            _buffer = _bufferManager.TakeBuffer(nextSize);
+            _bufferWritten = 0;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Clear();
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        ///  Returns all mmmory to the current BufferManager
+        /// </summary>
+        public void Clear()
+        {
+            if (_buffer != null)
+            {
+                _bufferManager.ReturnBuffer(_buffer);
+                _buffer = null;
+            }
+
+            if (_bufferList != null)
+            {
+                foreach (var buffer in _bufferList)
+                    _bufferManager.ReturnBuffer(buffer);
+                _bufferList = null;
+            }
+        }
+
+        /// <summary>
+        /// Copies bytes from <paramref name="src"/> to <paramref name="dest"/> using fastes 
+        /// copy based on process bitness (x86 / x64) tested on .Net Framework 4.8
+        /// </summary>
+        private static unsafe void FastCopy(byte[] src, int srcOffset, byte[] dest, int destOffset, int count)
+        {
+            if (count == 0)
+                return;
+
+            if (Is64BitProcess && count <= 1024)
+            {
+                fixed (byte* s = &src[srcOffset], d = &dest[destOffset])
+                    Buffer.MemoryCopy(s, d, dest.Length - destOffset, count);
+            }
+            else
+            {
+                // For x86 it is significantly faster to do copying of int's and longs
+                // or similar in managed code for smaller counts (below 100-200)
+                // But we expect most copies to be larger since xml writer buffer around 500 bytes
+                Buffer.BlockCopy(src, srcOffset, dest, destOffset, count);
+            }
+        }
+
+        public ArraySegment<byte> GetArrayAndClear()
+        {
+            // We only have a single segment, return it directly with no copying
+            if (_bufferList == null)
+            {
+                var buffer = _buffer;
+                _buffer = null;
+
+                System.Diagnostics.Debug.Assert(_bufferWritten == _position + _offset);
+                Clear();
+                return new ArraySegment<byte>(buffer, _offset, _position);
+            }
+            else
+            {
+                // Copy in reverse order from filled to utilize CPU caches better
+                // _buffer might only be partially filled
+                int totalSize = _offset + _position;
+                int destOffset = totalSize - _bufferWritten;
+                byte[] buffer = null;
+
+                try
+                {
+                    // Reuse the "current" buffer if it is large enough
+                    if (_position <= _buffer.Length)
+                    {
+                        buffer = _buffer;
+                        FastCopy(_buffer, 0, buffer, destOffset, _bufferWritten);
+                        _buffer = null;
+                    }
+                    else
+                    {
+                        buffer = _bufferManager.TakeBuffer(totalSize);
+                        FastCopy(_buffer, 0, buffer, destOffset, _bufferWritten);
+                    }
+
+                    // Buffers in list are all full
+                    for (int i = _bufferList.Count - 1; i > 0; --i)
+                    {
+                        destOffset -= _bufferList[i].Length;
+                        FastCopy(_bufferList[i], 0, buffer, destOffset, _bufferList[i].Length);
+                    }
+
+                    // First buffer might have offset
+                    FastCopy(_bufferList[0], _offset, buffer, _offset, _bufferList[0].Length - _offset);
+                    System.Diagnostics.Debug.Assert(destOffset - (_bufferList[0].Length - _offset) == _offset);
+
+                    Clear();
+
+                    return new ArraySegment<byte>(buffer, _offset, _position);
+
+                }
+                catch
+                {
+                    if (buffer != null)
+                        _bufferManager.ReturnBuffer(buffer);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/PoxBinaryMessageEncodingBindingElement.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/PoxBinaryMessageEncodingBindingElement.cs
@@ -16,7 +16,7 @@ namespace OpenRiaServices.DomainServices.Client
     /// <summary>
     /// The binding element that specifies the .NET Binary Format for XML used to encode messages.
     /// </summary>
-    internal class PoxBinaryMessageEncodingBindingElement : MessageEncodingBindingElement
+    internal partial class PoxBinaryMessageEncodingBindingElement : MessageEncodingBindingElement
     {
         private readonly XmlDictionaryReaderQuotas _readerQuotas;
 
@@ -157,7 +157,7 @@ namespace OpenRiaServices.DomainServices.Client
         }
 
         // Message encoder for Binary XML.
-        internal class PoxBinaryMessageEncoder : MessageEncoder
+        internal partial class PoxBinaryMessageEncoder : MessageEncoder
         {
             private const string Fault = "Fault";
             private const string Namespace = "http://schemas.microsoft.com/ws/2005/05/envelope/none";
@@ -238,254 +238,17 @@ namespace OpenRiaServices.DomainServices.Client
             public override ArraySegment<byte> WriteMessage(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)
             {
                 if (message == null)
-                {
                     throw new ArgumentNullException(nameof(message));
-                }
 
                 if (bufferManager == null)
-                {
                     throw new ArgumentNullException(nameof(bufferManager));
-                }
 
                 if (maxMessageSize < 0)
-                {
                     throw new ArgumentOutOfRangeException(nameof(maxMessageSize));
-                }
 
                 this.ThrowIfInvalidMessageVersion(message);
 
-                message.Properties.Encoder = this;
-
-                /// PERF: 
-                /// For further imprioved perf we should look into adopting a similar behaviour as for the 
-                /// in binary encoding which performs *size prediction* 
-                /// https://referencesource.microsoft.com/#System.ServiceModel/System/ServiceModel/Channels/BufferedMessageWriter.cs,ed72c7ce79a15637
-                /// that should allow us to skip memory copies and further improve performance.
-                /// 
-                /// We should be able to pool both the stream and the binary writer togheter with size data
-                using (var stream = new BufferManagerStream(bufferManager, messageOffset, minAllocationSize: 2 * 1024, maxAllocationSize: maxMessageSize))
-                {
-                    using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
-                    {
-                        message.WriteMessage(writer);
-                        writer.Flush();
-
-                        return stream.GetArrayAndDispose();
-                    }
-                }
-            }
-
-            /// <summary>
-            /// Stream optimized for usage by <see cref="XmlBinaryWriter"/> without unneccessary 
-            /// allocations on LOH.
-            /// It writes directly to memory pooled by a <see cref="BufferManager"/> in order to 
-            /// avoid allocations and be able to return memory directly without additional copies 
-            /// (for small messages).
-            /// </summary>
-            internal class BufferManagerStream : Stream
-            {
-                private static readonly bool Is64BitProcess = Environment.Is64BitProcess;
-                private readonly BufferManager _bufferManager;
-                private readonly int _maxSize;
-                // The offset into the final byte array where our content should start
-                private readonly int _offset;
-                // number of bytes written to _buffer, used as offset into _buffer where we write next time
-                private int _bufferWritten;
-                // "Current" buffer where the next write should go
-                private byte[] _buffer;
-                // Any "previous" buffers already filled
-                private System.Collections.Generic.List<byte[]> _bufferList;
-                // String "position" (total size so far)
-                private int _position;
-
-                public BufferManagerStream(BufferManager bufferManager, int offset, int minAllocationSize, int maxAllocationSize)
-                {
-                    _bufferManager = bufferManager;
-                    _offset = offset;
-                    _bufferWritten = offset;
-                    _maxSize = maxAllocationSize;
-                    _buffer = bufferManager.TakeBuffer(minAllocationSize + offset);
-                }
-
-                public override bool CanRead => false;
-
-                public override bool CanSeek => false;
-
-                public override bool CanWrite => true;
-
-                public override long Length => throw new NotImplementedException();
-
-                public override long Position { get => _position; set => throw new NotImplementedException(); }
-
-                public override void Flush()
-                {
-                    // Nothing to do
-                }
-
-                public override int Read(byte[] buffer, int offset, int count)
-                {
-                    throw new NotImplementedException();
-                }
-
-                public override long Seek(long offset, SeekOrigin origin)
-                {
-                    throw new NotImplementedException();
-                }
-
-                public override void SetLength(long value)
-                {
-                    throw new NotImplementedException();
-                }
-
-                public override void Write(byte[] buffer, int offset, int count)
-                {
-                    // Argument validation is skipped since it is only used by 
-                    // BinaryXml writer which we trust to always give valid input
-
-                    // Note: BinaryXml buffers up to 512 bytesso we should expect most writes to be around 
-                    // 500+ bytes (smaller if the next write is a long string or byte array)
-                    do
-                    {
-                        EnsureBufferCapacity();
-
-                        // Write up to count bytes, but never more than the rest of the buffer
-                        int toCopy = Math.Min(count, _buffer.Length - _bufferWritten);
-                        FastCopy(buffer, offset, _buffer, _bufferWritten, toCopy);
-                        _position += toCopy;
-                        _bufferWritten += toCopy;
-                        offset += toCopy;
-                        count -= toCopy;
-                    } while (count > 0);
-                }
-
-                /// <summary>
-                /// Allocate more space if buffer is full.
-                /// Ensures _buffer is non null and has space to write more bytes
-                /// </summary>
-                private void EnsureBufferCapacity()
-                {
-                    // There is space left
-                    if (_bufferWritten < _buffer.Length)
-                        return;
-
-                    // Save current buffer in list before allocating a new buffer
-                    if (_bufferList == null)
-                        _bufferList = new System.Collections.Generic.List<byte[]>(capacity: 16);
-                    _bufferList.Add(_buffer);
-                    // Ensure we never return buffer twice in case TakeBuffer below throws
-                    _buffer = null;
-
-                    int nextSize = Math.Min(_position * 2, _maxSize);
-                    _buffer = _bufferManager.TakeBuffer(nextSize);
-                    _bufferWritten = 0;
-                }
-
-                protected override void Dispose(bool disposing)
-                {
-                    try
-                    {
-                        base.Dispose(disposing);
-                    }
-                    finally
-                    {
-                        if (_buffer != null)
-                        {
-                            _bufferManager.ReturnBuffer(_buffer);
-                            _buffer = null;
-                        }
-
-                        if (_bufferList != null)
-                        {
-                            foreach (var buffer in _bufferList)
-                                _bufferManager.ReturnBuffer(buffer);
-                            _bufferList = null;
-                        }
-                    }
-                }
-
-                /// <summary>
-                /// Copies bytes from <paramref name="src"/> to <paramref name="dest"/> using fastes 
-                /// copy based on process bitness (x86 / x64) tested on .Net Framework 4.8
-                /// </summary>
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                private static unsafe void FastCopy(byte[] src, int srcOffset, byte[] dest, int destOffset, int count)
-                {
-                    if (count == 0)
-                        return;
-
-                    if (Is64BitProcess && count <= 1024)
-                    {
-                        fixed (byte* s = &src[srcOffset], d = &dest[destOffset])
-                            Buffer.MemoryCopy(s, d, dest.Length - destOffset, count);
-                    }
-                    else
-                    {
-                        // For x86 it is significantly faster to do copying of int's and longs
-                        // or similar in managed code for smaller counts (below 100-200)
-                        // But we expect most copies to be larger since xml writer buffer around 500 bytes
-                        Buffer.BlockCopy(src, srcOffset, dest, destOffset, count);
-                    }
-                }
-
-                public ArraySegment<byte> GetArrayAndDispose()
-                {
-                    // We only have a single segment, return it directly with no copying
-                    if (_bufferList == null)
-                    {
-                        var buffer = _buffer;
-                        _buffer = null;
-
-                        System.Diagnostics.Debug.Assert(_bufferWritten == _position + _offset);
-                        Dispose();
-                        return new ArraySegment<byte>(buffer, _offset, _position);
-                    }
-                    else
-                    {
-                        // Copy in reverse order from filled to utilize CPU caches better
-                        // _buffer might only be partially filled
-                        int totalSize = _offset + _position;
-                        int destOffset = totalSize - _bufferWritten;
-                        byte[] buffer = null;
-
-                        try
-                        {
-                            // Reuse the "current" buffer if it is large enough
-                            if (_position <= _buffer.Length)
-                            {
-                                buffer = _buffer;
-                                FastCopy(_buffer, 0, buffer, destOffset, _bufferWritten);
-                                _buffer = null;
-                            }
-                            else
-                            {
-                                buffer = _bufferManager.TakeBuffer(totalSize);
-                                FastCopy(_buffer, 0, buffer, destOffset, _bufferWritten);
-                            }
-
-                            // Buffers in list are all full
-                            for (int i = _bufferList.Count - 1; i > 0; --i)
-                            {
-                                destOffset -= _bufferList[i].Length;
-                                FastCopy(_bufferList[i], 0, buffer, destOffset, _bufferList[i].Length);
-                            }
-
-                            // First buffer might have offset
-                            FastCopy(_bufferList[0], _offset, buffer, _offset, _bufferList[0].Length - _offset);
-                            System.Diagnostics.Debug.Assert(destOffset - (_bufferList[0].Length - _offset) == _offset);
-
-                            Dispose();
-
-                            return new ArraySegment<byte>(buffer, _offset, _position);
-
-                        }
-                        catch
-                        {
-                            if (buffer != null)
-                                _bufferManager.ReturnBuffer(buffer);
-                            throw;
-                        }
-                    }
-                }
+                return BinaryMessageWriter.WriteMessage(message, bufferManager, messageOffset);
             }
 
             public override void WriteMessage(Message message, Stream stream)

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/PoxBinaryMessageEncodingBindingElement.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/Services/MessageEncoders/PoxBinaryMessageEncodingBindingElement.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.Threading;
@@ -16,7 +15,7 @@ namespace OpenRiaServices.DomainServices.Client
     /// <summary>
     /// The binding element that specifies the .NET Binary Format for XML used to encode messages.
     /// </summary>
-    internal partial class PoxBinaryMessageEncodingBindingElement : MessageEncodingBindingElement
+    internal class PoxBinaryMessageEncodingBindingElement : MessageEncodingBindingElement
     {
         private readonly XmlDictionaryReaderQuotas _readerQuotas;
 
@@ -157,7 +156,7 @@ namespace OpenRiaServices.DomainServices.Client
         }
 
         // Message encoder for Binary XML.
-        internal partial class PoxBinaryMessageEncoder : MessageEncoder
+        private class PoxBinaryMessageEncoder : MessageEncoder
         {
             private const string Fault = "Fault";
             private const string Namespace = "http://schemas.microsoft.com/ws/2005/05/envelope/none";

--- a/src/OpenRiaServices.DomainServices.Hosting/Test/Data/BufferManagerStreamTests.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Test/Data/BufferManagerStreamTests.cs
@@ -13,15 +13,15 @@ namespace OpenRiaServices.DomainServices.Hosting.Test.Data
     [TestClass]
     public class BufferManagerStreamTests
     {
-        // Buffer with bytes [0..255]
+        // Buffer with bytes [1..255]
         private readonly byte[] _input;
 
         public BufferManagerStreamTests()
         {
-            _input = new byte[256];
+            _input = new byte[255];
             for (int i = 0; i < _input.Length; ++i)
             {
-                _input[i] = (byte)i;
+                _input[i] = (byte)(i + 1);
             }
         }
 
@@ -34,6 +34,10 @@ namespace OpenRiaServices.DomainServices.Hosting.Test.Data
             SmallWrite(offset: 0);
         }
 
+
+        /// <summary>
+        /// Only partially fill first buffer but start at an offset
+        /// </summary>
         [TestMethod]
         public void SmallWriteWithOffset()
         {
@@ -156,11 +160,13 @@ namespace OpenRiaServices.DomainServices.Hosting.Test.Data
 
             for (int i = 0; i < count; ++i)
             {
-                if (i != buffer.Array[buffer.Offset + i])
+                byte expected = (byte)(i + 1);
+                byte actual = buffer.Array[buffer.Offset + i];
+                if (expected != actual)
                 {
                     Dump(buffer.Array, count);
 
-                    Assert.Fail($"Buffer contents is wrong, expected {i} but buffer[{buffer.Offset} + {i}] = {buffer.Array[buffer.Offset + i]}");
+                    Assert.Fail($"Buffer contents is wrong, expected {expected} but buffer[{buffer.Offset} + {i}] = {actual}");
                 }
             }
         }
@@ -198,8 +204,7 @@ namespace OpenRiaServices.DomainServices.Hosting.Test.Data
 
             public override void ReturnBuffer(byte[] buffer)
             {
-                bool removed = _rented.Remove(buffer);
-                if (!removed)
+                if (!_rented.Remove(buffer))
                 {
                     Assert.Fail("Buffer was not rented (returned twice?");
                 }

--- a/src/OpenRiaServices.DomainServices.Hosting/Test/Data/BufferManagerStreamTests.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Test/Data/BufferManagerStreamTests.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel.Channels;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenRiaServices.DomainServices.Client.Test;
+using BufferManagerStream = OpenRiaServices.DomainServices.Hosting.PoxBinaryMessageEncodingBindingElement.PoxBinaryMessageEncoder.BufferManagerStream;
+
+namespace OpenRiaServices.DomainServices.Hosting.Test.Data
+{
+    [TestClass]
+    public class BufferManagerStreamTests
+    {
+        // Buffer with bytes [0..255]
+        private readonly byte[] _input;
+
+        public BufferManagerStreamTests()
+        {
+            _input = new byte[256];
+            for (int i = 0; i < _input.Length; ++i)
+            {
+                _input[i] = (byte)i;
+            }
+        }
+
+        /// <summary>
+        /// Only partially fill first buffer
+        /// </summary>
+        [TestMethod]
+        public void SingleSmallWrite()
+        {
+            var manager = new BufferManageMock();
+            using (var stream = new BufferManagerStream(manager, 0, 4, 1024))
+            {
+                stream.Write(_input, 0, 2);
+
+                var buffer = VerifyStreamContents(stream, 0, 2, manager);
+                Assert.AreEqual(1, manager.Allocated.Count, "Should only have allocated a single buffer");
+                Assert.AreSame(manager.Allocated[0], buffer.Array, "Should reuse initial array");
+            }
+        }
+
+        /// <summary>
+        /// Only partially fill first buffer
+        /// </summary>
+        [TestMethod]
+        public void FillInitialBuffer()
+        {
+            int initialOffset = 0, minBufferSize = 4;
+            var manager = new BufferManageMock();
+            using (var stream = new BufferManagerStream(manager, initialOffset, minBufferSize, 1024))
+            {
+                stream.Write(_input, 0, minBufferSize);
+                var buffer = VerifyStreamContents(stream, initialOffset, minBufferSize, manager);
+                Assert.AreEqual(1, manager.Allocated.Count, "Should only have allocated a single buffer");
+                Assert.AreSame(manager.Allocated[0], buffer.Array, "Should reuse initial array");
+            }
+        }
+
+        [TestMethod]
+        public void LargeWrite()
+        {
+            int initialOffset = 0;
+            var manager = new BufferManageMock();
+            using (var stream = new BufferManagerStream(manager, initialOffset, 4, 1024))
+            {
+                stream.Write(_input, 0, 40);
+                VerifyStreamContents(stream, initialOffset, 40, manager);
+                Assert.IsTrue(manager.Allocated.Count > 2, "Multiple buffers should have been used");
+            }
+        }
+
+        [TestMethod]
+        public void MultipleWrites()
+        {
+            int initialOffset = 0;
+            var manager = new BufferManageMock();
+            using (var stream = new BufferManagerStream(manager, initialOffset, 4, 1024))
+            {
+                stream.Write(_input, 0, 2); // Write partial buffer
+                stream.Write(_input, 2, 2); // Fill next buffer, next shoul be 4 
+
+                stream.Write(_input, 4, 2);
+                stream.Write(_input, 6, manager.Allocated[1].Length); // Write past buffer into next one
+
+                VerifyStreamContents(stream, initialOffset, 6 + manager.Allocated[1].Length, manager);
+                Assert.IsTrue(manager.Allocated.Count > 2, "Multiple buffers should have been used");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldHandleThrowingAllocationWithoutMemoryLeak()
+        {
+            bool shouldTrow = false;
+            Func<int, int> getBufferSize = size =>
+            {
+                if (shouldTrow) throw new InsufficientMemoryException();
+                else return size;
+            };
+
+            var manager = new BufferManageMock(getBufferSize);
+
+            using (var stream = new BufferManagerStream(manager, 0, 4, 1024))
+            {
+                stream.Write(_input, 0, 2); // Write some into first buffer
+
+                shouldTrow = true;
+                ExceptionHelper.ExpectException<InsufficientMemoryException>(() =>
+                    stream.Write(_input, 2, 10)
+                    );
+            }
+
+            manager.AssertEverythingIsReturned();
+        }
+
+        private ArraySegment<byte> VerifyStreamContents(BufferManagerStream stream, int expectedOffset, int count, BufferManageMock manager)
+        {
+            Assert.AreEqual(count, stream.Position, "Stream position should equal count");
+
+            var buffer = stream.GetArrayAndDispose();
+            VeriryBufferContents(buffer, expectedOffset, count);
+
+            // By returning buffer we also ensure that it was allocated through the buffer manager
+            manager.ReturnBuffer(buffer.Array);
+            manager.AssertEverythingIsReturned();
+            return buffer;
+        }
+
+        private static void VeriryBufferContents(ArraySegment<byte> buffer, int expectedOffset, int count)
+        {
+            Assert.AreEqual(buffer.Offset, expectedOffset, "Wrong offset");
+            Assert.AreEqual(buffer.Count, count, "Wrong count");
+
+            for (int i = 0; i < count; ++i)
+            {
+                if (i != buffer.Array[buffer.Offset + i])
+                {
+                    Dump(buffer.Array, count);
+
+                    Assert.Fail($"Buffer contents is wrong, expected {i} but buffer[{buffer.Offset} + {i}] = {buffer.Array[buffer.Offset + i]}");
+                }
+            }
+        }
+
+        private static void Dump(byte[] buf, int count)
+        {
+            for (int j = 0; j < count; ++j)
+            {
+                Console.Write("{0} ", (int)buf[j]);
+            }
+            Console.WriteLine();
+        }
+
+        sealed class BufferManageMock : BufferManager
+        {
+            private readonly HashSet<byte[]> _rented = new HashSet<byte[]>();
+            private readonly List<byte[]> _allocated = new List<byte[]>();
+            private readonly Func<int, int> _getBufferSize;
+
+            public IReadOnlyCollection<byte[]> Rented => _rented;
+            public IReadOnlyList<byte[]> Allocated => _allocated;
+
+            public BufferManageMock(Func<int, int> getBufferSize = null)
+            {
+                _getBufferSize = getBufferSize ?? ((int i) => i);
+            }
+
+            public override void Clear()
+            {
+                if (_rented.Count > 0)
+                    throw new InvalidOperationException();
+                _rented.Clear();
+                _allocated.Clear();
+            }
+
+            public override void ReturnBuffer(byte[] buffer)
+            {
+                bool removed = _rented.Remove(buffer);
+                if (!removed)
+                {
+                    Assert.Fail("Buffer was not rented (returned twice?");
+                }
+            }
+
+            public override byte[] TakeBuffer(int bufferSize)
+            {
+                var buff = new byte[_getBufferSize(bufferSize)];
+                _rented.Add(buff);
+                _allocated.Add(buff);
+                return buff;
+            }
+
+            public void AssertEverythingIsReturned()
+            {
+                Assert.AreEqual(0, _rented.Count, "Not all buffers were returned");
+            }
+        }
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Hosting/Test/Data/BufferManagerStreamTests.cs
+++ b/src/OpenRiaServices.DomainServices.Hosting/Test/Data/BufferManagerStreamTests.cs
@@ -29,14 +29,25 @@ namespace OpenRiaServices.DomainServices.Hosting.Test.Data
         /// Only partially fill first buffer
         /// </summary>
         [TestMethod]
-        public void SingleSmallWrite()
+        public void SmallWrite()
+        {
+            SmallWrite(offset: 0);
+        }
+
+        [TestMethod]
+        public void SmallWriteWithOffset()
+        {
+            SmallWrite(offset: 6);
+        }
+
+        public void SmallWrite(int offset)
         {
             var manager = new BufferManageMock();
-            using (var stream = new BufferManagerStream(manager, 0, 4, 1024))
+            using (var stream = new BufferManagerStream(manager, offset, 4, 1024))
             {
                 stream.Write(_input, 0, 2);
 
-                var buffer = VerifyStreamContents(stream, 0, 2, manager);
+                var buffer = VerifyStreamContents(stream, offset, 2, manager);
                 Assert.AreEqual(1, manager.Allocated.Count, "Should only have allocated a single buffer");
                 Assert.AreSame(manager.Allocated[0], buffer.Array, "Should reuse initial array");
             }
@@ -46,7 +57,7 @@ namespace OpenRiaServices.DomainServices.Hosting.Test.Data
         /// Only partially fill first buffer
         /// </summary>
         [TestMethod]
-        public void FillInitialBuffer()
+        public void SmallWriteFullBuffer()
         {
             int initialOffset = 0, minBufferSize = 4;
             var manager = new BufferManageMock();
@@ -62,12 +73,22 @@ namespace OpenRiaServices.DomainServices.Hosting.Test.Data
         [TestMethod]
         public void LargeWrite()
         {
-            int initialOffset = 0;
+            LargeWrite(offset: 0);
+        }
+
+        [TestMethod]
+        public void LargeWriteWithOffset()
+        {
+            LargeWrite(offset: 5);
+        }
+
+        public void LargeWrite(int offset)
+        {
             var manager = new BufferManageMock();
-            using (var stream = new BufferManagerStream(manager, initialOffset, 4, 1024))
+            using (var stream = new BufferManagerStream(manager, offset, 4, 1024))
             {
                 stream.Write(_input, 0, 40);
-                VerifyStreamContents(stream, initialOffset, 40, manager);
+                VerifyStreamContents(stream, offset, 40, manager);
                 Assert.IsTrue(manager.Allocated.Count > 2, "Multiple buffers should have been used");
             }
         }


### PR DESCRIPTION
Use the BufferManager to use pooled memory when serializing messages.
This should be able to drastically reduce memory usage compared to the MemoryStream.
And for larger messages the pressure on the LOH and Gen2 GCs should se improvements.

Fixes #177 

- [x] Add MemoryStream replacement
- [x] Stress test
- [x] Benchmark
- [x] Unit tests (Write based on current "draft" and maybe add some more)



## Benchmarks

### Before

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i5-8250U CPU 1.60GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]    : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.8.3815.0
  MediumRun : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.8.3815.0

Job=MediumRun  IterationCount=15  LaunchCount=2  
WarmupCount=10  

```
|                  Method | NumEntities | DomainClient |      Mean |     Error |    StdDev |     Median |    Gen 0 |    Gen 1 |   Gen 2 |  Allocated |
|------------------------ |------------ |------------- |----------:|----------:|----------:|-----------:|---------:|---------:|--------:|-----------:|
| **GetCititesUniqueContext** |          **10** |    **WcfBinary** |  **1.453 ms** | **0.4366 ms** | **0.6535 ms** |  **0.9640 ms** |  **21.4844** |        **-** |       **-** |   **71.38 KB** |
|  GetCititesReuseContext |          10 |    WcfBinary |  1.124 ms | 0.3025 ms | 0.4527 ms |  0.9710 ms |  19.5313 |        - |       - |   62.57 KB |
| **GetCititesUniqueContext** |         **100** |    **WcfBinary** |  **1.933 ms** | **0.4316 ms** | **0.6190 ms** |  **1.6856 ms** |  **48.8281** |  **15.6250** |       **-** |   **191.3 KB** |
|  GetCititesReuseContext |         100 |    WcfBinary |  2.406 ms | 0.5691 ms | 0.8519 ms |  1.9335 ms |  46.8750 |   9.7656 |       - |  163.89 KB |
| **GetCititesUniqueContext** |        **1000** |    **WcfBinary** | **11.147 ms** | **1.9772 ms** | **2.8981 ms** | **12.3418 ms** | **367.1875** | **195.3125** | **39.0625** |  **1318.2 KB** |
|  GetCititesReuseContext |        1000 |    WcfBinary |  7.322 ms | 1.8208 ms | 2.6690 ms |  5.6060 ms | 273.4375 | 117.1875 | 39.0625 | 1049.08 KB |


### Final with BinaryWriter

``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i5-8250U CPU 1.60GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.8.4018.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.8.4018.0


```
|                  Method | NumEntities | DomainClient |       Mean |       Error |      StdDev |    Gen 0 |    Gen 1 | Gen 2 |  Allocated |
|------------------------ |------------ |------------- |-----------:|------------:|------------:|---------:|---------:|------:|-----------:|
| **GetCititesUniqueContext** |          **10** |    **WcfBinary** |   **876.0 us** |    **16.72 us** |    **19.26 us** |  **20.5078** |   **0.9766** |     **-** |   **65.01 KB** |
|  GetCititesReuseContext |          10 |    WcfBinary |   848.6 us |    16.74 us |    38.79 us |  15.6250 |        - |     - |   56.12 KB |
| **GetCititesUniqueContext** |         **100** |    **WcfBinary** | **1,559.3 us** |    **29.18 us** |    **31.23 us** |  **42.9688** |  **11.7188** |     **-** |  **165.75 KB** |
|  GetCititesReuseContext |         100 |    WcfBinary | 1,444.0 us |    28.37 us |    45.00 us |  37.1094 |   5.8594 |     - |  124.98 KB |
| **GetCititesUniqueContext** |        **1000** |    **WcfBinary** | **6,169.1 us** | **1,339.30 us** | **1,187.25 us** | **343.7500** | **171.8750** |     **-** | **1063.03 KB** |
|  GetCititesReuseContext |        1000 |    WcfBinary | 5,357.5 us |   794.58 us |   704.37 us | 218.7500 |  93.7500 |     - |  793.62 KB |


### Only buffermanager stream

These benchmarks are 
``` ini

BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i5-8250U CPU 1.60GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
  [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.8.4010.0
  DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.8.4010.0


```
|                  Method | NumEntities | DomainClient |       Mean |     Error |       StdDev |     Median |    Gen 0 |    Gen 1 | Gen 2 |  Allocated |
|------------------------ |------------ |------------- |-----------:|----------:|-------------:|-----------:|---------:|---------:|------:|-----------:|
| **GetCititesUniqueContext** |          **10** |    **WcfBinary** |   **935.1 us** |  **18.51 us** |    **37.802 us** |   **930.9 us** |  **21.4844** |   **0.9766** |     **-** |   **67.74 KB** |
|  GetCititesReuseContext |          10 |    WcfBinary |   866.5 us |  17.19 us |    39.843 us |   859.4 us |  18.5547 |        - |     - |   58.85 KB |
| **GetCititesUniqueContext** |         **100** |    **WcfBinary** | **1,640.7 us** |  **10.18 us** |     **9.518 us** | **1,640.3 us** |  **42.9688** |  **13.6719** |     **-** |  **168.43 KB** |
|  GetCititesReuseContext |         100 |    WcfBinary | 1,584.1 us | 145.51 us |   199.172 us | 1,545.4 us |  39.0625 |   7.8125 |     - |  136.03 KB |
| **GetCititesUniqueContext** |        **1000** |    **WcfBinary** | **8,554.4 us** | **966.66 us** | **2,850.210 us** | **6,184.7 us** | **343.7500** | **171.8750** |     **-** | **1066.23 KB** |
|  GetCititesReuseContext |        1000 |    WcfBinary | 7,328.3 us | 839.02 us | 2,473.874 us | 5,249.5 us | 234.3750 | 101.5625 |     - |  797.26 KB |
