### PR TITLE
Simplify AuthenticationService execution flow

### DIFF
--- a/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationOperation.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationOperation.cs
@@ -54,17 +54,14 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         /// <returns>The async result returned by the underlying Begin call</returns>
         protected internal abstract Task<AuthenticationResult> InvokeAsync(CancellationToken cancellationToken);
 
-        /// <summary>
-        /// Raises property changes after the operation has completed.
-        /// </summary>
-        /// <remarks>
-        /// This method is invoked by the callback passed into <see cref="InvokeAsync"/> once
-        /// <see cref="OperationBase.Result"/> and <see cref="OperationBase.Error"/> have
-        /// been set. Change notifications for any properties that have been affected by the
-        /// state changes should occur here.
-        /// </remarks>
-        protected virtual void RaiseCompletionPropertyChanges()
+        internal new void SetError(Exception error)
         {
+            base.SetError(error);
+        }
+
+        internal virtual void Complete(AuthenticationResult endResult)
+        {
+            base.Complete(endResult);
             if (this.User != null)
             {
                 this.RaisePropertyChanged(nameof(User));
@@ -74,26 +71,15 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         private protected Task<AuthenticationResult> CastTaskResult<T>(Task<T> task)
             where T : AuthenticationResult
         {
-            return task.ContinueWith(res =>
+            return task.ContinueWith<AuthenticationResult>(res =>
             {
-                return (AuthenticationResult)res.GetAwaiter().GetResult();
+                return res.GetAwaiter().GetResult();
             }
            , CancellationToken.None
            , TaskContinuationOptions.NotOnCanceled | TaskContinuationOptions.ExecuteSynchronously
            , TaskScheduler.Default);
         }
 
-        internal new void SetError(Exception error)
-        {
-            base.SetError(error);
-            RaiseCompletionPropertyChanges();
-        }
-
-        internal void Complete(AuthenticationResult endResult)
-        {
-            base.Complete(endResult);
-            RaiseCompletionPropertyChanges();
-        }
         #endregion
     }
 }

--- a/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationOperation.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationOperation.cs
@@ -42,72 +42,17 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         /// This value will be <c>null</c> before the operation completes, if the operation
         /// is canceled, or if the operation has errors.
         /// </remarks>
-        public IPrincipal User
-        {
-            get { return (this.Result == null) ? null : this.Result.User; }
-        }
+        public IPrincipal User => this.Result?.User;
 
         #region Methods
-
-        /// <summary>
-        /// Starts the operation.
-        /// </summary>
-        /// <remarks>
-        /// This method will invoke <see cref="InvokeAsync"/> and will allow all
-        /// exceptions thrown from <see cref="InvokeAsync"/> to pass through.
-        /// </remarks>
-        internal Task StartAsync()
-        {
-            var task = this.InvokeAsync(this.CancellationToken);
-
-            // Continue on same SynchronizationContext
-            var scheduler = SynchronizationContext.Current != null ? TaskScheduler.FromCurrentSynchronizationContext() : TaskScheduler.Default;
-            return task.ContinueWith(InvokeComplete, this, CancellationToken.None, TaskContinuationOptions.HideScheduler, scheduler);
-
-            static void InvokeComplete(Task<object> res, object state)
-            {
-                var operation = (AuthenticationOperation)state;
-                object endResult = null;
-
-                if (res.IsCanceled)
-                {
-                    operation.SetCancelled();
-                    return;
-                }
-
-                try
-                {
-                    endResult = res.GetAwaiter().GetResult();
-                }
-                catch (Exception e)
-                {
-                    operation.SetError(e);
-                    operation.RaiseCompletionPropertyChanges();
-
-                    if (e.IsFatal())
-                    {
-                        throw;
-                    }
-
-                    return;
-                }
-
-                operation.Complete(endResult);
-                operation.RaiseCompletionPropertyChanges();
-            }
-        }
 
         /// <summary>
         /// Template method for invoking the corresponding Begin method in the
         /// underlying async result implementation.
         /// </summary>
-        /// <remarks>
-        /// This method is invoked from <see cref="StartAsync"/>. Any exceptions thrown
-        /// will be passed through.
-        /// </remarks>
         /// <param name="cancellationToken"></param>
         /// <returns>The async result returned by the underlying Begin call</returns>
-        protected abstract Task<object> InvokeAsync(CancellationToken cancellationToken);
+        protected internal abstract Task<AuthenticationResult> InvokeAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Raises property changes after the operation has completed.
@@ -126,16 +71,28 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
             }
         }
 
