### PR TITLE
Upgrade all projects to net 4.7.2

### DIFF
--- a/NuGet/OpenRiaServices.Client.CodeGen/OpenRiaServices.Client.CodeGen.nuspec
+++ b/NuGet/OpenRiaServices.Client.CodeGen/OpenRiaServices.Client.CodeGen.nuspec
@@ -22,7 +22,7 @@
     </metadata>
     <files>
         <file src="build\OpenRiaServices.CodeGen.targets" target="build\OpenRiaServices.Client.CodeGen.targets"/>
-        <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Tools.dll" target="build\OpenRiaServices.DomainServices.Tools.dll"/>
-        <file src="..\..\src\bin\Release\net46\Mono.Cecil.dll" target="build\Mono.Cecil.dll"/>
+        <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Tools.dll" target="build\OpenRiaServices.DomainServices.Tools.dll"/>
+        <file src="..\..\src\bin\Release\net472\Mono.Cecil.dll" target="build\Mono.Cecil.dll"/>
     </files>
 </package>

--- a/NuGet/OpenRiaServices.Client.Core.nuspec
+++ b/NuGet/OpenRiaServices.Client.Core.nuspec
@@ -18,17 +18,17 @@
     <language>en-US</language>
     <tags>WCF RIA Services RIAServices Silverlight OpenRiaServices</tags>
     <dependencies>
-      <group targetFramework="net46" />
+      <group targetFramework="net472" />
       <group targetFramework="netstandard2.0">
         <dependency id="System.ComponentModel.Annotations" version="4.7.0" />
-        <dependency id="System.ServiceModel.Http" version="4.7.0" />
+		<dependency id="System.ServiceModel.Http" version="4.7.0" />
       </group>
     </dependencies>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework="net46" />
-      <frameworkAssembly assemblyName="System.Runtime.Serialization" targetFramework="net46" />
-      <frameworkAssembly assemblyName="System.ServiceModel" targetFramework="net46" />
-      <frameworkAssembly assemblyName="System.ServiceModel.Web" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.Runtime.Serialization" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.ServiceModel" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.ServiceModel.Web" targetFramework="net472" />
     </frameworkAssemblies>
   </metadata>
   <files>
@@ -41,11 +41,11 @@
     <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.DomainServices.Client.Web.xml" target="lib\netstandard2.0\OpenRiaServices.DomainServices.Client.Web.xml" />
 
    <!-- Desktop binaries -->
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Client.dll" target="lib\net46\OpenRiaServices.DomainServices.Client.dll" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Client.pdb" target="lib\net46\OpenRiaServices.DomainServices.Client.pdb" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Client.xml" target="lib\net46\OpenRiaServices.DomainServices.Client.xml" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Client.Web.dll" target="lib\net46\OpenRiaServices.DomainServices.Client.Web.dll" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Client.Web.pdb" target="lib\net46\OpenRiaServices.DomainServices.Client.Web.pdb" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Client.Web.xml" target="lib\net46\OpenRiaServices.DomainServices.Client.Web.xml" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Client.dll" target="lib\net472\OpenRiaServices.DomainServices.Client.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Client.pdb" target="lib\net472\OpenRiaServices.DomainServices.Client.pdb" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Client.xml" target="lib\net472\OpenRiaServices.DomainServices.Client.xml" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Client.Web.dll" target="lib\net472\OpenRiaServices.DomainServices.Client.Web.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Client.Web.pdb" target="lib\net472\OpenRiaServices.DomainServices.Client.Web.pdb" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Client.Web.xml" target="lib\net472\OpenRiaServices.DomainServices.Client.Web.xml" />
   </files>
 </package>

--- a/NuGet/OpenRiaServices.Endpoints/OpenRiaServices.Endpoints.nuspec
+++ b/NuGet/OpenRiaServices.Endpoints/OpenRiaServices.Endpoints.nuspec
@@ -26,8 +26,8 @@
   </metadata>
   <files>
     <file src="content\web.config.transform" target="content\web.config.transform" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.Endpoint.dll" target="lib\net46\OpenRiaServices.DomainServices.Hosting.Endpoint.dll" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.Endpoint.pdb" target="lib\net46\OpenRiaServices.DomainServices.Hosting.Endpoint.pdb" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.Endpoint.xml" target="lib\net46\OpenRiaServices.DomainServices.Hosting.Endpoint.xml" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.Endpoint.dll" target="lib\net472\OpenRiaServices.DomainServices.Hosting.Endpoint.dll" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.Endpoint.pdb" target="lib\net472\OpenRiaServices.DomainServices.Hosting.Endpoint.pdb" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.Endpoint.xml" target="lib\net472\OpenRiaServices.DomainServices.Hosting.Endpoint.xml" />
   </files>
 </package>

