### PR TITLE
Support IgnoreDataMember on client and move types in client project from "Server" namespace 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -57,12 +57,12 @@ It is currently quite empty but already demonstrates some of the following scena
   
 ### Client
 
-* `IgnoreDataMember` can now be used on the client to prevent client properties from beeing included/overwritten when loading data using `MergeIntoCurrent` or the state manipulating methods `ApplyState`, `ExtractState` etc. #249
+* `IgnoreDataMemberAttribute` can now be used on the client to prevent client properties from beeing included/overwritten when loading data using `MergeIntoCurrent` or the state manipulating methods `ApplyState`, `ExtractState` etc. #249
 	* `MergeAttribute` which has a similar usage area has been moved to `OpenRiaServices.Client.Internal` and might be removed in future releases.
 
 ### Code Generation
 
-* Suppress generation of DebuggerStepThroughAttribute from async methods
+* Suppress generation of `DebuggerStepThroughAttribute` from async methods
 * New handling of shared files #229
   Instead of copying all ".shared" files to the `Generated_Code` folder the server version is referenced instead
   * This should build faster builds and allows find all references, refactoring etc to work for shared files

--- a/Changelog.md
+++ b/Changelog.md
@@ -51,7 +51,7 @@ It is currently quite empty but already demonstrates some of the following scena
 
 * "DomainServices" dropped from all namespaces, filenames as well as nugets and DLLs. #234
   * **IMPORTANT** Search and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files when uprading
