### PR TITLE
Make cancellation tests for WebDomainClient less prone to timing issues.

### DIFF
--- a/src/OpenRiaServices.DomainServices.Server/Test/InvokeOperationServerTest.cs
+++ b/src/OpenRiaServices.DomainServices.Server/Test/InvokeOperationServerTest.cs
@@ -51,7 +51,7 @@ namespace OpenRiaServices.DomainServices.Server.Test
             // verify GetOnlineMethods return all the invoke operations on this provider
             IEnumerable<DomainOperationEntry> returnedMethods = description.DomainOperationEntries.Where(p => p.Operation == DomainOperation.Invoke);
             Assert.IsNotNull(returnedMethods);
-            Assert.AreEqual(9, returnedMethods.Count());
+            Assert.AreEqual(10, returnedMethods.Count());
             Assert.IsTrue(returnedMethods.Any(p => p.Name == "Process_EntitiesAndSimpleParams"));
 
             Assert.IsTrue(returnedMethods.Any(p => p.Name == "Process_Return_EntityListParam"));

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.cs
@@ -14,7 +14,6 @@ namespace Cities
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.ComponentModel.DataAnnotations;
-    using System.Diagnostics;
     using System.Linq;
     using System.Runtime.Serialization;
     using System.ServiceModel;
@@ -681,7 +680,6 @@ namespace Cities
         /// </summary>
         /// <param name="delay">The value for the 'delay' parameter of the query.</param>
         /// <returns>An EntityQuery that can be loaded to retrieve <see cref="Zip"/> entity instances.</returns>
-        [DebuggerStepThrough()]
         public EntityQuery<Zip> GetZipsWithDelayQuery(TimeSpan delay)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -810,7 +808,6 @@ namespace Cities
         /// <param name="callback">Callback to invoke when the operation completes.</param>
         /// <param name="userState">Value to pass to the callback.  It can be <c>null</c>.</param>
         /// <returns>An operation instance that can be used to manage the asynchronous request.</returns>
-        [DebuggerStepThrough()]
         public InvokeOperation<string> EchoWithDelay(string msg, TimeSpan delay, Action<InvokeOperation<string>> callback, object userState)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -826,7 +823,6 @@ namespace Cities
         /// <param name="msg">The value for the 'msg' parameter of this action.</param>
         /// <param name="delay">The value for the 'delay' parameter of this action.</param>
         /// <returns>An operation instance that can be used to manage the asynchronous request.</returns>
-        [DebuggerStepThrough()]
         public InvokeOperation<string> EchoWithDelay(string msg, TimeSpan delay)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -843,7 +839,6 @@ namespace Cities
         /// <param name="delay">The value for the 'delay' parameter of this action.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
         /// <returns>An operation instance that can be used to manage the asynchronous request.</returns>
-        [DebuggerStepThrough()]
         public System.Threading.Tasks.Task<InvokeResult<string>> EchoWithDelayAsync(string msg, TimeSpan delay, CancellationToken cancellationToken = default(CancellationToken))
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.cs
@@ -14,6 +14,7 @@ namespace Cities
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.ComponentModel.DataAnnotations;
+    using System.Diagnostics;
     using System.Linq;
     using System.Runtime.Serialization;
     using System.ServiceModel;
@@ -676,6 +677,20 @@ namespace Cities
         }
         
         /// <summary>
+        /// Gets an EntityQuery instance that can be used to load <see cref="Zip"/> entity instances using the 'GetZipsWithDelay' query.
+        /// </summary>
+        /// <param name="delay">The value for the 'delay' parameter of the query.</param>
+        /// <returns>An EntityQuery that can be loaded to retrieve <see cref="Zip"/> entity instances.</returns>
+        [DebuggerStepThrough()]
+        public EntityQuery<Zip> GetZipsWithDelayQuery(TimeSpan delay)
+        {
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("delay", delay);
+            this.ValidateMethod("GetZipsWithDelayQuery", parameters);
+            return base.CreateQuery<Zip>("GetZipsWithDelay", parameters, false, true);
+        }
+        
+        /// <summary>
         /// Invokes the 'AssignCityZone' method of the specified <see cref="City"/> entity.
         /// </summary>
         /// <param name="city">The <see cref="City"/> entity instance.</param>
