### PR TITLE
Enable code gen to work for netstandard and netcoreapp clients

### DIFF
--- a/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
+++ b/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
@@ -247,7 +247,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     ================================================================
     -->
   <Target Name="ResolveOpenRiaClientCodeGenInputs" DependsOnTargets="ResolveReferences" Condition="Exists('$(LinkedOpenRiaServerProject)')">
-
+    
     <!-- Gather the build outputs of the server project -->
     <MSBuild   Projects="$(LinkedOpenRiaServerProject)" Targets="GetTargetPath">
       <Output TaskParameter="TargetOutputs" ItemName="OpenRiaClientCodeGenServerBuildOutput" />
@@ -272,6 +272,14 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <OpenRiaClientCodeGenClientAssemblySearchPath Include="$(TargetFrameworkDirectory)" />
       <OpenRiaClientCodeGenClientAssemblySearchPath Include="$(TargetFrameworkSDKDirectory)" />
     </ItemGroup>
+
+    <!-- For netstandard use directory of mscorlib to set FrameworkPathOverride to a valid folder-->
+    <ItemGroup Condition="'$(FrameworkPathOverride)' ==''">
+      <_MsCorlibDir Include="%(ReferencePath.FullPath)" Condition=" '%(ReferencePath.Filename)' == 'mscorlib' "/>
+    </ItemGroup>
+    <PropertyGroup Condition="'$(FrameworkPathOverride)' ==''">
+      <FrameworkPathOverride>$([System.IO.Directory]::GetParent(%(_MsCorlibDir.Identity)))</FrameworkPathOverride>    
+    </PropertyGroup>
 
   </Target>
 

--- a/src/OpenRiaServices.DomainServices.Tools/Framework/SharedTypes/SharedAssemblies.cs
+++ b/src/OpenRiaServices.DomainServices.Tools/Framework/SharedTypes/SharedAssemblies.cs
@@ -452,18 +452,31 @@ namespace OpenRiaServices.DomainServices.Tools.SharedTypes
         }
 
         /// <summary>
-        /// Compares <see cref="AssemblyNameReference"/> based on FullName
+        /// Compares <see cref="AssemblyNameReference"/> based on Name and PublicKeyToken
         /// </summary>
         private class AssemblyNameReferenceComparer : IEqualityComparer<AssemblyNameReference>
         {
             public bool Equals(AssemblyNameReference x, AssemblyNameReference y)
             {
-                return x.FullName == y.FullName;
+                if (x.Name == y.Name
+                    && x.PublicKeyToken.Length == y.PublicKeyToken.Length)
+                {
+                    for (int i = 0; i < x.PublicKeyToken.Length; ++i)
+                    {
+                        if (x.PublicKeyToken[i] != y.PublicKeyToken[i])
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+                return false;
             }
 
             public int GetHashCode(AssemblyNameReference obj)
             {
-                return obj.FullName.GetHashCode();
+                return obj.Name.GetHashCode();
             }
         }
     }


### PR DESCRIPTION
Adds a workaround so that code generation will run for clients targeting netstandard or netcoreapp.

Manually tested against netstandard2.0 and netcoreapp2.1

Other possible approaches:
* Dont set it to a valid directory
    * This has the upside of not loading in all assemblies to construct the AssemblyName for them
* Make the ClientFrameworkPath on code generatoin task optional (remove Requried)