--- a/NuGet/OpenRiaServices.EntityFramework.nuspec
+++ b/NuGet/OpenRiaServices.EntityFramework.nuspec
@@ -25,8 +25,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.EntityFramework.dll" target="lib\net46\OpenRiaServices.DomainServices.EntityFramework.dll" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.EntityFramework.pdb" target="lib\net46\OpenRiaServices.DomainServices.EntityFramework.pdb" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.EntityFramework.xml" target="lib\net46\OpenRiaServices.DomainServices.EntityFramework.xml" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.EntityFramework.dll" target="lib\net472\OpenRiaServices.DomainServices.EntityFramework.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.EntityFramework.pdb" target="lib\net472\OpenRiaServices.DomainServices.EntityFramework.pdb" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.EntityFramework.xml" target="lib\net472\OpenRiaServices.DomainServices.EntityFramework.xml" />
   </files>
 </package>

--- a/NuGet/OpenRiaServices.LinqToSql.nuspec
+++ b/NuGet/OpenRiaServices.LinqToSql.nuspec
@@ -23,8 +23,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.LinqToSql.dll" target="lib\net46\OpenRiaServices.DomainServices.LinqToSql.dll" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.LinqToSql.pdb" target="lib\net46\OpenRiaServices.DomainServices.LinqToSql.pdb" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.LinqToSql.xml" target="lib\net46\OpenRiaServices.DomainServices.LinqToSql.xml" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.LinqToSql.dll" target="lib\net472\OpenRiaServices.DomainServices.LinqToSql.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.LinqToSql.pdb" target="lib\net472\OpenRiaServices.DomainServices.LinqToSql.pdb" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.LinqToSql.xml" target="lib\net472\OpenRiaServices.DomainServices.LinqToSql.xml" />
   </files>
 </package>

--- a/NuGet/OpenRiaServices.OData/OpenRiaServices.OData.nuspec
+++ b/NuGet/OpenRiaServices.OData/OpenRiaServices.OData.nuspec
@@ -28,8 +28,8 @@
   </metadata>
   <files>
     <file src="content\web.config.transform" target="content\web.config.transform" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.OData.dll" target="lib\net46\OpenRiaServices.DomainServices.Hosting.OData.dll" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.OData.pdb" target="lib\net46\OpenRiaServices.DomainServices.Hosting.OData.pdb" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.OData.xml" target="lib\net46\OpenRiaServices.DomainServices.Hosting.OData.xml" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.OData.dll" target="lib\net472\OpenRiaServices.DomainServices.Hosting.OData.dll" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.OData.pdb" target="lib\net472\OpenRiaServices.DomainServices.Hosting.OData.pdb" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.OData.xml" target="lib\net472\OpenRiaServices.DomainServices.Hosting.OData.xml" />
   </files>
 </package>

--- a/NuGet/OpenRiaServices.Server.Authentication.AspNetMembership.nuspec
+++ b/NuGet/OpenRiaServices.Server.Authentication.AspNetMembership.nuspec
@@ -24,14 +24,14 @@ Common Types:
     <language>en-US</language>
     <tags>WCF RIA Services RIAServices Server aspnet OpenRiaServices Authentication Membership</tags>
 	<dependencies>
-		<group targetFramework="net46">
+		<group targetFramework="net472">
 			<dependency id="OpenRiaServices.Server" version="$version$"/>
 		</group>
 	</dependencies>
   </metadata>
   <files>
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.dll" target="lib\net46\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.dll" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.pdb" target="lib\net46\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.pdb" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.xml" target="lib\net46\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.xml" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.dll" target="lib\net472\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.pdb" target="lib\net472\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.pdb" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.xml" target="lib\net472\OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.xml" />
     </files>
 </package>

--- a/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
+++ b/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
@@ -22,10 +22,10 @@
     <language>en-US</language>
     <tags>WCF RIA Services RIAServices Server aspnet OpenRiaServices</tags>
     <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework="net46" />