@@ -785,6 +800,57 @@ namespace Cities
             parameters.Add("msg", msg);
             this.ValidateMethod("Echo", parameters);
             return this.InvokeOperationAsync<string>("Echo", parameters, true, cancellationToken);
+        }
+        
+        /// <summary>
+        /// Asynchronously invokes the 'EchoWithDelay' method of the DomainService.
+        /// </summary>
+        /// <param name="msg">The value for the 'msg' parameter of this action.</param>
+        /// <param name="delay">The value for the 'delay' parameter of this action.</param>
+        /// <param name="callback">Callback to invoke when the operation completes.</param>
+        /// <param name="userState">Value to pass to the callback.  It can be <c>null</c>.</param>
+        /// <returns>An operation instance that can be used to manage the asynchronous request.</returns>
+        [DebuggerStepThrough()]
+        public InvokeOperation<string> EchoWithDelay(string msg, TimeSpan delay, Action<InvokeOperation<string>> callback, object userState)
+        {
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("msg", msg);
+            parameters.Add("delay", delay);
+            this.ValidateMethod("EchoWithDelay", parameters);
+            return this.InvokeOperation<string>("EchoWithDelay", typeof(string), parameters, true, callback, userState);
+        }
+        
+        /// <summary>
+        /// Asynchronously invokes the 'EchoWithDelay' method of the DomainService.
+        /// </summary>
+        /// <param name="msg">The value for the 'msg' parameter of this action.</param>
+        /// <param name="delay">The value for the 'delay' parameter of this action.</param>
+        /// <returns>An operation instance that can be used to manage the asynchronous request.</returns>
+        [DebuggerStepThrough()]
+        public InvokeOperation<string> EchoWithDelay(string msg, TimeSpan delay)
+        {
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("msg", msg);
+            parameters.Add("delay", delay);
+            this.ValidateMethod("EchoWithDelay", parameters);
+            return this.InvokeOperation<string>("EchoWithDelay", typeof(string), parameters, true, null, null);
+        }
+        
+        /// <summary>
+        /// Asynchronously invokes the 'EchoWithDelay' method of the DomainService.
+        /// </summary>
+        /// <param name="msg">The value for the 'msg' parameter of this action.</param>
+        /// <param name="delay">The value for the 'delay' parameter of this action.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+        /// <returns>An operation instance that can be used to manage the asynchronous request.</returns>
+        [DebuggerStepThrough()]
+        public System.Threading.Tasks.Task<InvokeResult<string>> EchoWithDelayAsync(string msg, TimeSpan delay, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("msg", msg);
+            parameters.Add("delay", delay);
+            this.ValidateMethod("EchoWithDelay", parameters);
+            return this.InvokeOperationAsync<string>("EchoWithDelay", parameters, true, cancellationToken);
         }
         
         /// <summary>
@@ -928,6 +994,25 @@ namespace Cities
             /// <param name="result">The IAsyncResult returned from 'BeginEcho'.</param>
             /// <returns>The 'String' returned from the 'Echo' operation.</returns>
             string EndEcho(IAsyncResult result);
+            
+            /// <summary>
+            /// Asynchronously invokes the 'EchoWithDelay' operation.
+            /// </summary>
+            /// <param name="msg">The value for the 'msg' parameter of this action.</param>
+            /// <param name="delay">The value for the 'delay' parameter of this action.</param>
+            /// <param name="callback">Callback to invoke on completion.</param>
+            /// <param name="asyncState">Optional state object.</param>
+            /// <returns>An IAsyncResult that can be used to monitor the request.</returns>
+            [HasSideEffects(true)]
+            [OperationContract(AsyncPattern=true, Action="http://tempuri.org/CityDomainService/EchoWithDelay", ReplyAction="http://tempuri.org/CityDomainService/EchoWithDelayResponse")]
+            IAsyncResult BeginEchoWithDelay(string msg, TimeSpan delay, AsyncCallback callback, object asyncState);
+            
+            /// <summary>
+            /// Completes the asynchronous operation begun by 'BeginEchoWithDelay'.
+            /// </summary>
+            /// <param name="result">The IAsyncResult returned from 'BeginEchoWithDelay'.</param>
+            /// <returns>The 'String' returned from the 'EchoWithDelay' operation.</returns>
+            string EndEchoWithDelay(IAsyncResult result);
             
             /// <summary>
             /// Asynchronously invokes the 'GetCities' operation.
