### PR TITLE
Handle early cancellation in WebDomainClient and use csharp 8.0

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -89,9 +89,9 @@ dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 ############################### 
 [*.cs] 
 # var preferences 
-csharp_style_var_for_built_in_types = false:silent 
-csharp_style_var_when_type_is_apparent = true:silent 
-csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = false:silent
 # Expression-bodied members 
 csharp_style_expression_bodied_methods = false:silent 
 csharp_style_expression_bodied_constructors = false:silent 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,8 +7,8 @@
 
     <DeterministicSourcePaths Condition="'$(BUILD_BUILDID)' != '' and '$(IsFrameworkProject)' == 'true'">true</DeterministicSourcePaths>
 
-    <!-- Use csharp 7.3 for all projects -->
-    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">7.3</LangVersion>
+    <!-- Use csharp 8.0 for all projects -->
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">8.0</LangVersion>
 
     <SonarQubeTestProject Condition="'$(IsTestProject)' == 'true'">True</SonarQubeTestProject>
 

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/DomainContextTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/DomainContextTests.cs
@@ -90,7 +90,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
         public async Task SubmitAsync_Cancel_EmptyChangeset()
         {
             Northwind nw = new Northwind(TestURIs.LTS_Northwind);
-            CancellationTokenSource cts = new CancellationTokenSource();
+            using CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
 
             // This should not throw any error, OperationCancelledException might be acceptable

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/DomainContextTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/DomainContextTests.cs
@@ -347,21 +347,6 @@ namespace OpenRiaServices.DomainServices.Client.Test
             this.LoadOperation = this.CityDomainContext.Load(query, LoadBehavior.RefreshCurrent, callback, userState);
         }
 
-        private Task<LoadResult<City>> BeginLoadCityDataAsync(CancellationToken cts)
-        {
-            var query = this.CityDomainContext.GetCitiesQuery();
-            return this.CityDomainContext.LoadAsync(query, LoadBehavior.RefreshCurrent, cts);
-        }
-
-        private void BeginLoadCityData(Action<LoadOperation<City>> callback, bool assertInProgress)
-        {
-            this.BeginLoadCityData(callback, null);
-            if (assertInProgress)
-            {
-                this.AssertInProgress(this.LoadOperation);
-            }
-        }
-
         private void BeginLoadCityData()
         {
             this.BeginLoadCityData(null, null);
@@ -381,41 +366,14 @@ namespace OpenRiaServices.DomainServices.Client.Test
             this.SubmitOperation = this.CityDomainContext.SubmitChanges(callback, this.CityDomainContext);
         }
 
-        private void BeginSubmitCityData(Action<SubmitOperation> callback, bool assertInProgress)
-        {
-            this.BeginSubmitCityData(callback);
-            if (assertInProgress)
-            {
-                this.AssertInProgress(this.SubmitOperation);
-            }
-        }
-
         private void BeginSubmitCityData()
         {
             this.BeginSubmitCityData(null);
         }
 
-        private void BeginSubmitCityDataAndCancel()
-        {
-            this.BeginSubmitCityData(null);
-            this.SubmitOperation.Cancel();
-        }
-
-        private void AssertLoadCompleted()
-        {
-            Assert.IsNotNull(this.LoadOperation);
-            Assert.IsFalse(this.LoadOperation.IsCanceled);
-            this.AssertOperationCompleted(this.LoadOperation, false);
-        }
-
         private void AssertLoadCancelled()
         {
             this.AssertOperationCompleted(this.LoadOperation, true);
-        }
-
-        private void AssertInProgress(OperationBase operation)
-        {
-            Assert.IsFalse(operation.IsComplete);
         }
 
         private void AssertOperationCompleted(OperationBase operation, bool cancelled)
@@ -425,25 +383,5 @@ namespace OpenRiaServices.DomainServices.Client.Test
         }
 
         #endregion // Test Methods
-    }
-
-    public class MockAsyncResult : IAsyncResult
-    {
-        public object AsyncState
-        {
-            get { throw new NotImplementedException(); }
-        }
-        public WaitHandle AsyncWaitHandle
-        {
-            get { throw new NotImplementedException(); }
-        }
-        public bool CompletedSynchronously
-        {
-            get { throw new NotImplementedException(); }
-        }
-        public bool IsCompleted
-        {
-            get { throw new NotImplementedException(); }
-        }
     }
 }

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/DomainContextWithMockDomainClientTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/DomainContextWithMockDomainClientTests.cs
@@ -111,7 +111,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
 
             // If cancellation results in request beeing cancelled the result should be cancelled
             var tcs = new TaskCompletionSource<InvokeCompletedResult>();
-            var cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
             mockDomainClient.InvokeCompletedResult = tcs.Task;
             var invokeTask = ctx.EchoAsync("TestInvoke", cts.Token);
             cts.Cancel();
@@ -133,7 +133,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             // If the web requires returns a value even if cancelled
             // It should still return a result
             var tcs = new TaskCompletionSource<InvokeCompletedResult>();
-            var cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
             mockDomainClient.InvokeCompletedResult = tcs.Task;
             var invokeTask = ctx.EchoAsync("TestInvoke", cts.Token);
             cts.Cancel();