+      <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework="net472" />
     </frameworkAssemblies>	
 	<dependencies>
-		<group targetFramework="net46">
+		<group targetFramework="net472">
 			<dependency id="System.Threading.Tasks.Extensions" version="4.5.4"/>
 		</group>
 	</dependencies>
@@ -34,12 +34,12 @@
     <file src="content\web.config.transform" target="content\web.config.transform" />
     <file src="tools\Install.ps1" target="tools\Install.ps1" />
     <file src="build\OpenRiaServices.Server.targets" target="build\OpenRiaServices.Server.targets" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Tools.dll" target="build\OpenRiaServices.DomainServices.Tools.dll" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.dll" target="lib\net46\OpenRiaServices.DomainServices.Hosting.dll" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.pdb" target="lib\net46\OpenRiaServices.DomainServices.Hosting.pdb" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Hosting.xml" target="lib\net46\OpenRiaServices.DomainServices.Hosting.xml" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.dll" target="lib\net46\OpenRiaServices.DomainServices.Server.dll" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.pdb" target="lib\net46\OpenRiaServices.DomainServices.Server.pdb" />
-    <file src="..\..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.xml" target="lib\net46\OpenRiaServices.DomainServices.Server.xml" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Tools.dll" target="build\OpenRiaServices.DomainServices.Tools.dll" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.dll" target="lib\net472\OpenRiaServices.DomainServices.Hosting.dll" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.pdb" target="lib\net472\OpenRiaServices.DomainServices.Hosting.pdb" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Hosting.xml" target="lib\net472\OpenRiaServices.DomainServices.Hosting.xml" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.dll" target="lib\net472\OpenRiaServices.DomainServices.Server.dll" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.pdb" target="lib\net472\OpenRiaServices.DomainServices.Server.pdb" />
+    <file src="..\..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.xml" target="lib\net472\OpenRiaServices.DomainServices.Server.xml" />
     </files>
 </package>

--- a/NuGet/OpenRiaServices.T4.nuspec
+++ b/NuGet/OpenRiaServices.T4.nuspec
@@ -21,11 +21,11 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Tools.TextTemplate.dll" target="lib\net46\OpenRiaServices.DomainServices.Tools.TextTemplate.dll" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Tools.TextTemplate.pdb" target="lib\net46\OpenRiaServices.DomainServices.Tools.TextTemplate.pdb" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Tools.TextTemplate.xml" target="lib\net46\OpenRiaServices.DomainServices.Tools.TextTemplate.xml" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Tools.dll" target="lib\net46\OpenRiaServices.DomainServices.Tools.dll" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Tools.pdb" target="lib\net46\OpenRiaServices.DomainServices.Tools.pdb" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Tools.xml" target="lib\net46\OpenRiaServices.DomainServices.Tools.xml" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Tools.TextTemplate.dll" target="lib\net472\OpenRiaServices.DomainServices.Tools.TextTemplate.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Tools.TextTemplate.pdb" target="lib\net472\OpenRiaServices.DomainServices.Tools.TextTemplate.pdb" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Tools.TextTemplate.xml" target="lib\net472\OpenRiaServices.DomainServices.Tools.TextTemplate.xml" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Tools.dll" target="lib\net472\OpenRiaServices.DomainServices.Tools.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Tools.pdb" target="lib\net472\OpenRiaServices.DomainServices.Tools.pdb" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Tools.xml" target="lib\net472\OpenRiaServices.DomainServices.Tools.xml" />
   </files>
 </package>

--- a/NuGet/OpenRiaServices.UnitTesting.nuspec
+++ b/NuGet/OpenRiaServices.UnitTesting.nuspec
@@ -20,8 +20,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.UnitTesting.dll" target="lib\net46\OpenRiaServices.DomainServices.Server.UnitTesting.dll" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.UnitTesting.pdb" target="lib\net46\OpenRiaServices.DomainServices.Server.UnitTesting.pdb" />
-    <file src="..\src\bin\Release\net46\OpenRiaServices.DomainServices.Server.UnitTesting.xml" target="lib\net46\OpenRiaServices.DomainServices.Server.UnitTesting.xml" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.UnitTesting.dll" target="lib\net472\OpenRiaServices.DomainServices.Server.UnitTesting.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.UnitTesting.pdb" target="lib\net472\OpenRiaServices.DomainServices.Server.UnitTesting.pdb" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.DomainServices.Server.UnitTesting.xml" target="lib\net472\OpenRiaServices.DomainServices.Server.UnitTesting.xml" />
   </files>
 </package>