@@ -1152,6 +1237,24 @@ namespace Cities
             /// <param name="result">The IAsyncResult returned from 'BeginGetZipsIfUser'.</param>
             /// <returns>The 'QueryResult' returned from the 'GetZipsIfUser' operation.</returns>
             QueryResult<Zip> EndGetZipsIfUser(IAsyncResult result);
+            
+            /// <summary>
+            /// Asynchronously invokes the 'GetZipsWithDelay' operation.
+            /// </summary>
+            /// <param name="delay">The value for the 'delay' parameter of this action.</param>
+            /// <param name="callback">Callback to invoke on completion.</param>
+            /// <param name="asyncState">Optional state object.</param>
+            /// <returns>An IAsyncResult that can be used to monitor the request.</returns>
+            [HasSideEffects(false)]
+            [OperationContract(AsyncPattern=true, Action="http://tempuri.org/CityDomainService/GetZipsWithDelay", ReplyAction="http://tempuri.org/CityDomainService/GetZipsWithDelayResponse")]
+            IAsyncResult BeginGetZipsWithDelay(TimeSpan delay, AsyncCallback callback, object asyncState);
+            
+            /// <summary>
+            /// Completes the asynchronous operation begun by 'BeginGetZipsWithDelay'.
+            /// </summary>
+            /// <param name="result">The IAsyncResult returned from 'BeginGetZipsWithDelay'.</param>
+            /// <returns>The 'QueryResult' returned from the 'GetZipsWithDelay' operation.</returns>
+            QueryResult<Zip> EndGetZipsWithDelay(IAsyncResult result);
             
             /// <summary>
             /// Asynchronously invokes the 'ResetData' operation.

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.vb
@@ -20,6 +20,7 @@ Imports System
 Imports System.Collections.Generic
 Imports System.ComponentModel
 Imports System.ComponentModel.DataAnnotations
+Imports System.Diagnostics
 Imports System.Linq
 Imports System.Runtime.Serialization
 Imports System.ServiceModel