@@ -280,7 +280,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
 
             // If cancellation results in request beeing cancelled the result should be cancelled
             var tcs = new TaskCompletionSource<QueryCompletedResult>();
-            var cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
             mockDomainClient.QueryCompletedResult = tcs.Task;
             var loadTask = ctx.LoadAsync(ctx.GetCitiesQuery(), cts.Token);
 
@@ -305,7 +305,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
 
             // If cancellation results in request beeing cancelled the result should be cancelled
             var tcs = new TaskCompletionSource<QueryCompletedResult>();
-            var cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
             mockDomainClient.QueryCompletedResult = tcs.Task;
             var loadTask = ctx.LoadAsync(ctx.GetCitiesQuery(), cts.Token);
             cts.Cancel();
@@ -418,7 +418,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
 
             // If cancellation results in request beeing cancelled the result should be cancelled
             var tcs = new TaskCompletionSource<SubmitCompletedResult>();
-            var cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
             mockDomainClient.SubmitCompletedResult = tcs.Task;
 
             ctx.Cities.Add(new City() { Name = "NewCity", StateName = "NN", CountyName = "NewCounty" });
@@ -444,7 +444,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             Cities.CityDomainContext ctx = new Cities.CityDomainContext(mockDomainClient);
 
             // If cancellation results in request beeing cancelled the result should be cancelled
-            var cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
             mockDomainClient.SubmitCompletedCallback = async (changeSet, submitOperations) =>
             {
                 // Wait for cancellation, and then return successfully without cancellation
@@ -452,9 +452,9 @@ namespace OpenRiaServices.DomainServices.Client.Test
                 {
                     await Task.Delay(-1, cts.Token);
                 }
-                catch
+                catch (OperationCanceledException)
                 {
-
+                    // Do nothing this is the expected outcome
                 }
                 // perform mock submit operations
                 SubmitCompletedResult submitResults = new SubmitCompletedResult(changeSet, submitOperations);

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/OperationTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/OperationTests.cs
@@ -76,6 +76,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
     [TestClass]
     public class OperationTests : UnitTestBase
     {
+        [TestMethod]
         public void Operation_MarkAsHandled()
         {
             TestDataContext ctxt = new TestDataContext(new Uri(TestURIs.RootURI, "TestDomainServices-TestCatalog1.svc"));
@@ -104,7 +105,6 @@ namespace OpenRiaServices.DomainServices.Client.Test
             // results in an exception
             lo = new LoadOperation<Product>(query, LoadBehavior.KeepCurrent, null, null, false);
             Assert.IsFalse(lo.HasError);
-            Assert.IsTrue(lo.IsErrorHandled);
             ExceptionHelper.ExpectInvalidOperationException(delegate
             {
                 lo.MarkErrorAsHandled();

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/QueryTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/QueryTests.cs
@@ -1954,7 +1954,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             var query = ctxt.CreateQuery<Product>("ThrowGeneralException", null, false, true);
             await ValidateQueryException(ctxt, query, ValidateGeneralException);
 
-            void ValidateGeneralException(Exception exception)
+            static void ValidateGeneralException(Exception exception)
             {
                 var ex = (DomainOperationException)exception;
                 Assert.IsNotNull(ex);

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/QueryTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/QueryTests.cs
@@ -1340,7 +1340,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
         [TestMethod]
         public async Task TestDomainContext_IsLoadingPropertyChangeNotifications()
         {
-            var propertyChangeCalled = new SemaphoreSlim(0);
+            using var propertyChangeCalled = new SemaphoreSlim(0);
             PropertyChangedEventArgs loadingEventArgs = null;
             PropertyChangedEventArgs loadedEventArgs = null;
             object savedSender = null;
@@ -1374,7 +1374,6 @@ namespace OpenRiaServices.DomainServices.Client.Test
             LoadOperation lo = catalog.Load(catalog.GetProductsQuery(), false);
 
             bool waitSuccess = await propertyChangeCalled.WaitAsync(TimeSpan.FromSeconds(30));
-            propertyChangeCalled.Dispose();
 
             Assert.IsTrue(waitSuccess, "Waited to long for callback to be executed, semaphore note signalled");
 
@@ -1712,7 +1711,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             }
 
             // Wait for loads to complete with a timeout
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
             for (int i = 0; i < numberOfActiveLoadCalls; i++)
             {
                 await waitHandles[i].WaitAsync(cts.Token);
@@ -1730,8 +1729,6 @@ namespace OpenRiaServices.DomainServices.Client.Test
             }
             Assert.AreEqual((numberOfActiveLoadCalls - 1), catalog.Products.Count);
             Assert.AreEqual(1, loadOperations.Where(a => a.IsCanceled).Count());
-
-            cts.Dispose();
         }
 
         [TestMethod]
@@ -1750,7 +1747,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             Assert.AreEqual(0, catalog.Products.Count);
             Assert.IsTrue(lo.IsCanceled, "Operation should've been cancelled.");
 
-            var cts = new CancellationTokenSource();
+            using var cts = new CancellationTokenSource();
             var loadTask = catalog.LoadAsync(query, cts.Token);
             cts.Cancel();
 


### PR DESCRIPTION
add a few "using" in tests to dispose CancellationTokenSources
remove unused methods
som minor code cleanup in DomainContext
Handle early cancellation in WebDomainClient
re enable test missing [TestMethod]