--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>4.0.0</VersionPrefix>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <PackageTags>WCF;RIA;Services;RIAServices;Silverlight;OpenRiaServices</PackageTags>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -12,7 +12,7 @@
     <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/OpenRiaServices.DomainServices.Client/Framework/OpenRiaServices.DomainServices.Client.csproj
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/OpenRiaServices.DomainServices.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>4.0.0</VersionPrefix>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="PresentationFramework" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data.Linq" />
@@ -53,7 +53,7 @@
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <DefineConstants>$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
   </PropertyGroup>
 

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.External.Test/OpenRiaServices.DomainServices.Client.External.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.External.Test/OpenRiaServices.DomainServices.Client.External.Test.csproj
@@ -3,7 +3,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>S.SM.DS.Client.External.Text</RootNamespace>
     <AssemblyName>S.SM.DS.Client.External.Text</AssemblyName>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/OpenRiaServices.DomainServices.Client.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Test/OpenRiaServices.DomainServices.Client.Test.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>108</NoWarn>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <DefineConstants>$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
   </PropertyGroup>
   

--- a/src/OpenRiaServices.DomainServices.Client/Test/Client.Vb.Test/OpenRiaServices.DomainServices.Client.Vb.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Client/Test/Client.Vb.Test/OpenRiaServices.DomainServices.Client.Vb.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>TRACE;DEBUG;VBTests</DefineConstants>
     <NoWarn>108</NoWarn>

--- a/src/OpenRiaServices.DomainServices.Client/Test/VbDomainClients/VbDomainClients.vbproj
+++ b/src/OpenRiaServices.DomainServices.Client/Test/VbDomainClients/VbDomainClients.vbproj
@@ -4,7 +4,7 @@
     <DefineTrace>true</DefineTrace>
     <RootNamespace />
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>Off</OptionStrict>

--- a/src/OpenRiaServices.DomainServices.Client/Test/VbExpressions/VbExpressions.vbproj
+++ b/src/OpenRiaServices.DomainServices.Client/Test/VbExpressions/VbExpressions.vbproj
@@ -6,7 +6,7 @@
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
     <DefineTrace>true</DefineTrace>
     <MyType>Windows</MyType>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <OptionExplicit>On</OptionExplicit>
     <OptionCompare>Binary</OptionCompare>
     <OptionStrict>Off</OptionStrict>

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Framework/OpenRiaServices.DomainServices.EntityFramework.csproj
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Framework/OpenRiaServices.DomainServices.EntityFramework.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
-    <DefineConstants>$(DefineConstants);SERVERFX;DBCONTEXT;NET46;</DefineConstants>
+    <TargetFramework>net472</TargetFramework>
+    <DefineConstants>$(DefineConstants);SERVERFX;DBCONTEXT;net472;</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Test/CodeFirstModel/EFCodeFirstModels.csproj
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Test/CodeFirstModel/EFCodeFirstModels.csproj
@@ -4,7 +4,7 @@
     <NoWarn>618</NoWarn>
     <RootNamespace>CodeFirstModels</RootNamespace>
     <AssemblyName>CodeFirstModels</AssemblyName>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <DefineConstants>$(DefineConstants);DBCONTEXT</DefineConstants>
   </PropertyGroup>
   <Target Name="WriteProjectPath">

--- a/src/OpenRiaServices.DomainServices.EntityFramework/Test/DbContextModel/EFDbContextModels.csproj
+++ b/src/OpenRiaServices.DomainServices.EntityFramework/Test/DbContextModel/EFDbContextModels.csproj
@@ -4,7 +4,7 @@
     <NoWarn>618</NoWarn>
     <RootNamespace>DbContextModels</RootNamespace>
     <AssemblyName>DbContextModels</AssemblyName>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
     <Message Text="Writing project path" />

--- a/src/OpenRiaServices.DomainServices.Hosting.Endpoint/Framework/OpenRiaServices.DomainServices.Hosting.Endpoint.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.Endpoint/Framework/OpenRiaServices.DomainServices.Hosting.Endpoint.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <DefineConstants>SERVERFX;$(DefineConstants)</DefineConstants>
     <RootNamespace>OpenRiaServices.DomainServices.Hosting</RootNamespace>
   </PropertyGroup>