@@ -618,6 +619,19 @@ Namespace Cities
         End Function
         
         ''' <summary>
+        ''' Gets an EntityQuery instance that can be used to load <see cref="Zip"/> entity instances using the 'GetZipsWithDelay' query.
+        ''' </summary>
+        ''' <param name="delay">The value for the 'delay' parameter of the query.</param>
+        ''' <returns>An EntityQuery that can be loaded to retrieve <see cref="Zip"/> entity instances.</returns>
+        <DebuggerStepThrough()>  _
+        Public Function GetZipsWithDelayQuery(ByVal delay As TimeSpan) As EntityQuery(Of Zip)
+            Dim parameters As Dictionary(Of String, Object) = New Dictionary(Of String, Object)()
+            parameters.Add("delay", delay)
+            Me.ValidateMethod("GetZipsWithDelayQuery", parameters)
+            Return MyBase.CreateQuery(Of Zip)("GetZipsWithDelay", parameters, false, true)
+        End Function
+        
+        ''' <summary>
         ''' Invokes the 'AssignCityZone' method of the specified <see cref="City"/> entity.
         ''' </summary>
         ''' <param name="city">The <see cref="City"/> entity instance.</param>
@@ -717,6 +731,54 @@ Namespace Cities
             parameters.Add("msg", msg)
             Me.ValidateMethod("Echo", parameters)
             Return Me.InvokeOperationAsync(Of String)("Echo", parameters, true, cancellationToken)
+        End Function
+        
+        ''' <summary>
+        ''' Asynchronously invokes the 'EchoWithDelay' method of the DomainService.
+        ''' </summary>
+        ''' <param name="msg">The value for the 'msg' parameter of this action.</param>
+        ''' <param name="delay">The value for the 'delay' parameter of this action.</param>
+        ''' <param name="callback">Callback to invoke when the operation completes.</param>
+        ''' <param name="userState">Value to pass to the callback.  It can be <c>null</c>.</param>
+        ''' <returns>An operation instance that can be used to manage the asynchronous request.</returns>
+        <DebuggerStepThrough()>  _
+        Public Overloads Function EchoWithDelay(ByVal msg As String, ByVal delay As TimeSpan, ByVal callback As Action(Of InvokeOperation(Of String)), ByVal userState As Object) As InvokeOperation(Of String)
+            Dim parameters As Dictionary(Of String, Object) = New Dictionary(Of String, Object)()
+            parameters.Add("msg", msg)
+            parameters.Add("delay", delay)
+            Me.ValidateMethod("EchoWithDelay", parameters)
+            Return Me.InvokeOperation(Of String)("EchoWithDelay", GetType(String), parameters, true, callback, userState)
+        End Function
+        
+        ''' <summary>
+        ''' Asynchronously invokes the 'EchoWithDelay' method of the DomainService.
+        ''' </summary>
+        ''' <param name="msg">The value for the 'msg' parameter of this action.</param>
+        ''' <param name="delay">The value for the 'delay' parameter of this action.</param>
+        ''' <returns>An operation instance that can be used to manage the asynchronous request.</returns>
+        <DebuggerStepThrough()>  _
+        Public Overloads Function EchoWithDelay(ByVal msg As String, ByVal delay As TimeSpan) As InvokeOperation(Of String)
+            Dim parameters As Dictionary(Of String, Object) = New Dictionary(Of String, Object)()
+            parameters.Add("msg", msg)
+            parameters.Add("delay", delay)
+            Me.ValidateMethod("EchoWithDelay", parameters)
+            Return Me.InvokeOperation(Of String)("EchoWithDelay", GetType(String), parameters, true, Nothing, Nothing)
+        End Function
+        
+        ''' <summary>
+        ''' Asynchronously invokes the 'EchoWithDelay' method of the DomainService.
+        ''' </summary>
+        ''' <param name="msg">The value for the 'msg' parameter of this action.</param>
+        ''' <param name="delay">The value for the 'delay' parameter of this action.</param>
+        ''' <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+        ''' <returns>An operation instance that can be used to manage the asynchronous request.</returns>
+        <DebuggerStepThrough()>  _
+        Public Function EchoWithDelayAsync(ByVal msg As String, ByVal delay As TimeSpan, Optional ByVal cancellationToken As CancellationToken = Nothing) As System.Threading.Tasks.Task(Of InvokeResult(Of String))
+            Dim parameters As Dictionary(Of String, Object) = New Dictionary(Of String, Object)()
+            parameters.Add("msg", msg)
+            parameters.Add("delay", delay)
+            Me.ValidateMethod("EchoWithDelay", parameters)
+            Return Me.InvokeOperationAsync(Of String)("EchoWithDelay", parameters, true, cancellationToken)
         End Function
         
         ''' <summary>
@@ -849,6 +911,25 @@ Namespace Cities
             ''' <param name="result">The IAsyncResult returned from 'BeginEcho'.</param>
             ''' <returns>The 'String' returned from the 'Echo' operation.</returns>
             Function EndEcho(ByVal result As IAsyncResult) As String
+            
+            ''' <summary>
+            ''' Asynchronously invokes the 'EchoWithDelay' operation.
+            ''' </summary>
+            ''' <param name="msg">The value for the 'msg' parameter of this action.</param>
+            ''' <param name="delay">The value for the 'delay' parameter of this action.</param>
+            ''' <param name="callback">Callback to invoke on completion.</param>
+            ''' <param name="asyncState">Optional state object.</param>
+            ''' <returns>An IAsyncResult that can be used to monitor the request.</returns>
+            <HasSideEffects(true),  _
+             OperationContract(AsyncPattern:=true, Action:="http://tempuri.org/CityDomainService/EchoWithDelay", ReplyAction:="http://tempuri.org/CityDomainService/EchoWithDelayResponse")>  _
+            Function BeginEchoWithDelay(ByVal msg As String, ByVal delay As TimeSpan, ByVal callback As AsyncCallback, ByVal asyncState As Object) As IAsyncResult
+            
+            ''' <summary>
+            ''' Completes the asynchronous operation begun by 'BeginEchoWithDelay'.
+            ''' </summary>
+            ''' <param name="result">The IAsyncResult returned from 'BeginEchoWithDelay'.</param>
+            ''' <returns>The 'String' returned from the 'EchoWithDelay' operation.</returns>
+            Function EndEchoWithDelay(ByVal result As IAsyncResult) As String
             
             ''' <summary>
             ''' Asynchronously invokes the 'GetCities' operation.
