### PR TITLE
Async methods for DomainServiceTestHost

### DIFF
--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/ServerSideAsyncTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/ServerSideAsyncTests.cs
@@ -458,6 +458,7 @@ namespace OpenRiaServices.Client.Test
 
             // Verify
             CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.RemovedEntities);
+            Assert.AreEqual("deleted", rangeItem.Text);
         }
 
         [TestMethod]

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/ServerSideAsyncTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/ServerSideAsyncTests.cs
@@ -458,7 +458,6 @@ namespace OpenRiaServices.Client.Test
 
             // Verify
             CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.RemovedEntities);
-            Assert.AreEqual("deleted", rangeItem.Text);
         }
 
         [TestMethod]

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -149,7 +149,21 @@ namespace OpenRiaServices.Server.UnitTesting
         /// <param name="ct">The <see cref="CancellationToken"/></param>
         /// <returns>The entities returned from the specified operation</returns>
         /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
-        public Task<IEnumerable<TEntity>> QueryAsync<TEntity>(Expression<Func<TDomainService, IEnumerable<TEntity>>> queryOperation, CancellationToken ct = default) 
+        public Task<IEnumerable<TEntity>> QueryAsync<TEntity>(Expression<Func<TDomainService, Task<IQueryable<TEntity>>>> queryOperation, CancellationToken ct = default) 
+            where TEntity : class
+        {
+            return this.QueryCoreAsync<TEntity>(queryOperation, ct);
+        }
+
+        /// <summary>
+        /// Invokes the specified <paramref name="queryOperation"/> asynchronously and returns the results
+        /// </summary>
+        /// <typeparam name="TEntity">The type of entity to return</typeparam>
+        /// <param name="queryOperation">The <see cref="Expression"/> identifying the query operation to invoke</param>
+        /// <param name="ct">The <see cref="CancellationToken"/></param>
+        /// <returns>The entities returned from the specified operation</returns>
+        /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
+        public Task<IEnumerable<TEntity>> QueryAsync<TEntity>(Expression<Func<TDomainService, IQueryable<TEntity>>> queryOperation, CancellationToken ct = default)
             where TEntity : class
         {
             return this.QueryCoreAsync<TEntity>(queryOperation, ct);

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -670,7 +670,7 @@ namespace OpenRiaServices.Server.UnitTesting
         /// <param name="result">The result of the operation</param>
         /// <param name="validationErrors">The validation errors that occurred</param>
         /// <returns>Whether the operation completed without error</returns>
-        public bool TryInvoke<TResult>(Expression<Func<TDomainService, Task>> invokeOperation, out IList<ValidationResult> validationErrors)
+        public bool TryInvoke(Expression<Func<TDomainService, Task>> invokeOperation, out IList<ValidationResult> validationErrors)
         {
             return this.TryInvokeCore<object>(invokeOperation, out var _, out validationErrors);
         }

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -665,9 +665,7 @@ namespace OpenRiaServices.Server.UnitTesting
         /// <remarks>
         /// This method should not be used to invoke query, insert, update, or delete operations
         /// </remarks>
-        /// <typeparam name="TResult">The result type</typeparam>
         /// <param name="invokeOperation">The <see cref="Expression"/> identifying the operation to invoke</param>
-        /// <param name="result">The result of the operation</param>
         /// <param name="validationErrors">The validation errors that occurred</param>
         /// <returns>Whether the operation completed without error</returns>
         public bool TryInvoke(Expression<Func<TDomainService, Task>> invokeOperation, out IList<ValidationResult> validationErrors)

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenRiaServices.Server;
 
 namespace OpenRiaServices.Server.UnitTesting
 {
@@ -288,6 +285,7 @@ namespace OpenRiaServices.Server.UnitTesting
         #endregion
 
         #region Update
+
         /// <summary>
         /// Invokes the update operation for the specified entity
         /// </summary>
@@ -299,18 +297,6 @@ namespace OpenRiaServices.Server.UnitTesting
         public Task UpdateAsync<TEntity>(TEntity entity, TEntity original = null, CancellationToken ct = default) where TEntity : class
         {
             return this.SubmitCoreAsync<TEntity>(DomainOperation.Update, /* submitOperation */ null, entity, original, ct);
-        }
-
-        /// <summary>
-        /// Invokes the update operation for the specified entity
-        /// </summary>
-        /// <typeparam name="TEntity">The entity type</typeparam>
-        /// <param name="entity">The entity to update</param>
-        /// <param name="original">The original version of the entity. This parameter can be <c>null</c>.</param>
-        /// <exception cref="DomainServiceTestHostException">is thrown if there are any <see cref="ChangeSet"/> errors</exception>
-        public void Update<TEntity>(TEntity entity, TEntity original = null) where TEntity : class
-        {
-            this.SubmitCore<TEntity>(DomainOperation.Update, /* submitOperation */ null, entity, original);
         }
 
         /// <summary>
@@ -328,6 +314,18 @@ namespace OpenRiaServices.Server.UnitTesting
             where TEntity : class
         {
             return this.SubmitCoreAsync<TEntity>(DomainOperation.Update, updateOperation, /* entity */ null, original, ct);
+        }
+
+        /// <summary>
+        /// Invokes the update operation for the specified entity
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type</typeparam>
+        /// <param name="entity">The entity to update</param>
+        /// <param name="original">The original version of the entity. This parameter can be <c>null</c>.</param>
+        /// <exception cref="DomainServiceTestHostException">is thrown if there are any <see cref="ChangeSet"/> errors</exception>
+        public void Update<TEntity>(TEntity entity, TEntity original = null) where TEntity : class
+        {
+            this.SubmitCore<TEntity>(DomainOperation.Update, /* submitOperation */ null, entity, original);
         }
 
         /// <summary>
@@ -553,40 +551,15 @@ namespace OpenRiaServices.Server.UnitTesting
         }
 
         /// <summary>
-        /// Invokes the specified <paramref name="invokeOperation"/>
-        /// </summary>
-        /// <remarks>
-        /// This method should not be used to invoke query, insert, update, or delete operations
-        /// </remarks>
-        /// <param name="invokeOperation">The <see cref="Expression"/> identifying the operation to invoke</param>
-        /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
-        public void Invoke(Expression<Action<TDomainService>> invokeOperation)
-        {
-            this.InvokeCore<object>(invokeOperation);
-        }
-
-        /// <summary>
         /// Invokes the specified <paramref name="invokeOperation"/> asynchronously
         /// </summary>
-        /// <typeparam name="TResult">The result type</typeparam>
         /// <param name="invokeOperation">The <see cref="Expression"/> with <see cref="Task<typeparamref name="TResult"/>"/> as return type,
         /// <param name="ct">The <see cref="CancellationToken"/></param>
         /// identifying the operation to invoke</param>
         /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
-        public Task InvokeAsync<TResult>(Expression<Func<TDomainService, Task>> invokeOperation, CancellationToken ct = default)
+        public Task InvokeAsync(Expression<Func<TDomainService, Task>> invokeOperation, CancellationToken ct = default)
         {
             return this.InvokeCoreAsync<object>(invokeOperation, ct);
-        }
-
-        /// <summary>
-        /// Invokes the specified <paramref name="invokeOperation"/>
-        /// </summary>
-        /// <param name="invokeOperation">The <see cref="Expression"/> with <see cref="Task"/> as return type,
-        /// identifying the operation to invoke</param>
-        /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
-        public void Invoke(Expression<Func<TDomainService, Task>> invokeOperation)
-        {
-            this.InvokeCore<object>(invokeOperation);
         }
 
         /// <summary>
@@ -605,20 +578,6 @@ namespace OpenRiaServices.Server.UnitTesting
         }
 
         /// <summary>