-        private protected Task<object> CastToObjectTask<T>(Task<T> task)
-            where T : class
+        private protected Task<AuthenticationResult> CastTaskResult<T>(Task<T> task)
+            where T : AuthenticationResult
         {
             return task.ContinueWith(res =>
             {
-                return (object)res.GetAwaiter().GetResult();
+                return (AuthenticationResult)res.GetAwaiter().GetResult();
             }
            , CancellationToken.None
            , TaskContinuationOptions.NotOnCanceled | TaskContinuationOptions.ExecuteSynchronously
            , TaskScheduler.Default);
+        }
+
+        internal new void SetError(Exception error)
+        {
+            base.SetError(error);
+            RaiseCompletionPropertyChanges();
+        }
+
+        internal void Complete(AuthenticationResult endResult)
+        {
+            base.Complete(endResult);
+            RaiseCompletionPropertyChanges();
         }
         #endregion
     }

--- a/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationService.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/AuthenticationService.cs
@@ -454,29 +454,15 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         private static string GetBusyPropertyName(AuthenticationOperation operation)
         {
             Debug.Assert(operation != null, "The operation cannot be null.");
-            Type operationType = operation.GetType();
 
-            if (typeof(LoginOperation) == operationType)
+            return operation switch
             {
-                return "IsLoggingIn";
-            }
-            else if (typeof(LogoutOperation) == operationType)
-            {
-                return "IsLoggingOut";
-            }
-            else if (typeof(LoadUserOperation) == operationType)
-            {
-                return "IsLoadingUser";
-            }
-            else if (typeof(SaveUserOperation) == operationType)
-            {
-                return "IsSavingUser";
-            }
-            else
-            {
-                Debug.Assert(false, "operationType parameter is invalid.");
-                return string.Empty;
-            }
+                LoginOperation _ => nameof(IsLoggingIn),
+                LogoutOperation _ => nameof(IsLoggingOut),
+                LoadUserOperation _ => nameof(IsLoadingUser),
+                SaveUserOperation _ => nameof(IsSavingUser),
+                _ => throw new NotImplementedException("unknown operation type"),
+            };
         }
 
         /// <summary>

--- a/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LoadUserOperation.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LoadUserOperation.cs
@@ -22,9 +22,9 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns>The async result for the operation</returns>
-        protected override Task<object> InvokeAsync(CancellationToken cancellationToken)
+        protected internal override Task<AuthenticationResult> InvokeAsync(CancellationToken cancellationToken)
         {
-            return CastToObjectTask(this.Service.LoadUserAsync(cancellationToken));
+            return CastTaskResult(this.Service.LoadUserAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LoginOperation.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LoginOperation.cs
@@ -53,12 +53,9 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
             return CastTaskResult(this.Service.LoginAsync(this.LoginParameters, cancellationToken));
         }
 
-        /// <summary>
-        /// Raises property changes after the operation has completed.
-        /// </summary>
-        protected override void RaiseCompletionPropertyChanges()
+        internal override void Complete(AuthenticationResult endResult)
         {
-            base.RaiseCompletionPropertyChanges();
+            base.Complete(endResult);
             if (this.LoginSuccess)
             {
                 this.RaisePropertyChanged(nameof(LoginSuccess));

--- a/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LoginOperation.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LoginOperation.cs
@@ -48,9 +48,9 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         /// Begins a login operation
         /// </summary>
         /// <returns>The async result for the operation</returns>
-        protected override Task<object> InvokeAsync(CancellationToken cancellationToken)
+        protected internal override Task<AuthenticationResult> InvokeAsync(CancellationToken cancellationToken)
         {
-            return CastToObjectTask(this.Service.LoginAsync(this.LoginParameters, cancellationToken));
+            return CastTaskResult(this.Service.LoginAsync(this.LoginParameters, cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LogoutOperation.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/LogoutOperation.cs
@@ -22,9 +22,9 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The async result for the operation</returns>
-        protected override Task<object> InvokeAsync(CancellationToken cancellationToken)
+        protected internal override Task<AuthenticationResult> InvokeAsync(CancellationToken cancellationToken)
         {
-            return CastToObjectTask(this.Service.LogoutAsync(cancellationToken));
+            return CastTaskResult(this.Service.LogoutAsync(cancellationToken));
         }
 
         /// <summary>

--- a/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/SaveUserOperation.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/SaveUserOperation.cs
@@ -22,9 +22,9 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>The async result for the operation</returns>
-        protected override Task<object> InvokeAsync(CancellationToken cancellationToken)
+        protected internal override Task<AuthenticationResult> InvokeAsync(CancellationToken cancellationToken)
         {
-            return CastToObjectTask(this.Service.SaveUserAsync(this.Service.User, cancellationToken));
+            return CastTaskResult(this.Service.SaveUserAsync(this.Service.User, cancellationToken));
         }
 
         /// <summary>


### PR DESCRIPTION
* centralize state management logic for `AuthenticationService` to `AuthenticationService` (move parts from `AuthenticationOperation`)
* simplify GetBusyPropertyName via switch expression
* simplify completion flow by inlining RaiseCompletionPropertyChanges 