--- a/src/OpenRiaServices.DomainServices.Hosting.Endpoint/Test/OpenRiaServices.DomainServices.Hosting.Endpoint.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.Endpoint/Test/OpenRiaServices.DomainServices.Hosting.Endpoint.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>OpenRiaServices.DomainServices.Hosting.Test</RootNamespace>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/src/OpenRiaServices.DomainServices.Hosting.Local/Framework/OpenRiaServices.DomainServices.Hosting.Local.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.Local/Framework/OpenRiaServices.DomainServices.Hosting.Local.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>SERVERFX;$(DefineConstants)</DefineConstants>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.DomainServices.Hosting.Local/Test/OpenRiaServices.DomainServices.Hosting.Local.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.Local/Test/OpenRiaServices.DomainServices.Hosting.Local.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
     <Message Text="Writing project path" />

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/OpenRiaServices.DomainServices.Hosting.OData.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Framework/OpenRiaServices.DomainServices.Hosting.OData.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>SERVERFX;$(DefineConstants)</DefineConstants>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.DomainServices.Hosting.OData/Test/OpenRiaServices.DomainServices.Hosting.OData.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting.OData/Test/OpenRiaServices.DomainServices.Hosting.OData.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <GenerateAssemblyRefs>true</GenerateAssemblyRefs>
   </PropertyGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.DomainServices.Hosting/Framework/OpenRiaServices.DomainServices.Hosting.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting/Framework/OpenRiaServices.DomainServices.Hosting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <DefineConstants>SERVERFX;$(DefineConstants)</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/OpenRiaServices.DomainServices.Hosting/Test/OpenRiaServices.DomainServices.Hosting.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Hosting/Test/OpenRiaServices.DomainServices.Hosting.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />

--- a/src/OpenRiaServices.DomainServices.LinqToSql/Framework/OpenRiaServices.DomainServices.LinqToSql.csproj
+++ b/src/OpenRiaServices.DomainServices.LinqToSql/Framework/OpenRiaServices.DomainServices.LinqToSql.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>SERVERFX;LINQTOSQL;$(DefineConstants)</DefineConstants>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/src/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership/Framework/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.csproj
+++ b/src/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership/Framework/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <DefineConstants>$(DefineConstants);SERVERFX</DefineConstants>
   </PropertyGroup>
 

--- a/src/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.DomainServices.Server.Authentication.AspNetMembership.Test.csproj
@@ -3,7 +3,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>618</NoWarn>
     <DefineConstants>$(DefineConstants);SERVERFX</DefineConstants>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\OpenRiaServices.DomainServices.Server\Test\ServerTestHelper.cs" Link="Shared\ServerTestHelper.cs" />

--- a/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/OpenRiaServices.DomainServices.Server.UnitTesting.csproj
+++ b/src/OpenRiaServices.DomainServices.Server.UnitTesting/Framework/OpenRiaServices.DomainServices.Server.UnitTesting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.DomainServices.Server/Framework/OpenRiaServices.DomainServices.Server.csproj
+++ b/src/OpenRiaServices.DomainServices.Server/Framework/OpenRiaServices.DomainServices.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <DefineConstants>$(DefineConstants);SERVERFX</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.DomainServices.Server/Test/OpenRiaServices.DomainServices.Server.Test.csproj
+++ b/src/OpenRiaServices.DomainServices.Server/Test/OpenRiaServices.DomainServices.Server.Test.csproj
@@ -3,7 +3,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>618</NoWarn>
     <DefineConstants>$(DefineConstants);SERVERFX</DefineConstants>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />

--- a/src/OpenRiaServices.DomainServices.Tools.TextTemplate/Framework/OpenRiaServices.DomainServices.Tools.TextTemplate.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools.TextTemplate/Framework/OpenRiaServices.DomainServices.Tools.TextTemplate.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>$(DefineConstants);SERVERFX</DefineConstants>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.DomainServices.Tools/Framework/OpenRiaServices.DomainServices.Tools.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Framework/OpenRiaServices.DomainServices.Tools.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);SERVERFX;DBCONTEXT;NET40</DefineConstants>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <!-- Copy Mono.Cecil to output directory -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/src/OpenRiaServices.DomainServices.Tools/Test/ClientClassLib/ClientClassLib.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/ClientClassLib/ClientClassLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>$(DefineConstants);SILVERLIGHT</DefineConstants>
     <DebugType>pdbonly</DebugType>

