### PR TITLE
Link shared files

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,12 +6,14 @@
 2. Client networking API the *DomainClient* is now based on Task instead of using the APM pattern with Begin/End methods
 3. Supported TargetFrameworks has changed
 4. Code generation now works against *netstandard 2.0* and *netcore 2.1+* clients
+5. **Major namespace changes** *DomainServices* is dropped from namespaces and assemblies
 5. AspNetMembership authentication (**AuthenticationBase** and related classes) are moved to a new namespace and nuget package
    * Add a reference to *OpenRIAServices.Server.Authenication.AspNetMembership* if you use it
 
 ## Upgrade instructions
 
 1. Update both all client anor/or server nuget packages to the new version, dont't mix with v4 in the same project.
+2. Seach and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files
 2. If you have been using **AuthenticationBase** or other classes in the `OpenRiaServices.Server.ApplicationServices` namespace in your server project 
    1. Add the *OpenRiaServices.Server.Authentication.AspNetMembership* nuget package to it
    2. Replace *OpenRiaServices.Server.ApplicationServices* with *OpenRiaServices.Server.Authentication*
@@ -42,6 +44,8 @@ It is currently quite empty but already demonstrates some of the following scena
 
 # 5.0.0 RC
 
+* "DomainServices" dropped from all namespaces, filenames as well as nugets and DLLs.
+  * **IMPORTANT** Seach and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files when uprading
 * Updated required version of .Net Framework to 4.7.2 (#241)
 * Updated dependencies including EntityFramework to latests availible versions #240
 * Create, Update and Delete methods on server can now return Task #226

--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,17 @@ It is currently quite empty but already demonstrates some of the following scena
     * Using Asp.Net Identity for authentication
     * Writing your own custom Authentication logic
     * Running OpenRiaServices in same project as Asp.Net MVC
+
+# 5.0.0 RC
+
+* Updated required version of .Net Framework to 4.7.2 (#241)
+* Updated dependencies including EntityFramework to latests availible versions #240
+* Create, Update and Delete methods on server can now return Task #226
+* New handling of shared files #229
+  Instead of copying all ".shared" files to the `Generated_Code` folder the server version is referenced instead
+  * This should build faster builds and allows find all references, refactoring etc to work for shared files
+  * It is possible to opt out of the new behaviour by adding `<OpenRiaSharedFilesMode>Copy</OpenRiaSharedFilesMode>` in the project file
+  * The tooling is updated with a new option
   
 # 5.0.0 Preview 3
 

--- a/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
+++ b/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
@@ -353,7 +353,8 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
        IsClientApplication="$(OpenRiaGenerateApplicationContext)"
        UseFullTypeNames="$(OpenRiaClientUseFullTypeNames)"
        ClientAssemblySearchPaths="@(OpenRiaClientCodeGenClientAssemblySearchPath)"
-       CodeGeneratorName="$(OpenRiaClientCodeGeneratorName)">
+       CodeGeneratorName="$(OpenRiaClientCodeGeneratorName)"
+       CopyOrLinkSharedFiles="Link">
 
       <!-- Copy the task outputs to global item collections for other tasks -->
       <Output ItemName="OpenRiaClientGeneratedFiles" TaskParameter="GeneratedFiles" />
@@ -361,19 +362,17 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <Output ItemName="OpenRiaClientCopiedFiles" TaskParameter="CopiedFiles" />
       <Output ItemName="OpenRiaClientLinkedFiles" TaskParameter="LinkedFiles" />
 
-      <!-- Inform the compiler of the newly generated and copied files -->
-      <Output ItemName="Compile" TaskParameter="GeneratedFiles" />
-      <Output ItemName="Compile" TaskParameter="CopiedFiles" />
-
       <Output ItemName="FileWrites" TaskParameter="GeneratedFiles" />
-      <Output ItemName="FileWrites" TaskParameter="CopiedFiles" />
-
+      <!-- <Output ItemName="FileWrites" TaskParameter="CopiedFiles" /> -->
+      <!--<Output ItemName="FileWrites" TaskParameter="OutputFiles" />-->
     </CreateOpenRiaClientFilesTask>
 
-  </Target>
+    <ItemGroup>
+      <!-- Inform the compiler of the newly generated and copied files -->
+      <Compile Include="@(OpenRiaClientGeneratedFiles)" KeepDuplicates="false" />
+      <Compile Include="@(OpenRiaClientCopiedFiles)" KeepDuplicates="false" />
+    </ItemGroup>
 
-  <!-- Import the WCF targets for proxy generation if it exists -->
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight\v5.0\Microsoft.VisualStudio.ServiceModel.targets"
-          Condition="'$(SilverlightVersion)' != '' and Exists('$(MSBuildExtensionsPath)\Microsoft\Silverlight\v5.0\Microsoft.VisualStudio.ServiceModel.targets')" />
+  </Target>
 
 </Project>

--- a/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
+++ b/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
@@ -23,12 +23,9 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
     <!-- Use SilverlightApplication if present, otherwise check if we are building an exe -->
     <OpenRiaGenerateApplicationContext Condition="'$(OpenRiaGenerateApplicationContext)' == '' and '$(SilverlightApplication)' != '' ">$(SilverlightApplication)</OpenRiaGenerateApplicationContext>
     <OpenRiaGenerateApplicationContext Condition="'$(OpenRiaGenerateApplicationContext)' == '' and '$(OutputType)'=='exe' ">true</OpenRiaGenerateApplicationContext>
-  
+    <OpenRiaSharedFilesMode Condition="'$(OpenRiaSharedFilesMode)' ==''">Link</OpenRiaSharedFilesMode>
+    <_OpenRiaDesignTimeBuild Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'">true</_OpenRiaDesignTimeBuild> 
   </PropertyGroup>
-    
-    <PropertyGroup Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'">
-         <_AvoidExpensiveCalculation>true</_AvoidExpensiveCalculation>
-     </PropertyGroup>
   
   <!--
     ============================================================
@@ -326,6 +323,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       IsClientApplication:        [optional] (string) boolean, where "true" means the client project is an application
       UseFullTypeNames:           [optional] (string) boolean where "true" means fully qualified type names should be generated
       CodeGeneratorName:          [optional] the name of the code generator to use
+      SharedFilesMode             [optional] "Link" (default) or "Copy"
       
     Outputs are:
       GeneratedFiles:             the list of all generated code files (does not include copied files)
@@ -354,7 +352,7 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
        UseFullTypeNames="$(OpenRiaClientUseFullTypeNames)"
        ClientAssemblySearchPaths="@(OpenRiaClientCodeGenClientAssemblySearchPath)"
        CodeGeneratorName="$(OpenRiaClientCodeGeneratorName)"
-       CopyOrLinkSharedFiles="Link">
+       SharedFilesMode="$(OpenRiaSharedFilesMode)">
 
       <!-- Copy the task outputs to global item collections for other tasks -->
       <Output ItemName="OpenRiaClientGeneratedFiles" TaskParameter="GeneratedFiles" />

--- a/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
+++ b/NuGet/OpenRiaServices.Client.CodeGen/build/OpenRiaServices.CodeGen.targets
@@ -363,14 +363,13 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
       <Output ItemName="OpenRiaClientLinkedFiles" TaskParameter="LinkedFiles" />
 
       <Output ItemName="FileWrites" TaskParameter="GeneratedFiles" />
-      <!-- <Output ItemName="FileWrites" TaskParameter="CopiedFiles" /> -->
-      <!--<Output ItemName="FileWrites" TaskParameter="OutputFiles" />-->
+      <Output ItemName="FileWrites" TaskParameter="CopiedFiles" /> 
     </CreateOpenRiaClientFilesTask>
 
     <ItemGroup>
       <!-- Inform the compiler of the newly generated and copied files -->
       <Compile Include="@(OpenRiaClientGeneratedFiles)" KeepDuplicates="false" />
-      <Compile Include="@(OpenRiaClientCopiedFiles)" KeepDuplicates="false" />
+      <Compile Include="@(OpenRiaClientSharedFiles)" KeepDuplicates="false" />
     </ItemGroup>
 
   </Target>

--- a/src/OpenRiaServices.Hosting.Local/Framework/DomainServiceProxy.cs
+++ b/src/OpenRiaServices.Hosting.Local/Framework/DomainServiceProxy.cs
@@ -23,7 +23,7 @@ namespace OpenRiaServices.Hosting.Local
         /// <param name="domainService">The type of <see cref="DomainService"/> to perform this query operation against.</param>
         /// <param name="context">The current context.</param>
         /// <param name="domainServiceInstances">The list of tracked <see cref="DomainService"/> instances that any newly created
-        /// <see cref="DomainServices"/> will be added to.</param>
+        /// <see cref="DomainService"/> will be added to.</param>
         /// <param name="queryName">The name of the query to invoke.</param>
         /// <param name="parameters">The query parameters.</param>
         /// <returns>The query results. May be null if there are no query results.</returns>
@@ -35,7 +35,7 @@ namespace OpenRiaServices.Hosting.Local
         /// <param name="domainService">The type of <see cref="DomainService"/> to perform this query operation against.</param>
         /// <param name="context">The current context.</param>
         /// <param name="domainServiceInstances">The list of tracked <see cref="DomainService"/> instances that any newly created
-        /// <see cref="DomainServices"/> will be added to.</param>
+        /// <see cref="DomainService"/> will be added to.</param>
         /// <param name="name">The name of the operation to invoke.</param>
         /// <param name="parameters">The operation parameters.</param>
         /// <returns>The result of the invoke operation.</returns>
@@ -47,7 +47,7 @@ namespace OpenRiaServices.Hosting.Local
         /// <param name="domainService">The type of <see cref="DomainService"/> to perform this query operation against.</param>
         /// <param name="context">The current context.</param>
         /// <param name="domainServiceInstances">The list of tracked <see cref="DomainService"/> instances that any newly created
-        /// <see cref="DomainServices"/> will be added to.</param>
+        /// <see cref="DomainService"/> will be added to.</param>
         /// <param name="currentOriginalEntityMap">The mapping of current and original entities used with the utility <see cref="DomainServiceProxy.AssociateOriginal"/> method.</param>
         /// <param name="entity">The entity being submitted.</param>
         /// <param name="operationName">The name of the submit operation. For CUD operations, this can be null.</param>

--- a/src/OpenRiaServices.Hosting.Local/Framework/Internal/DomainServiceProxyHelper.cs
+++ b/src/OpenRiaServices.Hosting.Local/Framework/Internal/DomainServiceProxyHelper.cs
@@ -25,7 +25,7 @@ namespace OpenRiaServices.Hosting.Local
         /// <param name="domainService">The type of <see cref="DomainService"/> to perform this query operation against.</param>
         /// <param name="context">The current context.</param>
         /// <param name="domainServiceInstances">The list of tracked <see cref="DomainService"/> instances that any newly created
-        /// <see cref="DomainServices"/> will be added to.</param>
+        /// <see cref="DomainService"/> will be added to.</param>
         /// <param name="queryName">The name of the query to invoke.</param>
         /// <param name="parameters">The query parameters.</param>
         /// <returns>The query results. May be null if there are no query results.</returns>
@@ -91,7 +91,7 @@ namespace OpenRiaServices.Hosting.Local
         /// <param name="domainService">The type of <see cref="DomainService"/> to perform this query operation against.</param>
         /// <param name="context">The current context.</param>
         /// <param name="domainServiceInstances">The list of tracked <see cref="DomainService"/> instances that any newly created
-        /// <see cref="DomainServices"/> will be added to.</param>
+        /// <see cref="DomainService"/> will be added to.</param>
         /// <param name="currentOriginalEntityMap">The mapping of current and original entities used with the utility <see cref="DomainServiceProxy.AssociateOriginal"/> method.</param>
         /// <param name="entity">The entity being submitted.</param>
         /// <param name="operationName">The name of the submit operation. For CUD operations, this can be null.</param>
@@ -145,7 +145,7 @@ namespace OpenRiaServices.Hosting.Local
         /// <param name="domainService">The type of <see cref="DomainService"/> to perform this query operation against.</param>
         /// <param name="context">The current context.</param>
         /// <param name="domainServiceInstances">The list of tracked <see cref="DomainService"/> instances that any newly created
-        /// <see cref="DomainServices"/> will be added to.</param>
+        /// <see cref="DomainService"/> will be added to.</param>
         /// <param name="name">The name of the operation to invoke.</param>
         /// <param name="parameters">The operation parameters.</param>
         /// <returns>The result of the invoke operation.</returns>

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/DomainContextGenerator.partial.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/DomainContextGenerator.partial.cs
@@ -8,7 +8,6 @@ namespace OpenRiaServices.Tools.TextTemplate
     using System.Globalization;
     using System.Linq;
     using OpenRiaServices;
-    using OpenRiaServices;
     using OpenRiaServices.Hosting;
     using OpenRiaServices.Server;
     using OpenRiaServices.Tools.SharedTypes;

--- a/src/OpenRiaServices.Tools/Framework/CreateOpenRiaClientFilesTask.cs
+++ b/src/OpenRiaServices.Tools/Framework/CreateOpenRiaClientFilesTask.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Web.Compilation;
@@ -129,6 +131,14 @@ namespace OpenRiaServices.Tools
         public string CodeGeneratorName { get; set; }
 
         /// <summary>
+        /// Gets the string form of a boolean that indicates
+        /// whether the shared files should be copied (instead of linked).
+        /// </summary>
+        public string CopyOrLinkSharedFiles { set => LinkSharedFilesInsteadOfCopy = string.Equals(value, "Link", StringComparison.OrdinalIgnoreCase); }
+
+        private bool LinkSharedFilesInsteadOfCopy { get; set; } = true;
+
+        /// <summary>
         /// Gets the list of code files created by this task.
         /// </summary>
         /// <value>
@@ -161,9 +171,9 @@ namespace OpenRiaServices.Tools
             {
                 Dictionary<string, IList<string>> sharedFilesByProject = this.SharedFilesByProject;
                 List<ITaskItem> result = new List<ITaskItem>();
-                foreach (IList<string> files in sharedFilesByProject.Values)
+                foreach (var filesByProject in sharedFilesByProject)
                 {
-                    foreach (string file in files)
+                    foreach (string file in filesByProject.Value)
                     {
                         result.Add(new TaskItem(file));
                     }
@@ -305,11 +315,12 @@ namespace OpenRiaServices.Tools
         /// <value>
         /// This list is a concatenation of <see cref="GeneratedFiles"/> and <see cref="CopiedFiles"/>.
         /// </value>
-        internal IEnumerable<ITaskItem> OutputFiles
+        [Output]
+        public IEnumerable<ITaskItem> OutputFiles
         {
             get
             {
-                return this.GeneratedFiles.Concat(this.CopiedFiles);
+                return (LinkSharedFilesInsteadOfCopy) ? GeneratedFiles : GeneratedFiles.Concat(CopiedFiles);
             }
         }
 
@@ -377,7 +388,7 @@ namespace OpenRiaServices.Tools
         {
             get
             {
-                if(string.IsNullOrEmpty(ClientFrameworkPath))
+                if (string.IsNullOrEmpty(ClientFrameworkPath))
                     return TargetPlatform.Unknown;
 
                 if (ClientFrameworkPath.IndexOf("Silverlight", StringComparison.InvariantCultureIgnoreCase) != -1)
@@ -524,7 +535,8 @@ namespace OpenRiaServices.Tools
                 // We do the copy first so that we know which files are shared between projects
                 if (this.IsServerProjectAvailable)
                 {
-                    this.CopySharedFiles();
+                    if (!LinkSharedFilesInsteadOfCopy)
+                        this.CopySharedFiles();
                     this.GenerateClientProxies();
                 }
 
@@ -966,7 +978,7 @@ namespace OpenRiaServices.Tools
                 this._projectFileReader.Dispose();
                 this._projectFileReader = null;
             }
-            }
+        }
 
         /// <summary>
         /// Issue a build warning if we cannot find a PDB file for the given assembly
@@ -1134,10 +1146,25 @@ namespace OpenRiaServices.Tools
         /// <summary>
         /// Adds the given file name to the list returned by <see cref="CopiedFiles"/>.
         /// </summary>
-        /// <param name="fileName">The absolute path of a file.</param>
-        private void AddCopiedFile(string fileName)
+        /// <param name="sourceFilePath">The absolute path of a file.</param>
+        /// <param name="destinationFilePath">The absolute path of a file.</param>
+        /// 
+        private void AddCopiedFile(string sourceFilePath, string destinationFilePath)
         {
-            this._copiedFiles.Add(new TaskItem(fileName));
+            if (LinkSharedFilesInsteadOfCopy)
+            {
+                // ClientProjectDirectory is without "/" so add 1 to get relative path starting with "Generated_Code"
+                string relativePath = destinationFilePath.Substring(ClientProjectDirectory.Length + 1);
+                Debug.Assert(relativePath[0] == GeneratedCodeFolderName[0]);
+
+                var metadata = new SortedList(initialCapacity: 1) { { "Link", relativePath } };
+                this._copiedFiles.Add(new TaskItem(sourceFilePath, metadata));
+
+            }
+            else
+            {
+                this._copiedFiles.Add(new TaskItem(destinationFilePath));
+            }
         }
 
         /// <summary>
@@ -1257,7 +1284,7 @@ namespace OpenRiaServices.Tools
             }
 
             // Keep track of all files that are logically copied, even if we find it is current
-            this.AddCopiedFile(destinationFilePath);
+            this.AddCopiedFile(sourceFilePath, destinationFilePath);
 
             // Don't do any work unless the inputs are newer.
             // Note: we are sensitive to a VS TextBuffer being dirty as being newer

--- a/src/OpenRiaServices.Tools/Framework/CreateOpenRiaClientFilesTask.cs
+++ b/src/OpenRiaServices.Tools/Framework/CreateOpenRiaClientFilesTask.cs
@@ -132,7 +132,7 @@ namespace OpenRiaServices.Tools
         /// Gets the string form of a boolean that indicates
         /// whether the shared files should be copied (instead of linked).
         /// </summary>
-        public string SharedFilesMode { set => LinkSharedFilesInsteadOfCopy = !string.Equals(value, "Copy", StringComparison.OrdinalIgnoreCase); }
+        public string SharedFilesMode { set => LinkSharedFilesInsteadOfCopy = !string.Equals(value,  OpenRiaSharedFilesMode.Copy.ToString(), StringComparison.OrdinalIgnoreCase); }
 
         private bool LinkSharedFilesInsteadOfCopy { get; set; } = true;
 
@@ -1216,10 +1216,13 @@ namespace OpenRiaServices.Tools
         /// </remarks>
         private void CopySharedFiles()
         {
+            Dictionary<string, IList<string>> sharedFilesByProject = this.SharedFilesByProject;
+
+            // SharedFilesByProject initializes important information about service links
+            // Dont exit until after initialization
             if (LinkSharedFilesInsteadOfCopy)
                 return;
 
-            Dictionary<string, IList<string>> sharedFilesByProject = this.SharedFilesByProject;
             HashSet<string> fileHash = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // Each separate project's set of files is copied under a unique folder under GeneratedCode.

--- a/src/OpenRiaServices.Tools/Framework/CreateOpenRiaClientFilesTask.cs
+++ b/src/OpenRiaServices.Tools/Framework/CreateOpenRiaClientFilesTask.cs
@@ -132,7 +132,7 @@ namespace OpenRiaServices.Tools
         /// Gets the string form of a boolean that indicates
         /// whether the shared files should be copied (instead of linked).
         /// </summary>
-        public string CopyOrLinkSharedFiles { set => LinkSharedFilesInsteadOfCopy = string.Equals(value, "Link", StringComparison.OrdinalIgnoreCase); }
+        public string SharedFilesMode { set => LinkSharedFilesInsteadOfCopy = !string.Equals(value, "Copy", StringComparison.OrdinalIgnoreCase); }
 
         private bool LinkSharedFilesInsteadOfCopy { get; set; } = true;
 

--- a/src/OpenRiaServices.Tools/Framework/DomainServiceProxyGenerator.cs
+++ b/src/OpenRiaServices.Tools/Framework/DomainServiceProxyGenerator.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Reflection;
 using System.ServiceModel;
 using OpenRiaServices;
-using OpenRiaServices;
 using OpenRiaServices.Hosting;
 using OpenRiaServices.Server;
 using System.ServiceModel.Web;

--- a/src/OpenRiaServices.Tools/Framework/OpenRiaServices.Tools.csproj
+++ b/src/OpenRiaServices.Tools/Framework/OpenRiaServices.Tools.csproj
@@ -54,6 +54,12 @@
     <Content Include="Pdb\ReadMe.txt" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\..\NuGet\OpenRiaServices.Client.CodeGen\build\OpenRiaServices.CodeGen.targets" Link="build\OpenRiaServices.CodeGen.targets" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="build\" />
   </ItemGroup>
 </Project>

--- a/src/OpenRiaServices.Tools/Framework/OpenRiaSharedFilesMode.cs
+++ b/src/OpenRiaServices.Tools/Framework/OpenRiaSharedFilesMode.cs
@@ -1,4 +1,4 @@
-﻿namespace OpenRiaServices.VisualStudio.Installer
+﻿namespace OpenRiaServices.DomainServices.Tools
 {
     /// <summary>
     /// Determine how ".shared" files should be handled by code generation

--- a/src/OpenRiaServices.Tools/Framework/OpenRiaSharedFilesMode.cs
+++ b/src/OpenRiaServices.Tools/Framework/OpenRiaSharedFilesMode.cs
@@ -1,4 +1,4 @@
-﻿namespace OpenRiaServices.DomainServices.Tools
+﻿namespace OpenRiaServices.Tools
 {
     /// <summary>
     /// Determine how ".shared" files should be handled by code generation

--- a/src/OpenRiaServices.Tools/Test/CleanRiaClientFilesTaskTests.cs
+++ b/src/OpenRiaServices.Tools/Test/CleanRiaClientFilesTaskTests.cs
@@ -16,7 +16,6 @@ namespace OpenRiaServices.Tools.Test
         {
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CLRCF1")]
         [Description("CleanOpenRiaClientFilesTask deletes ancillary files in OutputPath and code in GeneratedOutputPath")]
         [TestMethod]
         public void CleanRiaClientFiles_Deletes_Generated_Files()
@@ -28,7 +27,7 @@ namespace OpenRiaServices.Tools.Test
                 // ====================================================
                 // Test setup -- generate code by calling Create task
                 // ====================================================
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CLRCF1", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ false);
                 bool success = task.Execute();
                 if (!success)
                 {

--- a/src/OpenRiaServices.Tools/Test/CodeGenHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/CodeGenHelper.cs
@@ -87,6 +87,15 @@ namespace OpenRiaServices.Tools.Test
         }
 
         /// <summary>
+        /// Assert that <paramref name="items"/> contains all the files specified in <paramref name="shortNames"/>
+        /// </summary>
+        public static void AssertOutputContainsFiles(ITaskItem[] items, string[] shortNames)
+        {
+            foreach (var shortName in shortNames)
+                GetOutputFile(items, shortName); // GetOutputFile assert that the file exists
+        }
+
+        /// <summary>
         /// Returns the name of the assembly built by the server project
         /// </summary>
         /// <param name="serverProjectPath"></param>

--- a/src/OpenRiaServices.Tools/Test/CreateRiaClientFilesTaskTests.cs
+++ b/src/OpenRiaServices.Tools/Test/CreateRiaClientFilesTaskTests.cs
@@ -46,7 +46,6 @@ namespace OpenRiaServices.Tools.Test
         {
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF0")]
         [Description("CreateOpenRiaClientFilesTask populates its internal computed properties correctly")]
         [TestMethod]
         public void CreateRiaClientFiles_Validate_Internal_Computed_Task_Properties()
@@ -55,7 +54,7 @@ namespace OpenRiaServices.Tools.Test
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF0", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ false);
 
                 // ServerProjectRootNamespace
                 string serverRootNamespace = task.ServerProjectRootNameSpace;
@@ -83,7 +82,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF1")]
         [Description("CreateOpenRiaClientFilesTask should issue warning if no server assembly was specified")]
         [TestMethod]
         public void CreateRiaClientFiles_Warn_No_Assembly_Specified()
@@ -92,7 +90,7 @@ namespace OpenRiaServices.Tools.Test
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF1", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ false);
 
                 task.ServerAssemblies = Array.Empty<TaskItem>();
                 task.ServerReferenceAssemblies = Array.Empty<TaskItem>();
@@ -112,7 +110,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF2")]
         [Description("CreateOpenRiaClientFilesTask should issue warning if server assembly does not exist")]
         [TestMethod]
         public void CreateRiaClientFiles_Warn_No_Assembly_Exists()
@@ -121,7 +118,7 @@ namespace OpenRiaServices.Tools.Test
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF2", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ false);
                 task.ServerAssemblies = MsBuildHelper.AsTaskItems(new string[] { "NotExist.dll" }).ToArray();
                 task.ServerReferenceAssemblies = Array.Empty<TaskItem>();
 
@@ -191,7 +188,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF3")]
         [Description("CreateOpenRiaClientFilesTask issues no warning if ask to write null content to non-existant file")]
         [TestMethod]
         public void CreateRiaClientFiles_No_Warning_Write_Empty_Content()
@@ -200,7 +196,7 @@ namespace OpenRiaServices.Tools.Test
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF3", false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", false);
 
                 // Create place to write file that should not exist
                 string outputFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
@@ -220,7 +216,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF12")]
         [Description("CreateOpenRiaClientFilesTask logs error if the RIA Link points to non-existent file")]
         [TestMethod]
         public void CreateRiaClientFiles_Bad_RIA_Link()
@@ -229,7 +224,7 @@ namespace OpenRiaServices.Tools.Test
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF12", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ false);
                 MockBuildEngine mockBuildEngine = task.BuildEngine as MockBuildEngine;
                 task.ServerProjectPath = task.ServerProjectPath + "bogus";  // tweak RIA Link to point to non existent file
 
@@ -250,7 +245,6 @@ namespace OpenRiaServices.Tools.Test
 
 
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF4")]
         [Description("CreateOpenRiaClientFilesTask issues warning if no PDB is found")]
         [TestMethod]
         public void CreateRiaClientFiles_Missing_Pdb_Warns()
@@ -259,7 +253,7 @@ namespace OpenRiaServices.Tools.Test
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF4", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ false);
                 MockBuildEngine mockBuildEngine = task.BuildEngine as MockBuildEngine;
                 string serverAssemblyFile = task.ServerAssemblies[0].ItemSpec;  // use name we mapped to deployment dir
                 string serverPdbFile = Path.ChangeExtension(serverAssemblyFile, "pdb");
@@ -290,35 +284,23 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF5")]
         [Description("CreateOpenRiaClientFilesTask creates ancillary files in OutputPath and code in GeneratedOutputPath")]
         [TestMethod]
         public void CreateRiaClientFiles_Validate_Generated_Files_Copy()
-        {
-            CreateRiaClientFiles_Validate_Generated_Files(OpenRiaSharedFilesMode.Copy);
-        }
+            => CreateRiaClientFiles_Validate_Generated_Files(OpenRiaSharedFilesMode.Copy);
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF5")]
         [Description("CreateOpenRiaClientFilesTask creates ancillary files in OutputPath and code in GeneratedOutputPath")]
         [TestMethod]
         public void CreateRiaClientFiles_Validate_Generated_Files_Link()
-        {
-            CreateRiaClientFiles_Validate_Generated_Files(OpenRiaSharedFilesMode.Link);
-        }
+            => CreateRiaClientFiles_Validate_Generated_Files(OpenRiaSharedFilesMode.Link);
 
         public void CreateRiaClientFiles_Validate_Generated_Files(OpenRiaSharedFilesMode sharedFilesMode)
         {
-            string[] expectedSharedFiles = new[]
-            {
-                "TestEntity.shared.cs",
-                "TestComplexType.shared.cs",
-            };
-
             CreateOpenRiaClientFilesTask task = null;
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF5", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance(string.Empty, /*includeClientOutputAssembly*/ false);
                 task.SharedFilesMode = sharedFilesMode.ToString();
                 bool success = task.Execute();
                 if (!success)
@@ -337,7 +319,7 @@ namespace OpenRiaServices.Tools.Test
                 Assert.IsTrue(File.Exists(generatedFile), "Expected task to have generated " + generatedFile);
 
 
-                foreach (var sharedFile in expectedSharedFiles)
+                foreach (var sharedFile in expectedServerNamedSharedFiles)
                 {
                     if (sharedFilesMode == OpenRiaSharedFilesMode.Copy)
                     {
@@ -375,7 +357,7 @@ namespace OpenRiaServices.Tools.Test
                 if (sharedFilesMode == OpenRiaSharedFilesMode.Copy)
                 {
                     Assert.AreEqual(expectedServerNamedSharedFiles.Length + expectedServer2NamedSharedFiles.Length, copiedFilesFromTask.Length, "Unexpected number of copied files");
-                    TestHelper.AssertContainsAtLeastTheseFiles(copiedFilesFromTask, mockProjectPath, expectedServerNamedSharedFiles);
+                    TestHelper.AssertContainsAtLeastTheseFiles(copiedFilesFromTask, mockProjectPath, CreateOpenRiaClientFilesTaskTests.expectedServerNamedSharedFiles);
                     mockProjectPath = Path.Combine(Path.Combine(generatedCodeOutputFolder, "ServerClassLib2"), "Mock");
                     TestHelper.AssertContainsAtLeastTheseFiles(copiedFilesFromTask, mockProjectPath, expectedServer2NamedSharedFiles);
                 }
@@ -399,7 +381,7 @@ namespace OpenRiaServices.Tools.Test
 
                 // Files list 
                 bool shouldCopy = (sharedFilesMode == OpenRiaSharedFilesMode.Copy);
-                foreach (var sharedFile in expectedSharedFiles)
+                foreach (var sharedFile in expectedServerNamedSharedFiles)
                     Assert.AreEqual(shouldCopy, fileListContents.Contains(sharedFile), "Checking if OpenRiaFiles.txt contains '{0}' with mode '{1}' actual content is '{2}'", sharedFile, sharedFilesMode, fileListContents);
 
 
@@ -457,7 +439,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF11")]
         [Description("CreateOpenRiaClientFilesTask can access web.config using ASP.NET AppDomain")]
         [TestMethod]
         public void CreateRiaClientFiles_ASPNET_AppDomain()
@@ -474,7 +455,7 @@ namespace OpenRiaServices.Tools.Test
                 //    the same as we would expect at runtime.  We use the CodeProcessor
                 //    approach because it is called by the code generator while it is
                 //    running within a ASP.NET AppDomain
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstanceForWAP("CRCF11");
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstanceForWAP("");
 
                 bool success = task.Execute();
                 if (!success)
@@ -522,20 +503,28 @@ namespace OpenRiaServices.Tools.Test
         }
 
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF7")]
         [Description("CreateOpenRiaClientFilesTask computes the correct set of shared files")]
         [TestMethod]
-        public void CreateRiaClientFiles_Validate_Shared_Files()
+        public void CreateRiaClientFiles_Validate_Shared_Files_Copy()
+            => CreateRiaClientFiles_Validate_Shared_Files(OpenRiaSharedFilesMode.Copy);
+
+        [Description("CreateOpenRiaClientFilesTask computes the correct set of shared files")]
+        [TestMethod]
+        public void CreateRiaClientFiles_Validate_Shared_Files_Link()
+            => CreateRiaClientFiles_Validate_Shared_Files(OpenRiaSharedFilesMode.Link);
+
+        public void CreateRiaClientFiles_Validate_Shared_Files(OpenRiaSharedFilesMode sharedFilesMode)
         {
             string projectPath = null;
             string outputPath = null;
-            TestHelper.GetProjectPaths("CRCF7", out projectPath, out outputPath);
+            TestHelper.GetProjectPaths("", out projectPath, out outputPath);
 
             CreateOpenRiaClientFilesTask task = null;
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF7", /*includeClientOutputAssembly*/ true);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ true);
+                task.SharedFilesMode = sharedFilesMode.ToString();
 
                 // Note: we do not execute this task because it will fail (due to true passed to helper above)
 
@@ -582,16 +571,26 @@ namespace OpenRiaServices.Tools.Test
 
 
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF8")]
-        [Description("CreateOpenRiaClientFilesTask does not regen files on second code-gen")]
+        [Description("CreateOpenRiaClientFilesTask does not regen files on second code-gen (OpenRiaSharedFilesMode.Copy)")]
         [TestMethod]
-        public void CreateRiaClientFiles_Second_CodeGen_Does_Nothing()
+        public void CreateRiaClientFiles_Second_CodeGen_Does_Nothing_Copy()
+            => CreateRiaClientFiles_Second_CodeGen_Does_Nothing(OpenRiaSharedFilesMode.Copy);
+
+        [Description("CreateOpenRiaClientFilesTask does not regen files on second code-gen (OpenRiaSharedFilesMode.Link)")]
+        [TestMethod]
+        public void CreateRiaClientFiles_Second_CodeGen_Does_Nothing_Link()
+        => CreateRiaClientFiles_Second_CodeGen_Does_Nothing(OpenRiaSharedFilesMode.Link);
+
+
+        public void CreateRiaClientFiles_Second_CodeGen_Does_Nothing(OpenRiaSharedFilesMode sharedFilesMode)
         {
             CreateOpenRiaClientFilesTask task = null;
+            int expectedNumberOfFiles = sharedFilesMode == OpenRiaSharedFilesMode.Copy ? 3 : 1;
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF8", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance(string.Empty, /*includeClientOutputAssembly*/ false);
+                task.SharedFilesMode = sharedFilesMode.ToString();
                 bool success = task.Execute();
                 if (!success)
                 {
@@ -603,19 +602,25 @@ namespace OpenRiaServices.Tools.Test
                 Assert.IsTrue(Directory.Exists(generatedCodeOutputFolder), "Expected task to have created " + generatedCodeOutputFolder);
 
                 string[] files = Directory.GetFiles(generatedCodeOutputFolder);
-                Assert.AreEqual(3, files.Length, "Code gen should have generated 3 code files");
+                Assert.AreEqual(expectedNumberOfFiles, files.Length, "Code gen should have generated 3 code files");
 
                 string generatedFile = Path.Combine(generatedCodeOutputFolder, "ServerClassLib.g.cs");
                 Assert.IsTrue(File.Exists(generatedFile), "Expected task to have generated " + generatedFile);
                 DateTime generatedTimestamp = File.GetLastWriteTime(generatedFile);
 
-                string copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
-                Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
-                DateTime copiedTimestamp = File.GetLastWriteTime(copiedFile);
+                DateTime copiedTimestamp = default;
+                DateTime copiedComplexTimestamp = default;
 
-                string copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
-                Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
-                DateTime copiedComplexTimestamp = File.GetLastWriteTime(copiedComplexFile);
+                if (sharedFilesMode == OpenRiaSharedFilesMode.Copy)
+                {
+                    string copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
+                    copiedTimestamp = File.GetLastWriteTime(copiedFile);
+
+                    string copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
+                    copiedComplexTimestamp = File.GetLastWriteTime(copiedComplexFile);
+                }
 
                 // Should have detected the set of client references changed
                 string clientReferenceListPath = task.ClientReferenceListPath();
@@ -641,23 +646,27 @@ namespace OpenRiaServices.Tools.Test
                 Assert.IsTrue(Directory.Exists(generatedCodeOutputFolder), "Expected task to have created " + generatedCodeOutputFolder);
 
                 files = Directory.GetFiles(generatedCodeOutputFolder);
-                Assert.AreEqual(3, files.Length, "Code gen should have generated 3 code files");
+                Assert.AreEqual(expectedNumberOfFiles, files.Length, "Code gen should have generated 3 code files");
 
                 generatedFile = Path.Combine(generatedCodeOutputFolder, "ServerClassLib.g.cs");
                 Assert.IsTrue(File.Exists(generatedFile), "Expected task to have generated " + generatedFile);
                 DateTime generatedTimestamp1 = File.GetLastWriteTime(generatedFile);
 
-                copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
-                Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
-                DateTime copiedTimestamp1 = File.GetLastWriteTime(copiedFile);
+                if (sharedFilesMode == OpenRiaSharedFilesMode.Copy)
+                {
+                    string copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
+                    DateTime copiedTimestamp1 = File.GetLastWriteTime(copiedFile);
 
-                copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
-                Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
-                DateTime copiedComplexTimestamp1 = File.GetLastWriteTime(copiedComplexFile);
+                    string copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
+                    DateTime copiedComplexTimestamp1 = File.GetLastWriteTime(copiedComplexFile);
+
+                    Assert.AreEqual(copiedTimestamp, copiedTimestamp1, "Did not expect 2nd code gen to recopy TestEntity.shared.cs");
+                    Assert.AreEqual(copiedComplexTimestamp, copiedComplexTimestamp1, "Did not expect 2nd code gen to recopy TestComplexType.shared.cs");
+                }
 
                 Assert.AreEqual(generatedTimestamp, generatedTimestamp1, "Did not expect 2nd code gen to regen ServerClassLib.g.cs");
-                Assert.AreEqual(copiedTimestamp, copiedTimestamp1, "Did not expect 2nd code gen to recopy TestEntity.shared.cs");
-                Assert.AreEqual(copiedComplexTimestamp, copiedComplexTimestamp1, "Did not expect 2nd code gen to recopy TestComplexType.shared.cs");
 
                 // Should not have updated the client or server references
                 Assert.IsTrue(File.Exists(serverReferenceListPath), "Expected file for server references");
@@ -673,16 +682,25 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF8")]
         [Description("CreateOpenRiaClientFilesTask generates breadcrumb files with relative paths, and does nothing on second build")]
         [TestMethod]
-        public void CreateRiaClientFiles_CopyClientProject()
+        public void CreateRiaClientFiles_CopyClientProject_Copy()
+            => CreateRiaClientFiles_CopyClientProject(OpenRiaSharedFilesMode.Copy);
+
+        [Description("CreateOpenRiaClientFilesTask generates breadcrumb files with relative paths, and does nothing on second build")]
+        [TestMethod]
+        public void CreateRiaClientFiles_CopyClientProject_Link()
+            => CreateRiaClientFiles_CopyClientProject(OpenRiaSharedFilesMode.Link);
+
+        public void CreateRiaClientFiles_CopyClientProject(OpenRiaSharedFilesMode sharedFilesMode)
         {
             CreateOpenRiaClientFilesTask task = null;
+            int expectedNumberOfFiles = sharedFilesMode == OpenRiaSharedFilesMode.Copy ? 3 : 1;
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance_CopyClientProjectToOutput("CRCF8", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance_CopyClientProjectToOutput("", /*includeClientOutputAssembly*/ false);
+                task.SharedFilesMode = sharedFilesMode.ToString();
                 bool success = task.Execute();
                 if (!success)
                 {
@@ -694,19 +712,24 @@ namespace OpenRiaServices.Tools.Test
                 Assert.IsTrue(Directory.Exists(generatedCodeOutputFolder), "Expected task to have created " + generatedCodeOutputFolder);
 
                 string[] files = Directory.GetFiles(generatedCodeOutputFolder);
-                Assert.AreEqual(3, files.Length, "Code gen should have generated 3 code files");
+                Assert.AreEqual(expectedNumberOfFiles, files.Length, "Code gen should have generated 3 code files");
 
                 string generatedFile = Path.Combine(generatedCodeOutputFolder, "ServerClassLib.g.cs");
                 Assert.IsTrue(File.Exists(generatedFile), "Expected task to have generated " + generatedFile);
                 DateTime generatedTimestamp = File.GetLastWriteTime(generatedFile);
 
-                string copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
-                Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
-                DateTime copiedTimestamp = File.GetLastWriteTime(copiedFile);
+                DateTime copiedTimestamp = default;
+                DateTime copiedComplexTimestamp = default;
+                if (sharedFilesMode == OpenRiaSharedFilesMode.Copy)
+                {
+                    string copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
+                    copiedTimestamp = File.GetLastWriteTime(copiedFile);
 
-                string copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
-                Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
-                DateTime copiedComplexTimestamp = File.GetLastWriteTime(copiedComplexFile);
+                    string copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
+                    copiedComplexTimestamp = File.GetLastWriteTime(copiedComplexFile);
+                }
 
                 // Should have detected the set of client references changed
                 string clientReferenceListPath = task.ClientReferenceListPath();
@@ -740,23 +763,27 @@ namespace OpenRiaServices.Tools.Test
                 Assert.IsTrue(Directory.Exists(generatedCodeOutputFolder), "Expected task to have created " + generatedCodeOutputFolder);
 
                 files = Directory.GetFiles(generatedCodeOutputFolder);
-                Assert.AreEqual(3, files.Length, "Code gen should have generated 3 code files");
+                Assert.AreEqual(expectedNumberOfFiles, files.Length, "Code gen should have generated 3 code files");
 
                 generatedFile = Path.Combine(generatedCodeOutputFolder, "ServerClassLib.g.cs");
                 Assert.IsTrue(File.Exists(generatedFile), "Expected task to have generated " + generatedFile);
                 DateTime generatedTimestamp1 = File.GetLastWriteTime(generatedFile);
 
-                copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
-                Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
-                DateTime copiedTimestamp1 = File.GetLastWriteTime(copiedFile);
+                if (sharedFilesMode == OpenRiaSharedFilesMode.Copy)
+                {
+                    string copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
+                    DateTime copiedTimestamp1 = File.GetLastWriteTime(copiedFile);
 
-                copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
-                Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
-                DateTime copiedComplexTimestamp1 = File.GetLastWriteTime(copiedComplexFile);
+                    string copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
+                    DateTime copiedComplexTimestamp1 = File.GetLastWriteTime(copiedComplexFile);
+
+                    Assert.AreEqual(copiedTimestamp, copiedTimestamp1, "Did not expect 2nd code gen to recopy TestEntity.shared.cs");
+                    Assert.AreEqual(copiedComplexTimestamp, copiedComplexTimestamp1, "Did not expect 2nd code gen to recopy TestComplexType.shared.cs");
+                }
 
                 Assert.AreEqual(generatedTimestamp, generatedTimestamp1, "Did not expect 2nd code gen to regen ServerClassLib.g.cs");
-                Assert.AreEqual(copiedTimestamp, copiedTimestamp1, "Did not expect 2nd code gen to recopy TestEntity.shared.cs");
-                Assert.AreEqual(copiedComplexTimestamp, copiedComplexTimestamp1, "Did not expect 2nd code gen to recopy TestComplexType.shared.cs");
 
                 // Should not have updated the client or server references
                 Assert.IsTrue(File.Exists(serverReferenceListPath), "Expected file for server references");
@@ -778,16 +805,25 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF9")]
         [Description("CreateOpenRiaClientFilesTask regenerates code if list of references changes")]
         [TestMethod]
-        public void CreateRiaClientFiles_Missing_ReferenceList_Regens()
+        public void CreateRiaClientFiles_Missing_ReferenceList_Regens_Copy()
+            => CreateRiaClientFiles_Missing_ReferenceList_Regens(OpenRiaSharedFilesMode.Copy);
+
+        [Description("CreateOpenRiaClientFilesTask regenerates code if list of references changes")]
+        [TestMethod]
+        public void CreateRiaClientFiles_Missing_ReferenceList_Regens_Link()
+            => CreateRiaClientFiles_Missing_ReferenceList_Regens(OpenRiaSharedFilesMode.Link);
+
+        public void CreateRiaClientFiles_Missing_ReferenceList_Regens(OpenRiaSharedFilesMode sharedFilesMode)
         {
             CreateOpenRiaClientFilesTask task = null;
+            int expectedNumberOfFiles = sharedFilesMode == OpenRiaSharedFilesMode.Copy ? 3 : 1;
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF9", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ false);
+                task.SharedFilesMode = sharedFilesMode.ToString();
                 bool success = task.Execute();
                 if (!success)
                 {
@@ -799,17 +835,20 @@ namespace OpenRiaServices.Tools.Test
                 Assert.IsTrue(Directory.Exists(generatedCodeOutputFolder), "Expected task to have created " + generatedCodeOutputFolder);
 
                 string[] files = Directory.GetFiles(generatedCodeOutputFolder);
-                Assert.AreEqual(3, files.Length, "Code gen should have generated 3 code files");
+                Assert.AreEqual(expectedNumberOfFiles, files.Length, "Code gen should have generated 3 code files");
 
                 string generatedFile = Path.Combine(generatedCodeOutputFolder, "ServerClassLib.g.cs");
                 Assert.IsTrue(File.Exists(generatedFile), "Expected task to have generated " + generatedFile);
                 DateTime generatedTimestamp = File.GetLastWriteTime(generatedFile);
 
-                string copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
-                Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
+                if (sharedFilesMode == OpenRiaSharedFilesMode.Copy)
+                {
+                    string copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
 
-                string copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
-                Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
+                    string copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
+                    Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
+                }
 
                 string outputFolder = task.OutputPath;
                 Assert.IsTrue(Directory.Exists(outputFolder), "Expected task to have created " + outputFolder);
@@ -841,17 +880,11 @@ namespace OpenRiaServices.Tools.Test
                 Assert.IsTrue(Directory.Exists(generatedCodeOutputFolder), "Expected task to have created " + generatedCodeOutputFolder);
 
                 files = Directory.GetFiles(generatedCodeOutputFolder);
-                Assert.AreEqual(3, files.Length, "Code gen should have generated 3 code files");
+                Assert.AreEqual(expectedNumberOfFiles, files.Length, "Code gen should have generated 3 code files");
 
                 generatedFile = Path.Combine(generatedCodeOutputFolder, "ServerClassLib.g.cs");
                 Assert.IsTrue(File.Exists(generatedFile), "Expected task to have generated " + generatedFile);
                 DateTime generatedTimestamp1 = File.GetLastWriteTime(generatedFile);
-
-                copiedFile = Path.Combine(generatedCodeOutputFolder, "TestEntity.shared.cs");
-                Assert.IsTrue(File.Exists(copiedFile), "Expected task to have copied " + copiedFile);
-
-                copiedComplexFile = Path.Combine(generatedCodeOutputFolder, "TestComplexType.shared.cs");
-                Assert.IsTrue(File.Exists(copiedComplexFile), "Expected task to have copied " + copiedComplexFile);
 
                 Assert.AreNotEqual(generatedTimestamp, generatedTimestamp1, "Expected 2nd code gen to regen ServerClassLib.g.cs");
             }
@@ -861,7 +894,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "CRCF10")]
         [Description("CreateOpenRiaClientFilesTask purges orphan files and folders on subsequent builds")]
         [TestMethod]
         public void CreateRiaClientFiles_Deletes_Orphan_Files()
@@ -870,7 +902,9 @@ namespace OpenRiaServices.Tools.Test
             string tempSharedFileFolder = CodeGenHelper.GenerateTempFolder();
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("CRCF10", /*includeClientOutputAssembly*/ false);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ false);
+                task.SharedFilesMode = OpenRiaSharedFilesMode.Copy.ToString();
+
                 MockBuildEngine mockBuildEngine = task.BuildEngine as MockBuildEngine;
                 string serverProjectPath = task.ServerProjectPath;
 

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -56,7 +56,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="ProjectPath.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.Tools/Test/SharedSourceFilesTests.cs
+++ b/src/OpenRiaServices.Tools/Test/SharedSourceFilesTests.cs
@@ -18,14 +18,13 @@ namespace OpenRiaServices.Tools.Test
         {
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "SFT")]
         [Description("SharedSourceFiles locates shared types between projects")]
         [TestMethod]
         public void SharedSourceFiles_Types()
         {
             string projectPath = null;
             string outputPath = null;
-            TestHelper.GetProjectPaths("SFT", out projectPath, out outputPath);
+            TestHelper.GetProjectPaths("", out projectPath, out outputPath);
             string clientProjectPath = CodeGenHelper.ClientClassLibProjectPath(projectPath);
             List<string> sourceFiles = CodeGenHelper.ClientClassLibSourceFiles(clientProjectPath);
             ConsoleLogger logger = new ConsoleLogger();
@@ -57,14 +56,13 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "SFT")]
         [Description("SharedSourceFiles locates shared methods between projects")]
         [TestMethod]
         public void SharedSourceFiles_Methods()
         {
             string projectPath = null;
             string outputPath = null;
-            TestHelper.GetProjectPaths("SFT", out projectPath, out outputPath);
+            TestHelper.GetProjectPaths("", out projectPath, out outputPath);
             string clientProjectPath = CodeGenHelper.ClientClassLibProjectPath(projectPath);
             List<string> sourceFiles = CodeGenHelper.ClientClassLibSourceFiles(clientProjectPath);
             ConsoleLogger logger = new ConsoleLogger();

--- a/src/OpenRiaServices.Tools/Test/SharedTypesCodegenTests.cs
+++ b/src/OpenRiaServices.Tools/Test/SharedTypesCodegenTests.cs
@@ -119,7 +119,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem(@"ProjectPath.txt", "STT")]
         [Description("CreateOpenRiaClientFilesTask produces error when detecting existing generated entity")]
         [TestMethod]
         public void SharedTypes_CodeGen_Errors_On_Existing_Generated_Entity()
@@ -128,7 +127,7 @@ namespace OpenRiaServices.Tools.Test
 
             try
             {
-                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("STT", /*includeClientOutputAssembly*/ true);
+                task = CodeGenHelper.CreateOpenRiaClientFilesTaskInstance("", /*includeClientOutputAssembly*/ true);
                 MockBuildEngine mockBuildEngine = task.BuildEngine as MockBuildEngine;
 
                 bool success = task.Execute();

--- a/src/OpenRiaServices.Tools/Test/ValidateDomainServicesTaskTests.cs
+++ b/src/OpenRiaServices.Tools/Test/ValidateDomainServicesTaskTests.cs
@@ -8,12 +8,11 @@ namespace OpenRiaServices.Tools.Test
     [TestClass]
     public class ValidateDomainServicesTaskTests
     {
-        [DeploymentItem(@"ProjectPath.txt", "VDST1")]
         [Description("ValidateDomainServicesTask runs succesfully for a well-formed DomainService")]
         [TestMethod]
         public void ValidateDomainServicesTaskRunsSuccessfully()
         {
-            ValidateDomainServicesTask task = CodeGenHelper.CreateValidateDomainServicesTask("VDST1");
+            ValidateDomainServicesTask task = CodeGenHelper.CreateValidateDomainServicesTask("");
             Assert.IsTrue(task.Execute(),
                 "Validation should have completed without error");
         }

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/MockDomainServices.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/MockDomainServices.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.ServiceModel;
 using OpenRiaServices;
-using OpenRiaServices;
 using OpenRiaServices.EntityFramework;
 using OpenRiaServices.Hosting;
 using OpenRiaServices.Server;

--- a/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml
+++ b/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml
@@ -2,7 +2,7 @@
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:dialog="clr-namespace:OpenRiaServices.VisualStudio.Installer.Dialog"
-        xmlns:local="clr-namespace:OpenRiaServices.DomainServices.Tools"
+        xmlns:local="clr-namespace:OpenRiaServices.Tools"
         Title="Link to Open RIA Services Project"  Initialized="VsDialogWindow_Initialized" SizeToContent="WidthAndHeight" MinWidth="300" MinHeight="150">
     <Grid>
         <Grid.ColumnDefinitions>

--- a/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml
+++ b/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml
@@ -2,6 +2,7 @@
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:dialog="clr-namespace:OpenRiaServices.VisualStudio.Installer.Dialog"
+        xmlns:local="clr-namespace:OpenRiaServices.VisualStudio.Installer"
         Title="Link to Open RIA Services Project"  Initialized="VsDialogWindow_Initialized" SizeToContent="WidthAndHeight" MinWidth="300" MinHeight="150">
     <Grid>
         <Grid.ColumnDefinitions>
@@ -14,6 +15,7 @@
             <RowDefinition />
             <RowDefinition />
             <RowDefinition />
+            <RowDefinition />
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <TextBlock Text="Open RIA Services Link"  Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="10" FontSize="16"/>
@@ -22,6 +24,12 @@
         <CheckBox Grid.Row="2" x:Name="OpenRiaGenerateApplicationContext" Margin="10">Generate WebContext class</CheckBox>
         <CheckBox Grid.Row="3" x:Name="OpenRiaClientUseFullTypeNames" Margin="10">Generate fully qualified type names</CheckBox>
         <CheckBox Grid.Row="4" x:Name="DisableFastUpToDateCheckBox" Margin="10">Disable Fast Up-To-Date Check</CheckBox>
-        <Button Grid.Row="5" Grid.Column="1" Height="20" Click="Button_Click" Margin="10">Save</Button>
+        <ComboBox Grid.Row="5" x:Name="SharedFilesMode" Margin="10" SelectedValuePath="Tag">
+            <ComboBoxItem Tag="{x:Null}">Default</ComboBoxItem>
+            <ComboBoxItem Tag="{x:Static local:OpenRiaSharedFilesMode.Link}">Link</ComboBoxItem>
+            <ComboBoxItem Tag="{x:Static local:OpenRiaSharedFilesMode.Copy}">Copy (old behaviour)</ComboBoxItem>
+        </ComboBox>
+        <TextBlock Grid.Row="5" Grid.Column="1" VerticalAlignment="Center" Text="Shared files" />
+        <Button Grid.Row="6" Grid.Column="1" Height="20" Click="Save_Click" Margin="10">Save</Button>
     </Grid>
 </dialog:VsDialogWindow>

--- a/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml
+++ b/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml
@@ -2,7 +2,7 @@
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:dialog="clr-namespace:OpenRiaServices.VisualStudio.Installer.Dialog"
-        xmlns:local="clr-namespace:OpenRiaServices.VisualStudio.Installer"
+        xmlns:local="clr-namespace:OpenRiaServices.DomainServices.Tools"
         Title="Link to Open RIA Services Project"  Initialized="VsDialogWindow_Initialized" SizeToContent="WidthAndHeight" MinWidth="300" MinHeight="150">
     <Grid>
         <Grid.ColumnDefinitions>

--- a/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml.cs
+++ b/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml.cs
@@ -44,7 +44,6 @@ namespace OpenRiaServices.VisualStudio.Installer.Dialog
         private void VsDialogWindow_Initialized(object sender, System.EventArgs e)
         {
             Dispatcher.VerifyAccess();
-
             var noneComboBoxItem = new ComboBoxItem { DataContext = null, Content = "<No Project Set>" };
             //load our combobox items
             this.Projects.Items.Add(noneComboBoxItem);
@@ -60,8 +59,7 @@ namespace OpenRiaServices.VisualStudio.Installer.Dialog
             this.OpenRiaGenerateApplicationContext.IsChecked = this._linker.OpenRiaGenerateApplicationContext;
             this.OpenRiaClientUseFullTypeNames.IsChecked = this._linker.OpenRiaClientUseFullTypeNames;
             this.DisableFastUpToDateCheckBox.IsChecked = this._linker.DisableFastUpToDateCheck;
-
-
+            this.SharedFilesMode.SelectedValue = this._linker.OpenRiaSharedFilesMode;
             this.Projects.SelectionChanged += new SelectionChangedEventHandler(this.Projects_SelectionChanged);
 
 
@@ -72,7 +70,7 @@ namespace OpenRiaServices.VisualStudio.Installer.Dialog
         }
 
 
-        private void Button_Click(object sender, System.Windows.RoutedEventArgs e)
+        private void Save_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             Dispatcher.VerifyAccess();
 
@@ -90,6 +88,7 @@ namespace OpenRiaServices.VisualStudio.Installer.Dialog
             this._linker.DisableFastUpToDateCheck = this.DisableFastUpToDateCheckBox.IsChecked;
             this._linker.OpenRiaClientUseFullTypeNames = this.OpenRiaClientUseFullTypeNames.IsChecked;
             this._linker.OpenRiaGenerateApplicationContext = this.OpenRiaGenerateApplicationContext.IsChecked;
+            this._linker.OpenRiaSharedFilesMode = (OpenRiaSharedFilesMode?)this.SharedFilesMode.SelectedValue;
 
             _project.Save();
 

--- a/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml.cs
+++ b/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml.cs
@@ -12,7 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using EnvDTE;
-using OpenRiaServices.DomainServices.Tools;
+using OpenRiaServices.Tools;
 using OpenRiaServices.VisualStudio.Installer.Helpers;
 
 namespace OpenRiaServices.VisualStudio.Installer.Dialog

--- a/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml.cs
+++ b/src/VisualStudio/Installer/Dialog/LinkRiaDialogWindow.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using EnvDTE;
+using OpenRiaServices.DomainServices.Tools;
 using OpenRiaServices.VisualStudio.Installer.Helpers;
 
 namespace OpenRiaServices.VisualStudio.Installer.Dialog

--- a/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
+++ b/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Helpers\VsConstants.cs" />
     <Compile Include="Helpers\VSUtility.cs" />
     <Compile Include="OpenRiaServicesPackage.cs" />
+    <Compile Include="OpenRiaSharedFilesMode.cs" />
     <Compile Include="PkgCmdID.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources.Designer.cs">

--- a/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
+++ b/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
@@ -73,7 +73,7 @@
     <PackageReference Include="VSSDK.ComponentModelHost" Version="12.0.4" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\OpenRiaServices.DomainServices.Tools\Framework\OpenRiaSharedFilesMode.cs">
+    <Compile Include="..\..\OpenRiaServices.Tools\Framework\OpenRiaSharedFilesMode.cs">
       <Link>Dialog\OpenRiaSharedFilesMode.cs</Link>
     </Compile>
     <Compile Include="Dialog\LinkRiaDialogWindow.xaml.cs">

--- a/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
+++ b/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
@@ -73,6 +73,9 @@
     <PackageReference Include="VSSDK.ComponentModelHost" Version="12.0.4" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Tools\Framework\OpenRiaSharedFilesMode.cs">
+      <Link>Dialog\OpenRiaSharedFilesMode.cs</Link>
+    </Compile>
     <Compile Include="Dialog\LinkRiaDialogWindow.xaml.cs">
       <DependentUpon>LinkRiaDialogWindow.xaml</DependentUpon>
     </Compile>

--- a/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
+++ b/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
@@ -87,7 +87,6 @@
     <Compile Include="Helpers\VsConstants.cs" />
     <Compile Include="Helpers\VSUtility.cs" />
     <Compile Include="OpenRiaServicesPackage.cs" />
-    <Compile Include="OpenRiaSharedFilesMode.cs" />
     <Compile Include="PkgCmdID.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources.Designer.cs">

--- a/src/VisualStudio/Installer/OpenRiaSharedFilesMode.cs
+++ b/src/VisualStudio/Installer/OpenRiaSharedFilesMode.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenRiaServices.VisualStudio.Installer
+{
+    public enum OpenRiaSharedFilesMode
+    {
+        Link,
+        Copy,
+    }
+
+}

--- a/src/VisualStudio/Installer/OpenRiaSharedFilesMode.cs
+++ b/src/VisualStudio/Installer/OpenRiaSharedFilesMode.cs
@@ -1,9 +1,19 @@
 ﻿namespace OpenRiaServices.VisualStudio.Installer
 {
+    /// <summary>
+    /// Determine how ".shared" files should be handled by code generation
+    /// </summary>
     public enum OpenRiaSharedFilesMode
     {
-        Link,
-        Copy,
+        /// <summary>
+        /// Reference the server version of the file (same as "Add existing file as link")
+        /// </summary>
+        Link = 0,
+
+        /// <summary>
+        /// Copy all shared files and reference copy
+        /// </summary>
+        Copy = 1,
     }
 
 }

--- a/src/VisualStudio/Installer/RiaProjectLinker.cs
+++ b/src/VisualStudio/Installer/RiaProjectLinker.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using EnvDTE;
 using Microsoft.Build.Evaluation;
-using OpenRiaServices.DomainServices.Tools;
+using OpenRiaServices.Tools;
 using OpenRiaServices.VisualStudio.Installer.Helpers;
 using Project = EnvDTE.Project;
 

--- a/src/VisualStudio/Installer/RiaProjectLinker.cs
+++ b/src/VisualStudio/Installer/RiaProjectLinker.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using EnvDTE;
 using Microsoft.Build.Evaluation;
+using OpenRiaServices.DomainServices.Tools;
 using OpenRiaServices.VisualStudio.Installer.Helpers;
 using Project = EnvDTE.Project;
 

--- a/src/VisualStudio/Installer/RiaProjectLinker.cs
+++ b/src/VisualStudio/Installer/RiaProjectLinker.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,6 +15,8 @@ namespace OpenRiaServices.VisualStudio.Installer
         private const string LinkedPropertyName = "LinkedOpenRiaServerProject";
         private const string DisableFastUpToDateCheckPropertyName = "DisableFastUpToDateCheck";
         private const string OpenRiaGenerateApplicationContextPropertyName = "OpenRiaGenerateApplicationContext";
+        private const string OpenRiaSharedFilesModePropertyName = "OpenRiaSharedFilesMode";
+        private const string OpenRiaClientUseFullTypeNamesPropertyName = "OpenRiaClientUseFullTypeNames";
 
         private readonly Project _riaProject;
         private readonly DTE _dte;
@@ -93,12 +96,18 @@ namespace OpenRiaServices.VisualStudio.Installer
         {
             get
             {
-                return GetBooleanProperty(nameof(OpenRiaClientUseFullTypeNames));
+                return GetBooleanProperty(OpenRiaClientUseFullTypeNamesPropertyName);
             }
             set
             {
-                SetBooleanProperty(nameof(OpenRiaClientUseFullTypeNames), value);
+                SetBooleanProperty(OpenRiaClientUseFullTypeNamesPropertyName, value);
             }
+        }
+
+        public OpenRiaSharedFilesMode? OpenRiaSharedFilesMode
+        {
+            get => GetEnumProperty<OpenRiaSharedFilesMode>(OpenRiaSharedFilesModePropertyName);
+            set => SetEnumProperty<OpenRiaSharedFilesMode>(OpenRiaSharedFilesModePropertyName, value);
         }
 
         private bool? GetBooleanProperty(string name)
@@ -131,6 +140,41 @@ namespace OpenRiaServices.VisualStudio.Installer
             else
             {
                 project.SetProperty(name, "true");
+            }
+        }
+
+
+        private TEnum? GetEnumProperty<TEnum>(string name) where TEnum  : struct
+        {
+            var project = this._riaProject.AsMSBuildProject();
+            string value = project.GetProperty(name)?.EvaluatedValue;
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            TEnum result;
+            if (Enum.TryParse(value, true, out result))
+                return result;
+            else
+                return null;
+        }
+
+        private void SetEnumProperty<TEnum>(string name, TEnum? value) where TEnum : struct
+        {
+            var project = this._riaProject.AsMSBuildProject();
+
+            if (value == null)
+            {
+                ProjectProperty projectProperty = project.GetProperty(name);
+                if (projectProperty != null)
+                {
+                    project.RemoveProperty(projectProperty);
+                }
+            }
+            else
+            {
+                project.SetProperty(name, value.ToString());
             }
         }
 


### PR DESCRIPTION
Instead of copying all ".shared" files to the `Generated_Code` folder the server version is referenced instead (much like how "Add Existing Item" -> "Add as Link" works within Visual Studio)
* This should allow faster builds
* Find all references, refactoring, codelens etc should now work as expected for shared files.
* No more "the file is readonly" errors for shared files.

It is possible to opt out of the new behaviour by adding `<OpenRiaSharedFilesMode>Copy</OpenRiaSharedFilesMode>` in the project file (of the client where code generation happens)
* The tooling is updated with the new option

OpenRiaSharedFilesMode

- [x] Add settings to fallback to copying of shared files
- [x ] Document new code generation setting (in wiki)
- [x] Add setting to tooling
- [x] Update unit tests
- [x] Update release notes