@@ -1073,6 +1154,24 @@ Namespace Cities
             ''' <param name="result">The IAsyncResult returned from 'BeginGetZipsIfUser'.</param>
             ''' <returns>The 'QueryResult' returned from the 'GetZipsIfUser' operation.</returns>
             Function EndGetZipsIfUser(ByVal result As IAsyncResult) As QueryResult(Of Zip)
+            
+            ''' <summary>
+            ''' Asynchronously invokes the 'GetZipsWithDelay' operation.
+            ''' </summary>
+            ''' <param name="delay">The value for the 'delay' parameter of this action.</param>
+            ''' <param name="callback">Callback to invoke on completion.</param>
+            ''' <param name="asyncState">Optional state object.</param>
+            ''' <returns>An IAsyncResult that can be used to monitor the request.</returns>
+            <HasSideEffects(false),  _
+             OperationContract(AsyncPattern:=true, Action:="http://tempuri.org/CityDomainService/GetZipsWithDelay", ReplyAction:="http://tempuri.org/CityDomainService/GetZipsWithDelayResponse")>  _
+            Function BeginGetZipsWithDelay(ByVal delay As TimeSpan, ByVal callback As AsyncCallback, ByVal asyncState As Object) As IAsyncResult
+            
+            ''' <summary>
+            ''' Completes the asynchronous operation begun by 'BeginGetZipsWithDelay'.
+            ''' </summary>
+            ''' <param name="result">The IAsyncResult returned from 'BeginGetZipsWithDelay'.</param>
+            ''' <returns>The 'QueryResult' returned from the 'GetZipsWithDelay' operation.</returns>
+            Function EndGetZipsWithDelay(ByVal result As IAsyncResult) As QueryResult(Of Zip)
             
             ''' <summary>
             ''' Asynchronously invokes the 'ResetData' operation.

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.vb
@@ -20,7 +20,6 @@ Imports System
 Imports System.Collections.Generic
 Imports System.ComponentModel
 Imports System.ComponentModel.DataAnnotations
-Imports System.Diagnostics
 Imports System.Linq
 Imports System.Runtime.Serialization
 Imports System.ServiceModel
@@ -623,7 +622,6 @@ Namespace Cities
         ''' </summary>
         ''' <param name="delay">The value for the 'delay' parameter of the query.</param>
         ''' <returns>An EntityQuery that can be loaded to retrieve <see cref="Zip"/> entity instances.</returns>
-        <DebuggerStepThrough()>  _
         Public Function GetZipsWithDelayQuery(ByVal delay As TimeSpan) As EntityQuery(Of Zip)
             Dim parameters As Dictionary(Of String, Object) = New Dictionary(Of String, Object)()
             parameters.Add("delay", delay)
@@ -741,7 +739,6 @@ Namespace Cities
         ''' <param name="callback">Callback to invoke when the operation completes.</param>
         ''' <param name="userState">Value to pass to the callback.  It can be <c>null</c>.</param>
         ''' <returns>An operation instance that can be used to manage the asynchronous request.</returns>
-        <DebuggerStepThrough()>  _
         Public Overloads Function EchoWithDelay(ByVal msg As String, ByVal delay As TimeSpan, ByVal callback As Action(Of InvokeOperation(Of String)), ByVal userState As Object) As InvokeOperation(Of String)
             Dim parameters As Dictionary(Of String, Object) = New Dictionary(Of String, Object)()
             parameters.Add("msg", msg)
