### PR TITLE
Complete Load/Invoke/Submit operation on calling SynchronizationContext

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,7 +25,30 @@
 For better scalability (can be done afterwards):
 
 1. Update your Query and Invoke methods so that they use async/await where relevant.
-  E.g if you are using EF6, other ORM frameworks or do network or file access.   
+  E.g if you are using EF6, other ORM frameworks or do network or file access.
+  
+  
+# 5.0.0 Unreleased
+
+### Client
+
+* Complete Load/Invoke/Submit operation on the ´SynchronizationContext` of the caller instead of saving the SynchronizationContext (#211, #209 for submit)
+  * This is a behavioral change which **might break** applications.
+This means that operations should be started on the UI thread if any data of the DomainContext or returned Operaitons are bound to the UI before completion.
+* Base SubmitChanges on SubmitChangesAsync (#209)
+   * Submit operation will now cancel only if the web request is cancelled (and then *after* cancellation)
+     Update cancellation behavior to be the same as for Load and Invoke (Follow up on #203 and #162)
+   * Changed extension point for SubmitChangesAsync to a new method called by both SubmitChanges and SubmitChangesAsync
+`protected virtual Task<SubmitResult> SubmitChangesAsync(EntityChangeSet changeSet, CancellationToken cancellationToken)`
+   * Changed extension point for InvokeOperationAsync to a new protected method.
+* Base DomainContext.Invoke on DomainContext.InvokeAsync (#203)
+    * Invoke operation will now cancel only if the web request is cancelled (and then *after* cancellation)
+* Ensure Completed event is always called when Load/Invoke/SubmitOperation finishes (#206)
+
+**Bugfix**
+* Handle early cancellation (Cancellation before actual request has been sent) in WebDomainClient (#210)
+  * In earlier previews an exception was thrown instead of the operation beeing Cancelled
+
 
 # 5.0.0 Preview 2
 

--- a/src/OpenRiaServices.DomainServices.Client/Framework/DomainContext.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/DomainContext.cs
@@ -40,7 +40,7 @@ namespace OpenRiaServices.DomainServices.Client
         private readonly object _syncRoot = new object();
         private static IDomainClientFactory s_domainClientFactory;
 
-        private TaskScheduler CurrrentSyncronizationContextTaskScheduler => SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default;
+        private TaskScheduler CurrrentSynchronizationContextTaskScheduler => SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default;
 
         /// <summary>
         /// Protected constructor
@@ -284,7 +284,7 @@ namespace OpenRiaServices.DomainServices.Client
                 , submitOperation
                 , CancellationToken.None
                 , TaskContinuationOptions.HideScheduler
-                , CurrrentSyncronizationContextTaskScheduler);
+                , CurrrentSynchronizationContextTaskScheduler);
 
             return submitOperation;
         }
@@ -527,7 +527,7 @@ namespace OpenRiaServices.DomainServices.Client
                 , (object)loadOperation
                 , CancellationToken.None
                 , TaskContinuationOptions.HideScheduler
-                , CurrrentSyncronizationContextTaskScheduler);
+                , CurrrentSynchronizationContextTaskScheduler);
 
             return loadOperation;
         }
@@ -842,7 +842,7 @@ namespace OpenRiaServices.DomainServices.Client
                 , (object)invokeOperation
                 , CancellationToken.None
                 , TaskContinuationOptions.HideScheduler
-                , CurrrentSyncronizationContextTaskScheduler);
+                , CurrrentSynchronizationContextTaskScheduler);
 
             return invokeOperation;
         }
@@ -986,7 +986,7 @@ namespace OpenRiaServices.DomainServices.Client
             , operationName
             , CancellationToken.None
             , TaskContinuationOptions.NotOnCanceled | TaskContinuationOptions.HideScheduler
-            , CurrrentSyncronizationContextTaskScheduler);
+            , CurrrentSynchronizationContextTaskScheduler);
         }
 
         /// <summary>

--- a/src/OpenRiaServices.DomainServices.Client/Framework/DomainContext.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/DomainContext.cs
@@ -964,20 +964,9 @@ namespace OpenRiaServices.DomainServices.Client
                 {
                     results = task.GetAwaiter().GetResult();
                 }
-                catch (DomainException)
+                catch (Exception ex) when (!(ex is DomainException || ex.IsFatal()))
                 {
-                    // DomainExceptions should not be modified
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    if (ex.IsFatal())
-                    {
-                        throw;
-                    }
-                    string message = string.Format(CultureInfo.CurrentCulture,
-               Resource.DomainContext_InvokeOperationFailed,
-               operation, ex.Message);
+                    string message = string.Format(Resource.DomainContext_InvokeOperationFailed, operation, ex.Message);
 
                     throw ex is DomainOperationException domainOperationException
                         ? new DomainOperationException(message, domainOperationException)
@@ -990,9 +979,7 @@ namespace OpenRiaServices.DomainServices.Client
                 }
                 else
                 {
-                    string message = string.Format(CultureInfo.CurrentCulture,
-             Resource.DomainContext_InvokeOperationFailed_Validation,
-             operation);
+                    string message = string.Format(Resource.DomainContext_InvokeOperationFailed_Validation, operation);
                     throw new DomainOperationException(message, results.ValidationErrors);
                 }
             }

--- a/src/OpenRiaServices.DomainServices.Client/Framework/DomainContext.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/DomainContext.cs
@@ -34,12 +34,14 @@ namespace OpenRiaServices.DomainServices.Client
         private int _activeLoadCount;
         private readonly DomainClient _domainClient;
         private EntityContainer _entityContainer;
-        private readonly TaskScheduler _syncContextScheduler;
         private ValidationContext _validationContext;
         private bool _isSubmitting;
         private readonly Dictionary<string, bool> _requiresValidationMap = new Dictionary<string, bool>();
         private readonly object _syncRoot = new object();
         private static IDomainClientFactory s_domainClientFactory;
+
+        private TaskScheduler CurrrentSyncronizationContextTaskScheduler => SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default;
+
 
         /// <summary>
         /// Protected constructor
@@ -53,7 +55,6 @@ namespace OpenRiaServices.DomainServices.Client
             }
 
             this._domainClient = domainClient;
-            this._syncContextScheduler = SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default;
         }
 
         /// <summary>
@@ -284,7 +285,7 @@ namespace OpenRiaServices.DomainServices.Client
                 , submitOperation
                 , CancellationToken.None
                 , TaskContinuationOptions.HideScheduler
-                , _syncContextScheduler);
+                , CurrrentSyncronizationContextTaskScheduler);
 
             return submitOperation;
         }
@@ -527,7 +528,7 @@ namespace OpenRiaServices.DomainServices.Client
                 , (object)loadOperation
                 , CancellationToken.None
                 , TaskContinuationOptions.HideScheduler
-                , _syncContextScheduler);
+                , CurrrentSyncronizationContextTaskScheduler);
 
             return loadOperation;
         }
@@ -691,7 +692,7 @@ namespace OpenRiaServices.DomainServices.Client
                 }
                 , continueationCts.Token
                 , TaskContinuationOptions.HideScheduler
-                , _syncContextScheduler);
+                , CurrrentSyncronizationContextTaskScheduler);
             }
             catch (Exception)
             {
@@ -865,7 +866,7 @@ namespace OpenRiaServices.DomainServices.Client
                 , (object)invokeOperation
                 , CancellationToken.None
                 , TaskContinuationOptions.HideScheduler
-                , _syncContextScheduler);
+                , CurrrentSyncronizationContextTaskScheduler);
 
             return invokeOperation;
         }
@@ -1022,7 +1023,7 @@ namespace OpenRiaServices.DomainServices.Client
             , operationName
             , CancellationToken.None
             , TaskContinuationOptions.NotOnCanceled | TaskContinuationOptions.HideScheduler
-            , _syncContextScheduler);
+            , CurrrentSyncronizationContextTaskScheduler);
         }
 
         /// <summary>

--- a/src/OpenRiaServices.DomainServices.Client/Framework/DomainContext.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/DomainContext.cs
@@ -42,7 +42,6 @@ namespace OpenRiaServices.DomainServices.Client
 
         private TaskScheduler CurrrentSyncronizationContextTaskScheduler => SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default;
 
-
         /// <summary>
         /// Protected constructor
         /// </summary>
@@ -617,87 +616,64 @@ namespace OpenRiaServices.DomainServices.Client
             }
 
             this.IncrementLoadCount();
-
             try
             {
                 // Proceed with query
                 var domainClientTask = this.DomainClient.QueryAsync(query, cancellationToken);
-
-                var continueationCts = new CancellationTokenSource();
-                return domainClientTask.ContinueWith(result =>
-                {
-                    IReadOnlyCollection<Entity> loadedEntities = null;
-                    List<Entity> allLoadedEntities = null;
-                    int totalCount;
-
-                    QueryCompletedResult results = null;
-                    try
-                    {
-                        lock (this._syncRoot)
-                        {
-                            // The task is known to be completed so this will never block
-                            results = result.GetAwaiter().GetResult();
-
-                            // load the entities into the entity container
-                            loadedEntities = this.EntityContainer.LoadEntities(results.Entities, loadBehavior);
-
-                            var loadedIncludedEntities = this.EntityContainer.LoadEntities(results.IncludedEntities, loadBehavior);
-                            allLoadedEntities = new List<Entity>(loadedEntities.Count + loadedIncludedEntities.Count);
-                            allLoadedEntities.AddRange(loadedEntities);
-                            allLoadedEntities.AddRange(loadedIncludedEntities);
-                            totalCount = results.TotalCount;
-                        }
-                    }
-                    catch (TaskCanceledException)
-                    {
-                        continueationCts.Cancel();
-                        throw new OperationCanceledException(continueationCts.Token);
-                    }
-                    catch (DomainException)
-                    {
-                        // DomainExceptions should not be modified
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        if (ex.IsFatal())
-                        {
-                            throw;
-                        }
-
-                        string message = string.Format(CultureInfo.CurrentCulture,
-                            Resource.DomainContext_LoadOperationFailed,
-                            query.QueryName, ex.Message);
-
-                        throw ex is DomainOperationException domainOperationException
-                            ? new DomainOperationException(message, domainOperationException)
-                            : new DomainOperationException(message, ex);
-                    }
-                    finally
-                    {
-                        this.DecrementLoadCount();
-                    }
-
-                    if (results.ValidationErrors.Any())
-                    {
-                        string message = string.Format(CultureInfo.CurrentCulture,
-            Resource.DomainContext_LoadOperationFailed_Validation,
-            query.QueryName);
-                        throw new DomainOperationException(message, results.ValidationErrors);
-                    }
-                    else
-                    {
-                        return new LoadResult<TEntity>(query, loadBehavior, loadedEntities.Cast<TEntity>(), allLoadedEntities, totalCount);
-                    }
-                }
-                , continueationCts.Token
-                , TaskContinuationOptions.HideScheduler
-                , CurrrentSyncronizationContextTaskScheduler);
+                return LoadAsyncImplementation(domainClientTask);
             }
             catch (Exception)
             {
                 DecrementLoadCount();
                 throw;
+            }
+
+            async Task<LoadResult<TEntity>> LoadAsyncImplementation(Task<QueryCompletedResult> queryCompletedResult)
+            {
+                IReadOnlyCollection<Entity> loadedEntities = null;
+                IReadOnlyCollection<Entity> loadedIncludedEntities = null;
+                List<Entity> allLoadedEntities = null;
+                int totalCount;
+
+                QueryCompletedResult results = null;
+                try
+                {
+                    // The task is known to be completed so this will never block
+                    results = await queryCompletedResult.ConfigureAwait(true);
+                    lock (this._syncRoot)
+                    {
+                        // load the entities into the entity container
+                        loadedEntities = this.EntityContainer.LoadEntities(results.Entities, loadBehavior);
+                        loadedIncludedEntities = this.EntityContainer.LoadEntities(results.IncludedEntities, loadBehavior);
+                    }
+
+                    allLoadedEntities = new List<Entity>(loadedEntities.Count + loadedIncludedEntities.Count);
+                    allLoadedEntities.AddRange(loadedEntities);
+                    allLoadedEntities.AddRange(loadedIncludedEntities);
+                    totalCount = results.TotalCount;
+                }
+                catch (Exception ex) when (!(ex is DomainException || ex is OperationCanceledException || ex.IsFatal()))
+                {
+                    string message = string.Format(Resource.DomainContext_LoadOperationFailed, query.QueryName, ex.Message);
+
+                    throw ex is DomainOperationException domainOperationException
+                        ? new DomainOperationException(message, domainOperationException)
+                        : new DomainOperationException(message, ex);
+                }
+                finally
+                {
+                    this.DecrementLoadCount();
+                }
+
+                if (results.ValidationErrors.Any())
+                {
+                    string message = string.Format(Resource.DomainContext_LoadOperationFailed_Validation, query.QueryName);
+                    throw new DomainOperationException(message, results.ValidationErrors);
+                }
+                else
+                {
+                    return new LoadResult<TEntity>(query, loadBehavior, loadedEntities.Cast<TEntity>(), allLoadedEntities, totalCount);
+                }
             }
         }
 

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/QueryTests.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/Data/QueryTests.cs
@@ -1751,7 +1751,7 @@ namespace OpenRiaServices.DomainServices.Client.Test
             var loadTask = catalog.LoadAsync(query, cts.Token);
             cts.Cancel();
 
-            await ExceptionHelper.ExpectExceptionAsync<OperationCanceledException>(() => loadTask);
+            await ExceptionHelper.ExpectExceptionAsync<TaskCanceledException>(() => loadTask);
             Assert.IsTrue(loadTask.IsCanceled, "Task should be cancelled");
         }
 


### PR DESCRIPTION
* Complete Load/Invoke/Submit operation on the SynchronizationContext of the caller instead of saving the SynchronizationContext
* Use async/await internally so failed load will now raise `TaskCanceledException` as one might expect instead of just `OperationCanceledException`

This is a behavioral change only, but might break applications.
This means that operations should be started on the UI thread if any data of the DomainContext or returned Operaitons are bound to the UI before completion.