-        /// Invokes the specified <paramref name="invokeOperation"/> and returns the result
-        /// </summary>
-        /// <remarks>
-        /// This method should not be used to invoke query, insert, update, or delete operations
-        /// </remarks>
-        /// <typeparam name="TResult">The result type</typeparam>
-        /// <param name="invokeOperation">The <see cref="Expression"/> identifying the operation to invoke</param>
-        /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
-        public TResult Invoke<TResult>(Expression<Func<TDomainService, TResult>> invokeOperation)
-        {
-            return this.InvokeCore<TResult>(invokeOperation);
-        }
-
-        /// <summary>
         /// Invokes the specified <paramref name="invokeOperation"/> asynchronously and returns the result
         /// </summary>
         /// <remarks>
@@ -631,6 +590,44 @@ namespace OpenRiaServices.Server.UnitTesting
         public Task<TResult> InvokeAsync<TResult>(Expression<Func<TDomainService, Task<TResult>>> invokeOperation, CancellationToken ct = default)
         {
             return this.InvokeCoreAsync<TResult>(invokeOperation, ct);
+        }
+
+        /// <summary>
+        /// Invokes the specified <paramref name="invokeOperation"/>
+        /// </summary>
+        /// <remarks>
+        /// This method should not be used to invoke query, insert, update, or delete operations
+        /// </remarks>
+        /// <param name="invokeOperation">The <see cref="Expression"/> identifying the operation to invoke</param>
+        /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
+        public void Invoke(Expression<Action<TDomainService>> invokeOperation)
+        {
+            this.InvokeCore<object>(invokeOperation);
+        }
+
+        /// <summary>
+        /// Invokes the specified <paramref name="invokeOperation"/>
+        /// </summary>
+        /// <param name="invokeOperation">The <see cref="Expression"/> with <see cref="Task"/> as return type,
+        /// identifying the operation to invoke</param>
+        /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
+        public void Invoke(Expression<Func<TDomainService, Task>> invokeOperation)
+        {
+            this.InvokeCore<object>(invokeOperation);
+        }
+
+        /// <summary>
+        /// Invokes the specified <paramref name="invokeOperation"/> and returns the result
+        /// </summary>
+        /// <remarks>
+        /// This method should not be used to invoke query, insert, update, or delete operations
+        /// </remarks>
+        /// <typeparam name="TResult">The result type</typeparam>
+        /// <param name="invokeOperation">The <see cref="Expression"/> identifying the operation to invoke</param>
+        /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
+        public TResult Invoke<TResult>(Expression<Func<TDomainService, TResult>> invokeOperation)
+        {
+            return this.InvokeCore<TResult>(invokeOperation);
         }
 
         /// <summary>
