### PR TITLE
Use HTTP 500 Internal Server Error for exceptions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -85,6 +85,8 @@ It is currently quite empty but already demonstrates some of the following scena
 * Create, Update and Delete methods on server can now return Task #226
 * The CancellationToken passed to SubmitAsync and InvokeAsync now supports cancellation on client disconnect #250
 * **Security**: Don't include stack traces for errors by default #256
+* Dont use HTTP status code "200 OK" for exceptions (will use 500 Internal Server Error by default) #257
+  * It is free for library consumers to change the handling of returned HTTP response codes status such as using a "SilverlightFaultBehavior" or similar
 
 ### Unit Testing
 

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/Behaviors/DomainServiceWebHttpBehavior.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/Behaviors/DomainServiceWebHttpBehavior.cs
@@ -251,12 +251,8 @@ namespace OpenRiaServices.Hosting.Wcf.Behaviors
                     }
                     else
                     {
-                        // serialize in the SOAP fault format so that Silverlight throws the right exception
                         MessageFault messageFault = MessageFault.CreateFault(faultError.Code, faultError.Reason, faultError.Detail);
                         fault = Message.CreateMessage(MessageVersion.None, messageFault, null);
-                        var rmp = new HttpResponseMessageProperty();
-                        rmp.StatusCode = System.Net.HttpStatusCode.OK;
-                        fault.Properties.Add(HttpResponseMessageProperty.Name, rmp);
                     }
                 }
             }


### PR DESCRIPTION
Removes old Silverlight workaround which set "200 OK" for all exceptions.