-* Namespace `OpenRiaServices.Client.ApplicationServices` has been replaced with  `OpenRiaServices.Client.Authentication` **search and replace is needed on upgraing** #248
+* Namespace `OpenRiaServices.Client.ApplicationServices` has been replaced with  `OpenRiaServices.Client.Authentication` **search and replace is needed on upgrading** #248
 * Updated required version of .Net Framework to 4.7.2 (#241)
 * Updated dependencies including EntityFramework to latests availible versions #240
   

--- a/Changelog.md
+++ b/Changelog.md
@@ -54,16 +54,20 @@ It is currently quite empty but already demonstrates some of the following scena
 * Namespace `OpenRiaServices.Client.ApplicationServices` has been replaced with  `OpenRiaServices.Client.Authentication` **search and replace is needed on upgraing** #248
 * Updated required version of .Net Framework to 4.7.2 (#241)
 * Updated dependencies including EntityFramework to latests availible versions #240
-* New handling of shared files #229
-  Instead of copying all ".shared" files to the `Generated_Code` folder the server version is referenced instead
-  * This should build faster builds and allows find all references, refactoring etc to work for shared files
-  * It is possible to opt out of the new behaviour by adding `<OpenRiaSharedFilesMode>Copy</OpenRiaSharedFilesMode>` in the project file
-  * The tooling is updated with a new option
   
 ### Client
 
 * `IgnoreDataMember` can now be used on the client to prevent client properties from beeing included/overwritten when loading data using `MergeIntoCurrent` or the state manipulating methods `ApplyState`, `ExtractState` etc. #249
 	* `MergeAttribute` which has a similar usage area has been moved to `OpenRiaServices.Client.Internal` and might be removed in future releases.
+
+### Code Generation
+
+* Suppress generation of DebuggerStepThroughAttribute from async methods
+* New handling of shared files #229
+  Instead of copying all ".shared" files to the `Generated_Code` folder the server version is referenced instead
+  * This should build faster builds and allows find all references, refactoring etc to work for shared files
+  * It is possible to opt out of the new behaviour by adding `<OpenRiaSharedFilesMode>Copy</OpenRiaSharedFilesMode>` in the project file
+  * The tooling is updated with a new option
 
 ### Server 
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,8 +15,8 @@
 ## Upgrade instructions
 
 1. Update both all client anor/or server nuget packages to the new version, dont't mix with v4 in the same project.
-2. Seach and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files
-3. Seach and Replace `.ApplicationServices` with `.Authentication` in all files.
+2. Search and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files
+3. Search and Replace `.ApplicationServices` with `.Authentication` in all files.
 	* `OpenRiaServices.Client.ApplicationServices` has been renamed to `OpenRiaServices.Client.Authentication`
 	* `OpenRiaServices.Server.ApplicationServices` has been renamed to `OpenRiaServices.Server.Authentication`
 2. If you have been using **AuthenticationBase** or other classes in the `OpenRiaServices.Server.ApplicationServices` namespace in your server project 
@@ -50,7 +50,7 @@ It is currently quite empty but already demonstrates some of the following scena
 # 5.0.0 RC
 
 * "DomainServices" dropped from all namespaces, filenames as well as nugets and DLLs. #234
-  * **IMPORTANT** Seach and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files when uprading
+  * **IMPORTANT** Search and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files when uprading
 * Namespace `OpenRiaServices.Client.ApplicationServices` has been replaced with  `OpenRiaServices.Client.Authentication` **search and replace is needed on upgraing** #248
 * Updated required version of .Net Framework to 4.7.2 (#241)
 * Updated dependencies including EntityFramework to latests availible versions #240

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,9 @@
 2. Client networking API the *DomainClient* is now based on Task instead of using the APM pattern with Begin/End methods
 3. Supported TargetFrameworks has changed
 4. Code generation now works against *netstandard 2.0* and *netcore 2.1+* clients
-5. **Major namespace changes** *DomainServices* is dropped from namespaces and assemblies
+5. **Major namespace changes** 
+	1. *DomainServices* is dropped from namespaces and assemblies
+	2. *ApplicationServices* has been renamed to *Authentication*
 5. AspNetMembership authentication (**AuthenticationBase** and related classes) are moved to a new namespace and nuget package
    * Add a reference to *OpenRIAServices.Server.Authenication.AspNetMembership* if you use it
 
@@ -14,6 +16,9 @@
 
 1. Update both all client anor/or server nuget packages to the new version, dont't mix with v4 in the same project.
 2. Seach and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files
+3. Seach and Replace `.ApplicationServices` with `.Authentication` in all files.
+	* `OpenRiaServices.Client.ApplicationServices` has been renamed to `OpenRiaServices.Client.Authentication`
+	* `OpenRiaServices.Server.ApplicationServices` has been renamed to `OpenRiaServices.Server.Authentication`
 2. If you have been using **AuthenticationBase** or other classes in the `OpenRiaServices.Server.ApplicationServices` namespace in your server project 
    1. Add the *OpenRiaServices.Server.Authentication.AspNetMembership* nuget package to it
    2. Replace *OpenRiaServices.Server.ApplicationServices* with *OpenRiaServices.Server.Authentication*
@@ -44,17 +49,39 @@ It is currently quite empty but already demonstrates some of the following scena
 
 # 5.0.0 RC
 
-* "DomainServices" dropped from all namespaces, filenames as well as nugets and DLLs.
+* "DomainServices" dropped from all namespaces, filenames as well as nugets and DLLs. #234
   * **IMPORTANT** Seach and Replace `OpenRiaServices.DomainServices` with `OpenRiaServices` in all files when uprading
+* Namespace `OpenRiaServices.Client.ApplicationServices` has been replaced with  `OpenRiaServices.Client.Authentication` **search and replace is needed on upgraing** #248
 * Updated required version of .Net Framework to 4.7.2 (#241)
 * Updated dependencies including EntityFramework to latests availible versions #240
-* Create, Update and Delete methods on server can now return Task #226
 * New handling of shared files #229
   Instead of copying all ".shared" files to the `Generated_Code` folder the server version is referenced instead
   * This should build faster builds and allows find all references, refactoring etc to work for shared files
   * It is possible to opt out of the new behaviour by adding `<OpenRiaSharedFilesMode>Copy</OpenRiaSharedFilesMode>` in the project file
   * The tooling is updated with a new option
   
+### Client
+
+* `IgnoreDataMember` can now be used on the client to prevent client properties from beeing included/overwritten when loading data using `MergeIntoCurrent` or the state manipulating methods `ApplyState`, `ExtractState` etc. #249
+	* `MergeAttribute` which has a similar usage area has been moved to `OpenRiaServices.Client.Internal` and might be removed in future releases.
+
+### Server 
+
+* Create, Update and Delete methods on server can now return Task #226
+
+### Unit Testing
+
+* `DomainServiceTestHost` has received an number of new methods and overloads to help with unit testing async code. (#245)
+	* Added async methods for DomainServiceTestHost
+		* UpdateAsync
+		* InsertAsync
+		* InvokeAsync
+		* QueryAsync
+		* SubmitAsync
+	* Added overloads to `Invoke` for methods returning `Task` to fix the following issues   
+		* Fixed bug when TResult was a Task and returned null (could await null)
+		* Fixed bug when TResult was a Task<TResult> and returned Task<TResult>
+
 # 5.0.0 Preview 3
 
 ### Client

--- a/Changelog.md
+++ b/Changelog.md
@@ -72,6 +72,7 @@ It is currently quite empty but already demonstrates some of the following scena
 ### Server 
 
 * Create, Update and Delete methods on server can now return Task #226
+* The CancellationToken passed to SubmitAsync and InvokeAsync now supports cancellation on client disconnect #250 
 
 ### Unit Testing
 

--- a/src/OpenRiaServices.Client/Framework/Internal/MergeAttribute.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MergeAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace OpenRiaServices.Client
+namespace OpenRiaServices.Client.Internal
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
     public class MergeAttribute : Attribute

--- a/src/OpenRiaServices.Client/Framework/Internal/MergeAttribute.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MergeAttribute.cs
@@ -3,7 +3,7 @@
 namespace OpenRiaServices.Client.Internal
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
-    public class MergeAttribute : Attribute
+    class MergeAttribute : Attribute
     {
         private readonly bool _isMergeable;
 

--- a/src/OpenRiaServices.Client/Framework/Internal/MetaMember.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MetaMember.cs
@@ -31,8 +31,8 @@ namespace OpenRiaServices.Client.Internal
             IsComplex = TypeUtility.IsSupportedComplexType(property.PropertyType);
             if (hasGetter && (property.GetSetMethod() != null))
             {
-                IsDataMember = IsComplex
-                    || (TypeUtility.IsPredefinedType(property.PropertyType) && !TypeUtility.IsAttributeDefined(property, typeof(IgnoreDataMemberAttribute), false));
+                IsDataMember = (IsComplex || TypeUtility.IsPredefinedType(property.PropertyType))
+                        && !TypeUtility.IsAttributeDefined(property, typeof(IgnoreDataMemberAttribute), false);
             }
 
             if (hasGetter)

--- a/src/OpenRiaServices.Client/Framework/Internal/MetaMember.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MetaMember.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 
 namespace OpenRiaServices.Client.Internal
 {
@@ -30,7 +31,8 @@ namespace OpenRiaServices.Client.Internal
             IsComplex = TypeUtility.IsSupportedComplexType(property.PropertyType);
             if (hasGetter && (property.GetSetMethod() != null))
             {
-                IsDataMember = IsComplex || TypeUtility.IsPredefinedType(property.PropertyType);
+                IsDataMember = IsComplex
+                    || (TypeUtility.IsPredefinedType(property.PropertyType) && !TypeUtility.IsAttributeDefined(property, typeof(IgnoreDataMemberAttribute)));
             }
 
             if (hasGetter)

--- a/src/OpenRiaServices.Client/Framework/Internal/MetaMember.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MetaMember.cs
@@ -32,7 +32,7 @@ namespace OpenRiaServices.Client.Internal
             if (hasGetter && (property.GetSetMethod() != null))
             {
                 IsDataMember = IsComplex
-                    || (TypeUtility.IsPredefinedType(property.PropertyType) && !TypeUtility.IsAttributeDefined(property, typeof(IgnoreDataMemberAttribute)));
+                    || (TypeUtility.IsPredefinedType(property.PropertyType) && !TypeUtility.IsAttributeDefined(property, typeof(IgnoreDataMemberAttribute), false));
             }
 
             if (hasGetter)

--- a/src/OpenRiaServices.Client/Framework/Internal/MetaMember.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MetaMember.cs
@@ -1,5 +1,4 @@
-﻿using OpenRiaServices.Server.Data;
-using System;
+﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Linq;

--- a/src/OpenRiaServices.Client/Framework/Internal/MetaType.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MetaType.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using OpenRiaServices.Server.Data;
 
 namespace OpenRiaServices.Client.Internal
 {

--- a/src/OpenRiaServices.Client/Framework/MergeAttribute.cs
+++ b/src/OpenRiaServices.Client/Framework/MergeAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace OpenRiaServices.Server.Data
+namespace OpenRiaServices.Client
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
     public class MergeAttribute : Attribute
@@ -13,7 +13,7 @@ namespace OpenRiaServices.Server.Data
         /// </summary>
         public MergeAttribute()
         {
-            this._isMergeable = true;
+            _isMergeable = true;
         }
 
 
@@ -23,7 +23,7 @@ namespace OpenRiaServices.Server.Data
         /// <param name="isMergeable">The member name for the mergeable member.</param>
         public MergeAttribute(bool isMergeable)
         {
-            this._isMergeable = isMergeable;
+            _isMergeable = isMergeable;
         }
 
         /// <summary>

--- a/src/OpenRiaServices.Client/Framework/Serialization/KeyValue.cs
+++ b/src/OpenRiaServices.Client/Framework/Serialization/KeyValue.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Runtime.Serialization;
 
 namespace OpenRiaServices.Serialization

--- a/src/OpenRiaServices.Client/Framework/Serialization/KeyValue.cs
+++ b/src/OpenRiaServices.Client/Framework/Serialization/KeyValue.cs
@@ -47,24 +47,3 @@ namespace OpenRiaServices.Serialization
         public TValue Value { get { return _value; } set { _value = value; } }
     }
 }
-
-namespace OpenRiaServices.Server
-{
-    using Serialization;
-
-    /// <summary>
-    /// Collection representing number of EntityAction invocations
-    /// </summary>
-    public class EntityActionCollection : List<KeyValue<string, object[]>>
-    {
-        /// <summary>
-        /// Adds a KeyValue to the specified list.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="value">The value.</param>
-        public void Add(string key, object[] value)
-        {
-            base.Add(new KeyValue<string, object[]>(key, value));
-        }
-    }
-}

--- a/src/OpenRiaServices.Client/Test/Client.Test/Reflection/MetaTypeTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Reflection/MetaTypeTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenRiaServices.Client.Internal;
+
+namespace OpenRiaServices.Client.Test.Reflection
+{
+    [TestClass]
+    public class MetaTypeTests
+    {
+        [TestMethod]
+        public void ShouldIgnorePropertiesWithIgnoreDataMember()
+        {
+            var metaType = MetaType.GetMetaType(typeof(EntityWithIgnoreProperty));
+            var entity = new EntityWithIgnoreProperty()
+            {
+                Id = 1,
+                IgnoredProperty = "ignored",
+            };
+
+            Assert.AreEqual(1, metaType.DataMembers.Count(), "DataMembers should not include ignored members");
+            Assert.AreEqual(nameof(EntityWithIgnoreProperty.Id), metaType.DataMembers.First().Name);
+
+            var state = ObjectStateUtility.ExtractState(entity);
+            Assert.AreEqual(1, state.Count, "Extract state should only include non ignored properties");
+
+            ObjectStateUtility.ApplyState(entity, new Dictionary<string, object>
+            {
+                { nameof(EntityWithIgnoreProperty.Id), (object)2},
+                { nameof(EntityWithIgnoreProperty.IgnoredProperty), null},
+            });
+            Assert.AreEqual(2, entity.Id, "ApplyState should not change ignored properties");
+            Assert.IsNotNull(entity.IgnoredProperty, "ApplyState should not change ignored properties");
+        }
+
+        public class EntityWithIgnoreProperty : Entity
+        {
+            public int Id { get; set; }
+
+            [IgnoreDataMember]
+            public string IgnoredProperty { get; set; }
+
+            [IgnoreDataMember]
+            public string ThrowingProperty { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        }
+    }
+}

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/EntityActionCollection.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/EntityActionCollection.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using OpenRiaServices.Serialization;
 
 namespace OpenRiaServices.Server.UnitTesting

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/EntityActionCollection.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/EntityActionCollection.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenRiaServices.Serialization;
+
+namespace OpenRiaServices.Server.UnitTesting
+{
+    /// <summary>
+    /// Collection representing number of EntityAction invocations
+    /// Usefull helper for setting <see cref="ChangeSetEntry.EntityActions"/>
+    /// </summary>
+    public class EntityActionCollection : List<KeyValue<string, object[]>>
+    {
+        /// <summary>
+        /// Adds a KeyValue to the specified list.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        public void Add(string key, object[] value)
+        {
+            base.Add(new KeyValue<string, object[]>(key, value));
+        }
+    }
+}

--- a/src/OpenRiaServices.Server/Test/AuthorizationTests.cs
+++ b/src/OpenRiaServices.Server/Test/AuthorizationTests.cs
@@ -9,6 +9,7 @@ using OpenRiaServices.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using System.Threading;
+using OpenRiaServices.Server.UnitTesting;
 
 namespace OpenRiaServices.Server.Test
 {

--- a/src/OpenRiaServices.Server/Test/DomainMethodServerTest.cs
+++ b/src/OpenRiaServices.Server/Test/DomainMethodServerTest.cs
@@ -8,6 +8,7 @@ using Cities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using System.Threading;
+using OpenRiaServices.Server.UnitTesting;
 
 namespace OpenRiaServices.Server.Test
 {

--- a/src/OpenRiaServices.Server/Test/DomainServiceTests.cs
+++ b/src/OpenRiaServices.Server/Test/DomainServiceTests.cs
@@ -17,6 +17,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestDomainServices;
 using System.Threading.Tasks;
 using System.Threading;
+using OpenRiaServices.Server.UnitTesting;
 
 namespace OpenRiaServices.Server.Test
 {

--- a/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
+++ b/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\OpenRiaServices.EntityFramework\Test\DbContextModel\EFDbContextModels.csproj" />
+    <ProjectReference Include="..\..\OpenRiaServices.Server.UnitTesting\Framework\OpenRiaServices.Server.UnitTesting.csproj" />
     <ProjectReference Include="..\..\OpenRiaServices.Tools\Framework\OpenRiaServices.Tools.csproj" />
     <ProjectReference Include="..\..\OpenRiaServices.LinqToSql\Framework\OpenRiaServices.LinqToSql.csproj" />
     <ProjectReference Include="..\..\Test\Desktop\EFPOCOModels\EFPOCOModels.csproj" />


### PR DESCRIPTION
1.  `IgnoreDataMember` can now be used on the client to prevent client properties from beeing included/overwritten when loading data using `MergeIntoCurrent` or the state manipulating methods `ApplyState`, `ExtractState` etc. #249
	* `MergeAttribute` which has a similar usage area has been moved to `OpenRiaServices.Client.Internal` and might be removed in future releases.

Namespace changes:

2. Moved `` OpenRiaServices.Server.EntityActionCollection` from client and server project to unit testing assembly (and changed namespace)
3. Moved `OpenRiaServices.Server.MergeAttribute` to `OpenRiaServices.Client.Internal`




Part of #244 