@@ -675,8 +672,7 @@ namespace OpenRiaServices.Server.UnitTesting
         /// <returns>Whether the operation completed without error</returns>
         public bool TryInvoke<TResult>(Expression<Func<TDomainService, Task>> invokeOperation, out IList<ValidationResult> validationErrors)
         {
-            object result;
-            return this.TryInvokeCore<object>(invokeOperation, out result, out validationErrors);
+            return this.TryInvokeCore<object>(invokeOperation, out var _, out validationErrors);
         }
 
         /// <summary>
@@ -907,10 +903,11 @@ namespace OpenRiaServices.Server.UnitTesting
         /// </summary>
         /// <param name="context"><see cref="OperationContext"/> for the current operation</param>
         /// <param name="changeSet">The <see cref="ChangeSet"/> identifying the operations to invoke.</param>
+        /// <param name="ct">The <see cref="ChangeSet"/> Cancellationtoken.</param>
         /// <exception cref="DomainServiceTestHostException">is thrown if there are any <see cref="ChangeSet"/> errors</exception>
         private static async Task SubmitChangeSetCoreAsync(OperationContext context, ChangeSet changeSet, CancellationToken ct)
         {
-            await context.DomainService.SubmitAsync(changeSet, CancellationToken.None);
+            await context.DomainService.SubmitAsync(changeSet, ct);
 
             ErrorUtility.AssertNoChangeSetErrors(context, changeSet);
         }
@@ -949,6 +946,7 @@ namespace OpenRiaServices.Server.UnitTesting
         /// </summary>
         /// <typeparam name="TResult">The result type</typeparam>
         /// <param name="invokeOperation">The <see cref="Expression"/> identifying the operation to invoke</param>