--- a/src/OpenRiaServices.DomainServices.Tools/Test/MsBuildHelper.cs
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/MsBuildHelper.cs
@@ -150,8 +150,8 @@ namespace OpenRiaServices.DomainServices.Tools.Test
                     }
                     else
                     {
-                        // fallback to net45
-                        project.SetGlobalProperty("TargetFramework", "net46");
+                        // fallback to net472
+                        project.SetGlobalProperty("TargetFramework", "net472");
                     }
                 }
             }

--- a/src/OpenRiaServices.DomainServices.Tools/Test/ServerClassLib/ServerClassLib.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/ServerClassLib/ServerClassLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <!-- We compile with Release settings to test PDB reader,
          though we pretend it is the Debug build just to simplify
          a debug build of the solution

--- a/src/OpenRiaServices.DomainServices.Tools/Test/ServerClassLib2/ServerClassLib2.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/ServerClassLib2/ServerClassLib2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/OpenRiaServices.DomainServices.Tools/Test/T4DomainServiceCodeGenerator/T4ClientCodeGenerator.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/T4DomainServiceCodeGenerator/T4ClientCodeGenerator.csproj
@@ -3,7 +3,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>OpenRiaServices.DomainServices.Tools.Test.T4Generator</RootNamespace>
     <AssemblyName>OpenRiaServices.DomainServices.Tools.Test.T4Generator</AssemblyName>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/OpenRiaServices.DomainServices.Tools/Test/TestWap/TestWap.csproj
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/TestWap/TestWap.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestWap</RootNamespace>
     <AssemblyName>TestWap</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/OpenRiaServices.DomainServices.Tools/Test/TestWap/Web.config
+++ b/src/OpenRiaServices.DomainServices.Tools/Test/TestWap/Web.config
@@ -7,17 +7,9 @@
   <connectionStrings>
     <add name="ApplicationServices" connectionString="data source=(localdb)\MSSQLLocalDB;Integrated Security=SSPI;AttachDBFilename=|DataDirectory|\aspnetdb.mdf;User Instance=true" providerName="System.Data.SqlClient"/>
   </connectionStrings>
-  <!--
-    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
-
-    The following attributes can be set on the <httpRuntime> tag.
-      <system.Web>
-        <httpRuntime targetFramework="4.6" />
-      </system.Web>
-  -->
   <system.web>
-    <httpRuntime targetFramework="4.5"/>
-    <compilation debug="true" targetFramework="4.6"/>
+    <httpRuntime targetFramework="4.7.2"/>
+    <compilation debug="true" targetFramework="4.7.2"/>
     <authentication mode="Forms">
       <forms loginUrl="~/Account/Login.aspx" timeout="2880"/>
     </authentication>

--- a/src/Test/Desktop/EFPOCOModels/EFPOCOModels.csproj
+++ b/src/Test/Desktop/EFPOCOModels/EFPOCOModels.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/OpenRiaServices.Common.DomainServices.Test.csproj
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/OpenRiaServices.Common.DomainServices.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/OpenRiaServices.Common.Test.csproj
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/OpenRiaServices.Common.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Test/WebsiteFullTrust/Web.config
+++ b/src/Test/WebsiteFullTrust/Web.config
@@ -33,8 +33,8 @@
       </outputCacheSettings>
     </caching>
     <anonymousIdentification enabled="false"/>
-    <httpRuntime targetFramework="4.6" maxUrlLength="2083" maxQueryStringLength="2083"/>
-    <compilation debug="true" targetFramework="4.6"/>
+    <httpRuntime targetFramework="4.7.2" maxUrlLength="2083" maxQueryStringLength="2083"/>
+    <compilation debug="true" targetFramework="4.7.2"/>
     <authentication mode="Forms"/>
   </system.web>
   <system.webServer>

--- a/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
+++ b/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WebsiteMediumTrust</RootNamespace>
     <AssemblyName>WebsiteMediumTrust</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <UseIISExpress>false</UseIISExpress>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
