### PR TITLE
Fix problems with await in tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,12 +5,14 @@ variables:
   BuildConfiguration: 'release'
   BuildPlatform: 'any cpu'
   Solution: 'src\RiaServices.sln'
+# Define the following variable for the build pipeline in order to enable sonarcloud analysis
+# sonarcloud-endpoint: 'sonarcloud.io'
 
 steps:
 
 - task: NuGetToolInstaller@0
   inputs:
-    versionSpec: 5.0.2
+    versionSpec: 5.3.1
     
 - task: GitVersion@4
   displayName: GitVersion
@@ -68,7 +70,7 @@ steps:
     codeCoverageEnabled: true
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    diagnosticsEnabled: true
+    diagnosticsEnabled: false
   timeoutInMinutes: 25
 
 - task: SonarCloudAnalyze@1

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/OperationAwaiter.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/OperationAwaiter.cs
@@ -40,7 +40,7 @@ namespace OpenRiaServices.DomainServices.Client
                 _operation.Completed += (sender, args) =>
                 {
                     ContextCallback action;
-                    if (syncContext is null || syncContext is Test.TestSynchronizationContext)
+                    if (syncContext is null /*|| syncContext is Test.TestSynchronizationContext*/)
                     {
                         action = (object o) => ((Action)o)();
                     }


### PR DESCRIPTION
* Improve "async/await" implementations for operations by propagating exceptions from callbacks to await point
* disable diagnostics from tests by default

- [ ] consider removing special code for getting AggregateExceptions from callbacks and just throw first one