### PR TITLE
Dont enable IncludeExceptionDetailInFaults by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -82,7 +82,8 @@ It is currently quite empty but already demonstrates some of the following scena
 ### Server 
 
 * Create, Update and Delete methods on server can now return Task #226
-* The CancellationToken passed to SubmitAsync and InvokeAsync now supports cancellation on client disconnect #250 
+* The CancellationToken passed to SubmitAsync and InvokeAsync now supports cancellation on client disconnect #250
+* **Security**: Don't include stack traces for errors by default #256
 
 ### Unit Testing
 

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/DomainServiceHost.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/DomainServiceHost.cs
@@ -220,7 +220,6 @@ namespace OpenRiaServices.Hosting.Wcf
             // Force default service behavior.
             ServiceBehaviorAttribute serviceBehavior = ServiceUtility.EnsureBehavior<ServiceBehaviorAttribute>(this.Description);
             serviceBehavior.InstanceContextMode = InstanceContextMode.PerCall;
-            serviceBehavior.IncludeExceptionDetailInFaults = true;
             serviceBehavior.AddressFilterMode = AddressFilterMode.Any;
 
             // Force metadata to be available through HTTP GET.

--- a/src/OpenRiaServices.Hosting.Wcf/Test/Data/DomainServiceHostTest.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Test/Data/DomainServiceHostTest.cs
@@ -58,7 +58,7 @@ namespace OpenRiaServices.Hosting.UnitTests
             var serviceBehaviorAtt = host.Description.Behaviors.Find<ServiceBehaviorAttribute>();
             Assert.IsNotNull(serviceBehaviorAtt, "Service behavior not found.");
             Assert.AreEqual(AddressFilterMode.Any, serviceBehaviorAtt.AddressFilterMode, "Unexpected address filter mode.");
-            Assert.IsTrue(serviceBehaviorAtt.IncludeExceptionDetailInFaults, "Exception details are expected to be included in faults.");
+            Assert.IsFalse(serviceBehaviorAtt.IncludeExceptionDetailInFaults, "Exception details should not be included in faults by default.");
 
             // Verify we that for a service with just a HTTP base address, only HttpGetEnabled is true.
             var metadataAtt = host.Description.Behaviors.Find<ServiceMetadataBehavior>();


### PR DESCRIPTION
It is considered bad practice to send stack traces to clients
Disable this insecure default and allow end users to define it instead if required by their scenario

Stack traces for exception thrown from within DomainService methods are still controlled by setting [customErrors](https://docs.microsoft.com/en-us/dotnet/api/system.web.configuration.customerror?view=netframework-4.8) under `sytem.web` in `web.config`

To enable stack traces for other code use `ServiceBehaviorAttribute` or specify [servicedebug](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/wcf/servicedebug) behavior