### PR TITLE
Fix cast error for empty Entity Actions in ChangeSetBuilder

### DIFF
--- a/src/OpenRiaServices.Client/Framework/ChangeSetBuilder.cs
+++ b/src/OpenRiaServices.Client/Framework/ChangeSetBuilder.cs
@@ -83,8 +83,7 @@ namespace OpenRiaServices.Client
                 }
 
                 // add any custom method invocations
-                var entityActions = (ICollection<EntityAction>)entity.EntityActions;
-                foreach (EntityAction customInvokation in entityActions)
+                foreach (EntityAction customInvokation in entity.EntityActions)
                 {
                     if (string.IsNullOrEmpty(customInvokation.Name))
                     {


### PR DESCRIPTION
Fix #261 

Removed unnecessary cast

Sidenotes
In .net Framework Enumerable.Empty returns empty T[] which also implements ICollection<T>.
In .net core/.net 5 Enumerable.Empty returns EmptyPartition<T> which cant be cast to ICollection<T>.


