### PR TITLE
Update nuget packages

### DIFF
--- a/NuGet/OpenRiaServices.Client.Core.nuspec
+++ b/NuGet/OpenRiaServices.Client.Core.nuspec
@@ -20,8 +20,8 @@
     <dependencies>
       <group targetFramework="net46" />
       <group targetFramework="netstandard2.0">
-        <dependency id="System.ComponentModel.Annotations" version="4.6.0" />
-		<dependency id="System.ServiceModel.Http" version="4.6.0" />
+        <dependency id="System.ComponentModel.Annotations" version="4.7.0" />
+        <dependency id="System.ServiceModel.Http" version="4.7.0" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/NuGet/OpenRiaServices.EntityFramework.nuspec
+++ b/NuGet/OpenRiaServices.EntityFramework.nuspec
@@ -20,7 +20,7 @@
     <language>en-US</language>
     <tags>WCF RIA Services RIAServices EntityFramework CodeFirst OpenRIAServices</tags>
     <dependencies>
-      <dependency id="EntityFramework" version="6.0.1" />
+      <dependency id="EntityFramework" version="6.4.4" />
       <dependency id="OpenRiaServices.Server" version="$version$"/>
     </dependencies>
   </metadata>

--- a/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
+++ b/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
@@ -26,7 +26,7 @@
     </frameworkAssemblies>	
 	<dependencies>
 		<group targetFramework="net46">
-			<dependency id="System.Threading.Tasks.Extensions" version="4.5.3"/>
+			<dependency id="System.Threading.Tasks.Extensions" version="4.5.4"/>
 		</group>
 	</dependencies>
   </metadata>

--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.ServiceModel.Http" Version="4.6.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/OpenRiaServices.DomainServices.Client/Framework/OpenRiaServices.DomainServices.Client.csproj
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/OpenRiaServices.DomainServices.Client.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.External.Test/OpenRiaServices.DomainServices.Client.External.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.External.Test/OpenRiaServices.DomainServices.Client.External.Test.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/OpenRiaServices.DomainServices.Client.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/OpenRiaServices.DomainServices.Client.Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Vb.Test/OpenRiaServices.DomainServices.Client.Vb.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Vb.Test/OpenRiaServices.DomainServices.Client.Vb.Test.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>OpenRiaServices.DomainServices.Client.Test</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/OpenRiaServices.DomainServices.EntityFramework.csproj
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/OpenRiaServices.DomainServices.EntityFramework.csproj
@@ -5,7 +5,7 @@
     <DefineConstants>$(DefineConstants);SERVERFX;DBCONTEXT;NET46;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Test/CodeFirstModel/EFCodeFirstModels.csproj
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Test/CodeFirstModel/EFCodeFirstModels.csproj
@@ -12,7 +12,7 @@
     <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Test/DbContextModel/EFDbContextModels.csproj
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Test/DbContextModel/EFDbContextModels.csproj
@@ -11,7 +11,7 @@
     <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/OpenRiaServices.DomainServices.Hosting.Endpoint/Test/OpenRiaServices.DomainServices.Hosting.Endpoint.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.Endpoint/Test/OpenRiaServices.DomainServices.Hosting.Endpoint.Test.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Hosting.Local/Test/OpenRiaServices.DomainServices.Hosting.Local.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.Local/Test/OpenRiaServices.DomainServices.Hosting.Local.Test.csproj
@@ -8,7 +8,7 @@
     <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Test/OpenRiaServices.DomainServices.Hosting.OData.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Test/OpenRiaServices.DomainServices.Hosting.OData.Test.csproj
@@ -14,7 +14,7 @@
     </EntityDeploy>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Hosting/Test/OpenRiaServices.DomainServices.Hosting.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting/Test/OpenRiaServices.DomainServices.Hosting.Test.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.DomainServices.Hosting/Test/OpenRiaServices.DomainServices.Hosting.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting/Test/OpenRiaServices.DomainServices.Hosting.Test.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.Test.csproj
@@ -11,7 +11,7 @@
     <Compile Include="..\..\OpenRiaServices.DomainServices.Server\Test\MockDataService.cs" Link="Shared\MockDataService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Server/Framework/OpenRiaServices.DomainServices.Server.csproj
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/OpenRiaServices.DomainServices.Server.csproj
@@ -49,6 +49,6 @@
     <Compile Condition=" '$(RunCodeAnalysis)' != 'true' " Remove="GlobalSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 </Project>

--- a/src/OpenRiaServices.DomainServices.Server/Test/OpenRiaServices.DomainServices.Server.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Server/Test/OpenRiaServices.DomainServices.Server.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Server/Test/OpenRiaServices.DomainServices.Server.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Server/Test/OpenRiaServices.DomainServices.Server.Test.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/OpenRiaServices.DomainServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/OpenRiaServices.DomainServices.Tools.TextTemplate.Test.csproj
@@ -47,7 +47,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" ExcludeAssets="runtime" />

