### PR TITLE
5.0-rc1 install.ps1 incorrectly removes config section

### DIFF
--- a/NuGet/OpenRiaServices.Hosting.WCF/tools/Install.ps1
+++ b/NuGet/OpenRiaServices.Hosting.WCF/tools/Install.ps1
@@ -55,7 +55,3 @@ try {
 
     $configXml.Save($configPath.Value)
 } catch { }
-
-
-
-/////////////////// TODOD_ REMOVE ALLA WITH DOMAINSERVICES

--- a/NuGet/OpenRiaServices.Hosting.WCF/tools/Install.ps1
+++ b/NuGet/OpenRiaServices.Hosting.WCF/tools/Install.ps1
@@ -15,7 +15,7 @@ try {
 
     function RemoveNodesWithOldNamespaces($nodes) {
         foreach($node in $nodes)  {
-            if ($node.Attributes["type"].Value.Contains("DomainServices")) {
+            if ($node.Attributes["type"].Value.Contains(".DomainServices.")) {
                 if ($node.PreviousSibling.NodeType -eq [System.Xml.XmlNodeType]::Whitespace) {
                     $node.ParentNode.RemoveChild($node.PreviousSibling);
                 }


### PR DESCRIPTION
Don't remove new section
Make sure to only remove nodes with old namespace

Actual behaviour

```xml
    <sectionGroup name="system.serviceModel">
    </sectionGroup></configSections>
```

Expected behavor:
* The section "domainServices" is present in web.config under "system.serviceModel" sectionGroup