@@ -756,7 +753,6 @@ Namespace Cities
         ''' <param name="msg">The value for the 'msg' parameter of this action.</param>
         ''' <param name="delay">The value for the 'delay' parameter of this action.</param>
         ''' <returns>An operation instance that can be used to manage the asynchronous request.</returns>
-        <DebuggerStepThrough()>  _
         Public Overloads Function EchoWithDelay(ByVal msg As String, ByVal delay As TimeSpan) As InvokeOperation(Of String)
             Dim parameters As Dictionary(Of String, Object) = New Dictionary(Of String, Object)()
             parameters.Add("msg", msg)
@@ -772,7 +768,6 @@ Namespace Cities
         ''' <param name="delay">The value for the 'delay' parameter of this action.</param>
         ''' <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
         ''' <returns>An operation instance that can be used to manage the asynchronous request.</returns>
-        <DebuggerStepThrough()>  _
         Public Function EchoWithDelayAsync(ByVal msg As String, ByVal delay As TimeSpan, Optional ByVal cancellationToken As CancellationToken = Nothing) As System.Threading.Tasks.Task(Of InvokeResult(Of String))
             Dim parameters As Dictionary(Of String, Object) = New Dictionary(Of String, Object)()
             parameters.Add("msg", msg)

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
@@ -293,7 +293,7 @@ namespace Cities
         }
 
         [Invoke]
-        public async Task<string> EchoWithDelay(string msg, TimeSpan delay)
+        public async Task<string> EchoWithDelayAsync(string msg, TimeSpan delay)
         {
             // This method is used to test cancellation of invoke operations
             // Since the method might return to soon otherwise we add a delay

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.ServiceModel;
-using OpenRiaServices;
+using System.Threading.Tasks;
 using OpenRiaServices.DomainServices;
 using OpenRiaServices.DomainServices.Hosting;
 using OpenRiaServices.DomainServices.Server;
@@ -121,6 +121,15 @@ namespace Cities
         }
 
         [Query]
+        public async Task<IQueryable<Zip>> GetZipsWithDelay(TimeSpan delay)
+        {
+            // This method is used to test cancellation of query operations
+            // Since the method might return to soon otherwise we add a delay
+            await Task.Delay(delay, ServiceContext.CancellationToken);
+            return GetZips();
+        }
+
+        [Query]
         [RequiresAuthentication]
         public IQueryable<Zip> GetZipsIfAuthenticated()
         {
@@ -195,7 +204,6 @@ namespace Cities
         }
         #endregion
 
-#pragma warning disable 618 // Service should work with the "old" approach with [EntityAction]
         #region Domain Methods
         [EntityAction]
         [CustomValidation(typeof(CityMethodValidator), "ValidateMethod")]
@@ -284,6 +292,15 @@ namespace Cities
             return "Echo: " + msg;
         }
 
+        [Invoke]
+        public async Task<string> EchoWithDelay(string msg, TimeSpan delay)
+        {
+            // This method is used to test cancellation of invoke operations
+            // Since the method might return to soon otherwise we add a delay
+            await Task.Delay(delay, ServiceContext.CancellationToken);
+            return Echo(msg);
+        }
+
         // This service operation is invoked to reset any static data
         // we retain across instances
         [Invoke]
@@ -345,7 +362,6 @@ namespace Cities
             city.EditHistory = "touch=" + touchString;
         }
         #endregion //Derived CUD/Custom/Service methods
-#pragma warning restore 618
     }
 
     /// <summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/UnitTestBase.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/UnitTestBase.cs
@@ -376,14 +376,14 @@ namespace OpenRiaServices.Silverlight.Testing
 
         public void EnqueueConditional(Func<bool> conditionalDelegate, int timeoutInSeconds, string timeoutMessage)
         {
-            DateTime endTime = DateTime.Now.AddSeconds(timeoutInSeconds);
+            DateTime endTime = DateTime.UtcNow.AddSeconds(timeoutInSeconds);
 
             this.Enqueue(
                 () =>
                 {
                     while (!conditionalDelegate())
                     {
-                        if (DateTime.Now >= endTime)
+                        if (DateTime.UtcNow >= endTime)
                         {
                             UnitTestBase.NumberOfTimeouts++;
                             Assert.Fail(UnitTestBase.ComposeTimeoutMessage(timeoutInSeconds, timeoutMessage));


### PR DESCRIPTION
* Add a built in delay to Query and Invoke used by cancellation tests so that the operations will not complete before we start to cancel the requests
* Use UtcNow instead of Now for comparing time in EnqueueConditional

Should be able to fix test failure preventing merge of #226 