--- a/src/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/OpenRiaServices.DomainServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools.TextTemplate/Test/OpenRiaServices.DomainServices.Tools.TextTemplate.Test.csproj
@@ -53,11 +53,11 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 </Project>

--- a/src/OpenRiaServices.DomainServices.Tools/Framework/OpenRiaServices.DomainServices.Tools.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Framework/OpenRiaServices.DomainServices.Tools.csproj
@@ -55,6 +55,6 @@
     <Content Include="Pdb\ReadMe.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.2" />
   </ItemGroup>
 </Project>

--- a/src/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
@@ -7,7 +7,7 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />

--- a/src/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/OpenRiaServices.DomainServices.Tools.Test.csproj
@@ -9,13 +9,13 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.2.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.7.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.DomainServices.Tools/Test/TestWap/TestWap.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/TestWap/TestWap.csproj
@@ -108,7 +108,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Extensions">
-      <Version>4.5.3</Version>
+      <Version>4.5.4</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/Test/Desktop/EFPOCOModels/EFPOCOModels.csproj
+++ b/src/Test/Desktop/EFPOCOModels/EFPOCOModels.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/OpenRiaServices.Common.DomainServices.Test.csproj
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/OpenRiaServices.Common.DomainServices.Test.csproj
@@ -6,7 +6,7 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
+++ b/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
@@ -137,7 +137,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework">
-      <Version>6.2.0</Version>
+      <Version>6.4.4</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/src/VisualStudio/Installer/Helpers/FilesystemExtensions.cs
+++ b/src/VisualStudio/Installer/Helpers/FilesystemExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
 
@@ -69,15 +68,20 @@ namespace OpenRiaServices.VisualStudio.Installer.Helpers
         }
 
 
-
-        public static string AbsolutePathFrom(this string relativePath, string currentDirectory, IFileSystem fileSystem)
+        /// <summary>
+        /// Get you an absolute path from a relativePath
+        /// </summary>
+        /// <param name="relativePath"></param>
+        /// <param name="currentDirectory"></param>
+        /// <returns></returns>
+        public static string AbsolutePathFrom(this string relativePath, string currentDirectory)
         {
-            if (fileSystem.Path.IsPathRooted(relativePath))
+            if (Path.IsPathRooted(relativePath))
             {
                 return relativePath;
             }
 
-            currentDirectory = fileSystem.Path.GetFullPath(currentDirectory);
+            currentDirectory = Path.GetFullPath(currentDirectory);
             var driveletterAndColon = currentDirectory.Substring(0, 2);
             currentDirectory = currentDirectory.Remove(0, 3);
 
@@ -103,17 +107,6 @@ namespace OpenRiaServices.VisualStudio.Installer.Helpers
 
             return
                 finalDirectoryPathPart.Reverse().Aggregate(new StringBuilder(driveletterAndColon), (sb, s) => sb.Append("\\").Append(s)).ToString();
-        }
-
-        /// <summary>
-        /// Get you an absolute path from a relativePath
-        /// </summary>
-        /// <param name="relativePath"></param>
-        /// <param name="currentDirectory"></param>
-        /// <returns></returns>
-        public static string AbsolutePathFrom(this string relativePath, string currentDirectory)
-        {
-            return AbsolutePathFrom(relativePath, currentDirectory, new FileSystem());
         }
     }
 

--- a/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
+++ b/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
@@ -65,7 +65,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Abstractions" Version="1.4.0.81" />
     <PackageReference Include="VSSDK.ComponentModelHost" Version="12.0.4" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudio/Tools/Framework/OpenRiaServices.VisualStudio.DomainServices.Tools.csproj
+++ b/src/VisualStudio/Tools/Framework/OpenRiaServices.VisualStudio.DomainServices.Tools.csproj
@@ -31,7 +31,7 @@
     <DefineConstants Condition="'$(VsVersion)' == '16.0'">$(DefineConstants);VS16</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="EnvDTE80" Version="8.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces.9.0" Version="9.0.30730" />
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces.WCF" Version="9.0.21023" />

--- a/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
+++ b/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
@@ -14,7 +14,7 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
+++ b/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
@@ -13,7 +13,7 @@
     <WriteLinesToFile File="DomainServiceToolsPath.txt" Lines="$(MSBuildProjectFullPath)" Overwrite="true" WriteOnlyWhenDifferent="true" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* Update nuget dependencies to latest version
  * EF 6.4.4 will allow us to add netstandard2.1 compatibility if we want to
  * Cecil might provide better performance for code generation
  * Update "System" nuget packages from 4.6 -> 4.7