+        /// <param name="ct">The <see cref="CancellationToken"/> Cancellationtoken</param>
         /// <exception cref="DomainServiceTestHostException">is thrown if there are any validation errors</exception>
         private async Task<TResult> InvokeCoreAsync<TResult>(Expression invokeOperation, CancellationToken ct)
         {

--- a/src/OpenRiaServices.Server.UnitTesting/Test/DomainServiceTestHostTests.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/DomainServiceTestHostTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.ServiceModel.Security;
+using System.Threading;
+using System.Threading.Tasks;
+using Cities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestDomainServices.TypeNameConflictResolution;
+
+namespace OpenRiaServices.Server.UnitTesting.Test
+{
+	[TestClass]
+	public class DomainServiceTestHostTests
+    {
+		[TestMethod]
+		public async Task AssertInvokeAsyncReturnsCorrectType()
+		{
+            var cityDomainServiceTestHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+
+            var expectedResult = "Echo: Hello";
+
+            var result = await cityDomainServiceTestHost.InvokeAsync(s => s.EchoWithDelay("Hello", TimeSpan.FromMilliseconds(1)), CancellationToken.None);
+            
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestMethod]
+        public void AssertInvokeWithTaskReturnsTResult()
+        {
+            var cityDomainServiceTestHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+
+            var expectedResult = "Echo: Hello";
+
+            var result = cityDomainServiceTestHost.Invoke(s => s.EchoWithDelay("Hello", TimeSpan.FromMilliseconds(1)));
+
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestMethod]
+        public void AssertInvokeWithTaskVoidReturnDoesNotThrowError()
+        {
+            var cityDomainServiceTestHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+
+            cityDomainServiceTestHost.Invoke(s => s.Delay(TimeSpan.FromMilliseconds(1)));
+        }
+
+        [TestMethod]
+        public async Task AssertInvokeAsyncWithoutTaskReturnsTResult()
+        {
+            var cityDomainServiceTestHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+
+            var expectedResult = "Echo: Hello";
+
+            var result = await cityDomainServiceTestHost.InvokeAsync(s => s.Echo("Hello"), CancellationToken.None);
+
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [TestMethod]
+        public async Task AssertQueryAsync()
+        {
+            var cityDomainServiceTestHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+
+            var result = await cityDomainServiceTestHost.QueryAsync(s => s.GetZips(), CancellationToken.None);
+
+            Assert.AreEqual(3, result.Count());
+        }
+
+        [TestMethod]
+        public async Task AssertQueryAsyncTask()
+        {
+            var cityDomainServiceTestHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+
+            var result = await cityDomainServiceTestHost.QueryAsync(s => s.GetZipsWithDelay(TimeSpan.FromMilliseconds(1)), CancellationToken.None);
+
+            Assert.AreEqual(3, result.Count());
+        }
+
+        [TestMethod]
+        public async Task AssertSumbitAsyncDoesNotThrow()
+        {
+            var cityDomainServiceTestHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+
+            var changeSetEntries = new HashSet<ChangeSetEntry> 
+            {
+                new ChangeSetEntry { Operation = DomainOperation.Insert, Entity = new Zip() }
+            };
+            var changeSet = new ChangeSet(changeSetEntries);
+
+            await cityDomainServiceTestHost.SubmitAsync(changeSet, CancellationToken.None);
+        }
+
+    }
+}

--- a/src/OpenRiaServices.Server.UnitTesting/Test/DomainServiceTestHostTests.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/DomainServiceTestHostTests.cs
@@ -18,7 +18,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
 		[TestMethod]
 		public async Task AssertInvokeAsyncReturnsCorrectType()
 		{
-            var testHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+            var testHost = new DomainServiceTestHost<CityDomainService>();
 
             var expectedResult = "Echo: Hello";
 
@@ -30,7 +30,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         [TestMethod]
         public void AssertInvokeWithTaskReturnsTResult()
         {
-            var testHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+            var testHost = new DomainServiceTestHost<CityDomainService>();
 
             var expectedResult = "Echo: Hello";
 
@@ -43,7 +43,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         public void AssertInvokeWithTaskVoidReturnDoesNotThrowError()
         {
             var domainService = new DummyDomainService();
-            var testHost = new UnitTesting.DomainServiceTestHost<DummyDomainService>(() => domainService);
+            var testHost = new DomainServiceTestHost<DummyDomainService>(() => domainService);
 
             testHost.Invoke(s => s.DummyInvoke());
 
@@ -54,7 +54,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         public async Task AssertInvokeAsyncWithTaskVoidReturnDoesNotThrowError()
         {
             var domainService = new DummyDomainService();
-            var testHost = new UnitTesting.DomainServiceTestHost<DummyDomainService>(() => domainService);
+            var testHost = new DomainServiceTestHost<DummyDomainService>(() => domainService);
 
             await testHost.InvokeAsync(s => s.DummyInvoke());
 
@@ -64,7 +64,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         [TestMethod]
         public async Task AssertInvokeAsyncWithoutTaskReturnsTResult()
         {
-            var testHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+            var testHost = new DomainServiceTestHost<CityDomainService>();
 
             var expectedResult = "Echo: Hello";
 
@@ -76,7 +76,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         [TestMethod]
         public async Task AssertQueryAsync()
         {
-            var testHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+            var testHost = new DomainServiceTestHost<CityDomainService>();
 
             var result = await testHost.QueryAsync(s => s.GetZips(), CancellationToken.None);
 
@@ -86,7 +86,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         [TestMethod]
         public async Task QueryAsync()
         {
-            var testHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+            var testHost = new DomainServiceTestHost<CityDomainService>();
 
             var result = await testHost.QueryAsync(s => s.GetZipsWithDelay(TimeSpan.FromMilliseconds(1)), CancellationToken.None);
 
@@ -96,11 +96,11 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         [TestMethod]
         public async Task SumbitAsync()
         {
-            var testHost = new UnitTesting.DomainServiceTestHost<CityDomainService>();
+            var testHost = new DomainServiceTestHost<ServerSideAsyncDomainService>();
 
             var changeSetEntries = new HashSet<ChangeSetEntry> 
             {
-                new ChangeSetEntry { Operation = DomainOperation.Insert, Entity = new Zip() }
+                new ChangeSetEntry { Operation = DomainOperation.Insert, Entity = new RangeItem() }
             };
             var changeSet = new ChangeSet(changeSetEntries);
 
@@ -110,7 +110,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         [TestMethod]
         public async Task InsertAsync()
         {
-            var testHost = new UnitTesting.DomainServiceTestHost<ServerSideAsyncDomainService>();
+            var testHost = new DomainServiceTestHost<ServerSideAsyncDomainService>();
 
             var rangeItem = new RangeItem();
 
@@ -122,7 +122,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         [TestMethod]
         public async Task UpdateAsync()
         {
-            var testHost = new UnitTesting.DomainServiceTestHost<ServerSideAsyncDomainService>();
+            var testHost = new DomainServiceTestHost<ServerSideAsyncDomainService>();
 
             var rangeItem = new RangeItem();
 
@@ -134,7 +134,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
         [TestMethod]
         public async Task DeleteAsync()
         {
-            var testHost = new UnitTesting.DomainServiceTestHost<ServerSideAsyncDomainService>();
+            var testHost = new DomainServiceTestHost<ServerSideAsyncDomainService>();
 
             var rangeItem = new RangeItem();
 

--- a/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <NoWarn>618</NoWarn>
+    <DefineConstants>$(DefineConstants);SERVERFX</DefineConstants>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>$(MSBuildExtensionsPath)\..\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Data.Linq" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.XML" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Test\Desktop\OpenRiaServices.Common.DomainServices.Test\OpenRiaServices.Common.DomainServices.Test.csproj" />
+    <ProjectReference Include="..\Framework\OpenRiaServices.Server.UnitTesting.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/OpenRiaServices.Server.UnitTesting/Test/Properties/AssemblyInfo.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM componenets.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ad0bd254-e3db-42b8-b10b-32fdf115d319")]
+
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: SecurityRules(SecurityRuleSet.Level1)]

--- a/src/OpenRiaServices.Server.UnitTesting/Test/Properties/AssemblyInfo.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/Properties/AssemblyInfo.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Security;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -14,6 +13,3 @@ using System.Security;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ad0bd254-e3db-42b8-b10b-32fdf115d319")]
-
-[assembly: AllowPartiallyTrustedCallers]
-[assembly: SecurityRules(SecurityRuleSet.Level1)]

--- a/src/RiaServices.sln
+++ b/src/RiaServices.sln
@@ -135,6 +135,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRiaServices.Server.Auth
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRiaServices.Server.Authentication.AspNetMembership.Test", "OpenRiaServices.Server.Authentication.AspNetMembership\Test\OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj", "{91239B86-30A2-42A8-AA8D-E6F0D2BB2F00}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRiaServices.Server.UnitTesting.Test", "OpenRiaServices.Server.UnitTesting\Test\OpenRiaServices.Server.UnitTesting.Test.csproj", "{7026BE35-4A31-4C10-B9C8-98BA36D333C5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -325,6 +327,10 @@ Global
 		{91239B86-30A2-42A8-AA8D-E6F0D2BB2F00}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{91239B86-30A2-42A8-AA8D-E6F0D2BB2F00}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{91239B86-30A2-42A8-AA8D-E6F0D2BB2F00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7026BE35-4A31-4C10-B9C8-98BA36D333C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7026BE35-4A31-4C10-B9C8-98BA36D333C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7026BE35-4A31-4C10-B9C8-98BA36D333C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7026BE35-4A31-4C10-B9C8-98BA36D333C5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -388,6 +394,7 @@ Global
 		{8F117F6B-6A2F-403B-9500-1D383151E769} = {8D64085D-DABC-4228-85E3-F337DFA7D55E}
 		{B2183838-A948-47FD-8AB4-E8E7C5CD4477} = {2095B11C-903C-47FF-B812-82DFA7A068AC}
 		{91239B86-30A2-42A8-AA8D-E6F0D2BB2F00} = {E8CAC11B-50B6-4243-A12A-D831EBB064CB}
+		{7026BE35-4A31-4C10-B9C8-98BA36D333C5} = {E8CAC11B-50B6-4243-A12A-D831EBB064CB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C135CEC9-180C-4B67-92AC-3342375AE14C}

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
@@ -293,12 +293,20 @@ namespace Cities
         }
 
         [Invoke]
-        public async Task<string> EchoWithDelayAsync(string msg, TimeSpan delay)
+        public async Task<string> EchoWithDelay(string msg, TimeSpan delay)
         {
             // This method is used to test cancellation of invoke operations
             // Since the method might return to soon otherwise we add a delay
-            await Task.Delay(delay, ServiceContext.CancellationToken);
+            await Delay(delay);
             return Echo(msg);
+        }
+
+        [Invoke]
+        public Task Delay(TimeSpan delay)
+        {
+            // This method is used to test cancellation of invoke operations
+            // Since the method might return to soon otherwise we add a delay
+            return Task.Delay(delay, ServiceContext.CancellationToken);
         }
 
         // This service operation is invoked to reset any static data

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
@@ -297,16 +297,8 @@ namespace Cities
         {
             // This method is used to test cancellation of invoke operations
             // Since the method might return to soon otherwise we add a delay
-            await Delay(delay);
+            await Task.Delay(delay, ServiceContext.CancellationToken);
             return Echo(msg);
-        }
-
-        [Invoke]
-        public Task Delay(TimeSpan delay)
-        {
-            // This method is used to test cancellation of invoke operations
-            // Since the method might return to soon otherwise we add a delay
-            return Task.Delay(delay, ServiceContext.CancellationToken);
         }
 
         // This service operation is invoked to reset any static data

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/ServerSideAsyncDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/ServerSideAsyncDomainService.cs
@@ -152,6 +152,7 @@ namespace TestDomainServices
         public async Task DeleteRangeAsync(RangeItem rangeItem)
         {
             await Delay(5);
+            rangeItem.Text = "deleted";
             ThrowExceptionIfSelected(rangeItem, 27);
         }
 


### PR DESCRIPTION
Added overload `Invoke(Expression<Func<TDomainService, Task>>`
and `Invoke<TResult>(Expression<Func<TDomainService, Task<TResult>>>`
- Fixed bug when `TResult` was a `Task` and returned `null` (could await null)
- Fixed bug when `TResult` was a `Task<TResult>` and returned `Task<TResult>`

Added async methods for DomainServiceTestHost
- UpdateAsync
- InsertAsync
- InvokeAsync
- QueryAsync
- SubmitAsync

Added tests for DomainServiceTestHost