+++ b/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
@@ -26,6 +26,11 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     <VSIXSubPath>OpenRiaServices</VSIXSubPath>
+    <!-- Prevent invalid resource from beeing generated in InitializeComponent for xaml dialogs -->
+    <AssemblyVersion>
+    </AssemblyVersion>
+    <Version>
+    </Version>
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>
@@ -194,6 +199,12 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\OpenRiaServices.DomainServices.EntityFramework\Framework\OpenRiaServices.DomainServices.EntityFramework.csproj">
+      <Project>{72137DB5-8A91-4FF8-A292-5F6E73A66CD6}</Project>
+      <Name>OpenRiaServices.DomainServices.EntityFramework</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup%3bBuiltProjectOutputGroupDependencies%3bGetCopyToOutputDirectoryItems%3bSatelliteDllsProjectOutputGroup%3b</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup%3b</IncludeOutputGroupsInVSIXLocalOnly>
+    </ProjectReference>
     <ProjectReference Include="..\..\OpenRiaServices.DomainServices.Hosting.OData\Framework\OpenRiaServices.DomainServices.Hosting.OData.csproj">
       <Project>{82539B51-6BB5-4C04-B37D-4FA850E397CF}</Project>
       <Name>OpenRiaServices.DomainServices.Hosting.OData</Name>
@@ -260,7 +271,6 @@
   <ItemGroup>
     <Page Include="Dialog\LinkRiaDialogWindow.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
+++ b/src/VisualStudio/Installer/OpenRiaServices.VisualStudio.Installer.csproj
@@ -17,7 +17,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenRiaServices.VisualStudio.Installer</RootNamespace>
     <AssemblyName>OpenRiaServices.VisualStudio.Installer</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <TargetFrameworkProfile />
     <!--prevent build server errors about to long path on deployment to experimental instance-->

--- a/src/VisualStudio/Installer/app.config
+++ b/src/VisualStudio/Installer/app.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
   </startup>
 </configuration>

--- a/src/VisualStudio/Installer/source.extension.vsixmanifest
+++ b/src/VisualStudio/Installer/source.extension.vsixmanifest
@@ -16,7 +16,7 @@ For 4.6.0+</Description>
         <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
     </Installation>
     <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.VisualStudio.DomainServices.Tools" Path="|OpenRiaServices.VisualStudio.DomainServices.Tools|" AssemblyName="|OpenRiaServices.VisualStudio.DomainServices.Tools;AssemblyName|" />

--- a/src/VisualStudio/Installer/source.extension.vsixmanifest
+++ b/src/VisualStudio/Installer/source.extension.vsixmanifest
@@ -1,42 +1,43 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="874C448B-42DE-466B-A7E7-0EFEC1E7C009" Version="0.0.9.3" Language="en-US" Publisher="Open Ria Services" />
-        <DisplayName>Open Ria Services</DisplayName>
-        <Description xml:space="preserve">OpenRiaServices Tooling and Templates For Visual Studio 2017 and 2019
+  <Metadata>
+    <Identity Id="874C448B-42DE-466B-A7E7-0EFEC1E7C009" Version="0.0.9.4" Language="en-US" Publisher="Open Ria Services" />
+    <DisplayName>Open Ria Services</DisplayName>
+    <Description xml:space="preserve">OpenRiaServices Tooling and Templates For Visual Studio 2017 and 2019
 
 For 4.6.0+</Description>
-        <MoreInfo>https://github.com/OpenRIAServices/OpenRiaServices/</MoreInfo>
-        <Icon>DomainServiceClass.10.0.ico</Icon>
-        <Preview>true</Preview>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.VisualStudio.DomainServices.Tools" Path="|OpenRiaServices.VisualStudio.DomainServices.Tools|" AssemblyName="|OpenRiaServices.VisualStudio.DomainServices.Tools;AssemblyName|" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.DomainServices.Hosting" Path="|OpenRiaServices.DomainServices.Hosting|" AssemblyName="|OpenRiaServices.DomainServices.Hosting;AssemblyName|" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.DomainServices.Hosting.OData" Path="|OpenRiaServices.DomainServices.Hosting.OData|" AssemblyName="|OpenRiaServices.DomainServices.Hosting.OData;AssemblyName|" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.DomainServices.Server" Path="|OpenRiaServices.DomainServices.Server|" AssemblyName="|OpenRiaServices.DomainServices.Server;AssemblyName|" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="EntityFramework.dll" AssemblyName="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-        <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="EntityFramework.SqlServer.dll" AssemblyName="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" Path="ItemTemplates" d:TargetPath="|AuthenticationDomainService;TemplateProjectOutputGroup|" d:ProjectName="AuthenticationDomainService" d:VsixSubPath="ItemTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" Path="ItemTemplates" d:TargetPath="|DomainServiceClass;TemplateProjectOutputGroup|" d:ProjectName="DomainServiceClass" d:VsixSubPath="ItemTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="it\VB\Web\1033\Authentication Domain Service.zip" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="it\VB\Web\1033\Domain Service Class.zip" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="pt\CS\SL\1033\Silverlight Business Application.zip" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="pt\VB\SL\1033\Silverlight Business Application.zip" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="pt\VB\SL\1033\Open RIA Services Class Library.zip" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:TargetPath="|BusinessApplicationProjectTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="OpenRiaServicesLibrary" d:TargetPath="|OpenRiaServicesLibrary;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-    </Assets>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
+    <MoreInfo>https://github.com/OpenRIAServices/OpenRiaServices/</MoreInfo>
+    <Icon>DomainServiceClass.10.0.ico</Icon>
+    <Preview>true</Preview>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.VisualStudio.DomainServices.Tools" Path="|OpenRiaServices.VisualStudio.DomainServices.Tools|" AssemblyName="|OpenRiaServices.VisualStudio.DomainServices.Tools;AssemblyName|" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.DomainServices.Hosting" Path="|OpenRiaServices.DomainServices.Hosting|" AssemblyName="|OpenRiaServices.DomainServices.Hosting;AssemblyName|" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.DomainServices.Hosting.OData" Path="|OpenRiaServices.DomainServices.Hosting.OData|" AssemblyName="|OpenRiaServices.DomainServices.Hosting.OData;AssemblyName|" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.DomainServices.Server" Path="|OpenRiaServices.DomainServices.Server|" AssemblyName="|OpenRiaServices.DomainServices.Server;AssemblyName|" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="EntityFramework.dll" AssemblyName="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="File" Path="EntityFramework.SqlServer.dll" AssemblyName="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" Path="ItemTemplates" d:TargetPath="|AuthenticationDomainService;TemplateProjectOutputGroup|" d:ProjectName="AuthenticationDomainService" d:VsixSubPath="ItemTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" Path="ItemTemplates" d:TargetPath="|DomainServiceClass;TemplateProjectOutputGroup|" d:ProjectName="DomainServiceClass" d:VsixSubPath="ItemTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="it\VB\Web\1033\Authentication Domain Service.zip" />
+    <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="File" Path="ItemTemplates" d:TargetPath="it\VB\Web\1033\Domain Service Class.zip" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="pt\CS\SL\1033\Silverlight Business Application.zip" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="pt\VB\SL\1033\Silverlight Business Application.zip" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="File" Path="ProjectTemplates" d:TargetPath="pt\VB\SL\1033\Open RIA Services Class Library.zip" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:TargetPath="|BusinessApplicationProjectTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+    <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="OpenRiaServicesLibrary" d:TargetPath="|OpenRiaServicesLibrary;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="OpenRiaServices.DomainServices.EntityFramework" Path="|OpenRiaServices.DomainServices.EntityFramework|" AssemblyName="|OpenRiaServices.DomainServices.EntityFramework;AssemblyName|" />
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/Tools/Framework/OpenRiaServices.VisualStudio.DomainServices.Tools.csproj
+++ b/src/VisualStudio/Tools/Framework/OpenRiaServices.VisualStudio.DomainServices.Tools.csproj
@@ -4,7 +4,7 @@
     <DefineConstants>$(DefineConstants);SERVERFX;WIZARD;DBCONTEXT;VS14</DefineConstants>
     <AssemblyName>OpenRiaServices.VisualStudio.DomainServices.Tools.14.0</AssemblyName>
     <VsVersion Condition=" '$(VsVersion)' == '' ">14.0</VsVersion>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>


### PR DESCRIPTION
Change target framework to 4.7.2, this allows us to take dependency on netstandard 2.0 nuget packages without breaking any users running previous versions of .net which have known problems with netstandard.

This also fixes a bug where never VS releases generates an invalid uri preventing the Tool Dialog from displaying

- [x] Verify extension works in VS 2015