### PR TITLE
VS Extension: Reference 5.0 nuget packages and fix installation

### DIFF
--- a/src/VisualStudio/Installer/assets/overview.md
+++ b/src/VisualStudio/Installer/assets/overview.md
@@ -1,13 +1,13 @@
-# Open Ria  Services Tooling
+# Open Ria  Services Tooling 5.0
 
 The Tooling provides templates for both items and projects using Open Ria Services as well as tooling support for configuring code generation options.
+The Tooling is only for OpenRiaServices **5.0.0+**
 
-Item Templates for "Domain Service" and "Authentication Service" for C# should work as expected, **other will probably give errors**
-Project Template "Open Ria Services Library" for C# should work, **other will probably give errors**
+Item Templates for "Domain Service" and "Authentication Service" for **C#** should work as expected.
+Project Template "Open Ria Services Library" for **C#** should work, **other will probably give errors**
 
-The tooling is only tested with OpenRiaServices 4.6.0+ and on for server nuget packages.
-
-Some of the errors (about invalid extension GUID should be solvable by also installing the tooling for VS 2015)
+If you need support for previous versions (4.x) of OpenRiaServices you need to install an older version, 
+or one of the older extensions on marketplace.
 
 # Open Ria Services Project Link
 

--- a/src/VisualStudio/Installer/source.extension.vsixmanifest
+++ b/src/VisualStudio/Installer/source.extension.vsixmanifest
@@ -1,14 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="874C448B-42DE-466B-A7E7-0EFEC1E7C009" Version="5.0.0.0" Language="en-US" Publisher="Open Ria Services" />
+        <Identity Id="874C448B-42DE-466B-A7E7-0EFEC1E7C009" Version="5.0.0.1" Language="en-US" Publisher="Open Ria Services" />
         <DisplayName>Open Ria Services</DisplayName>
         <Description xml:space="preserve">OpenRiaServices Tooling and Templates For Visual Studio 2017 and 2019
 
 For 5.0+</Description>
         <MoreInfo>https://github.com/OpenRIAServices/OpenRiaServices/</MoreInfo>
         <Icon>DomainServiceClass.10.0.ico</Icon>
-        <Preview>true</Preview>
     </Metadata>
     <Installation>
         <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Community" />
@@ -39,5 +38,6 @@ For 5.0+</Description>
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.NuGet" Version="[15.0,)" DisplayName="NuGet package manager" />
     </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/Installer/source.extension.vsixmanifest
+++ b/src/VisualStudio/Installer/source.extension.vsixmanifest
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="874C448B-42DE-466B-A7E7-0EFEC1E7C009" Version="0.0.9.4" Language="en-US" Publisher="Open Ria Services" />
+        <Identity Id="874C448B-42DE-466B-A7E7-0EFEC1E7C009" Version="5.0.0.0" Language="en-US" Publisher="Open Ria Services" />
         <DisplayName>Open Ria Services</DisplayName>
         <Description xml:space="preserve">OpenRiaServices Tooling and Templates For Visual Studio 2017 and 2019
 
-For 4.6.0+</Description>
+For 5.0+</Description>
         <MoreInfo>https://github.com/OpenRIAServices/OpenRiaServices/</MoreInfo>
         <Icon>DomainServiceClass.10.0.ico</Icon>
         <Preview>true</Preview>

--- a/src/VisualStudio/ItemTemplates/CSharp/AuthenticationDomainService/AuthenticationDomainService.vstemplate
+++ b/src/VisualStudio/ItemTemplates/CSharp/AuthenticationDomainService/AuthenticationDomainService.vstemplate
@@ -29,10 +29,9 @@
     <FullClassName>OpenRiaServices.VisualStudio.DomainServices.Tools.AuthenticationDomainServiceWizard</FullClassName>
   </WizardExtension>
   <WizardData>
-    <packages repository="extension"
-          repositoryId="874C448B-42DE-466B-A7E7-0EFEC1E7C009">
-      <package id="OpenRiaServices.Server" version = "4.6.0"/>
-      <!--<package id="OpenRiaServices.Server.Authentication.AspNetMembership" version = "4.6.0"/>-->
+    <packages>
+      <package id="OpenRiaServices.Server" version = "5.0.0"/>
+      <package id="OpenRiaServices.Server.Authentication.AspNetMembership" version = "5.0.0"/>
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/VisualStudio/ItemTemplates/CSharp/DomainServiceClass/DomainServiceClass.vstemplate
+++ b/src/VisualStudio/ItemTemplates/CSharp/DomainServiceClass/DomainServiceClass.vstemplate
@@ -31,9 +31,8 @@
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
-    <packages repository="extension"
-          repositoryId="874C448B-42DE-466B-A7E7-0EFEC1E7C009">
-      <package id="OpenRiaServices.Server" version = "4.6.0"/>
+    <packages>
+      <package id="OpenRiaServices.Server" version = "5.0.0"/>
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/VisualStudio/Templates/CSharp/BusinessApplication/BA.Web/server.vstemplate
+++ b/src/VisualStudio/Templates/CSharp/BusinessApplication/BA.Web/server.vstemplate
@@ -50,17 +50,14 @@
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
-    <packages repository="extension" repositoryId="cf249cd4-01b1-4533-8c65-2b1bb6dfa72b">
+    <packages>
       <package id="Microsoft.AspNet.Providers.Core" version="1.1" />
       <package id="Microsoft.AspNet.Providers" version="1.2" />
-    </packages>
-    <packages repository="extension"
-          repositoryId="874C448B-42DE-466B-A7E7-0EFEC1E7C009">
-        <package id="OpenRiaServices.Server" version = "4.6.0" />
+      <package id="OpenRiaServices.Server" version = "5.0.0" />
     </packages>
   </WizardData>
   <WizardExtension>
-    <Assembly>OpenRiaServices.VisualStudio.DomainServices.Tools.14.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=2e0b7ccb1ae5b4c8</Assembly>
+    <Assembly>OpenRiaServices.VisualStudio.DomainServices.Tools.14.0, Version=5.0.0.0, Culture=neutral, PublicKeyToken=2e0b7ccb1ae5b4c8</Assembly>
     <FullClassName>OpenRiaServices.VisualStudio.DomainServices.Tools.BusinessApplicationServerTemplateWizard</FullClassName>
   </WizardExtension>
 </VSTemplate>

--- a/src/VisualStudio/Templates/CSharp/BusinessApplication/BusinessApplication.vstemplate
+++ b/src/VisualStudio/Templates/CSharp/BusinessApplication/BusinessApplication.vstemplate
@@ -84,9 +84,8 @@
     <FullClassName>NuGet.VisualStudio.TemplateWizard</FullClassName>
   </WizardExtension>
   <WizardData>
-    <packages repository="extension"
-          repositoryId="874C448B-42DE-466B-A7E7-0EFEC1E7C009">
-        <package id="OpenRiaServices.Client" version = "4.6.3"/>
+    <packages>
+        <package id="OpenRiaServices.Client" version = "5.0.0"/>
     </packages>
   </WizardData>
   <WizardExtension>

--- a/src/VisualStudio/Templates/CSharp/RIAServicesLibrary/RIAServicesLibrary.vstemplate
+++ b/src/VisualStudio/Templates/CSharp/RIAServicesLibrary/RIAServicesLibrary.vstemplate
@@ -37,9 +37,8 @@
     <FullClassName>OpenRiaServices.VisualStudio.DomainServices.Tools.RiaServicesLibraryWizard</FullClassName>
   </WizardExtension>
   <WizardData>
-    <packages repository="extension"
-          repositoryId="874C448B-42DE-466B-A7E7-0EFEC1E7C009">
-      <package id="OpenRiaServices.Client" version = "4.6.3"/>
+    <packages>
+      <package id="OpenRiaServices.Client" version = "5.0.0"/>
     </packages>
   </WizardData>
 </VSTemplate>

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicClassConstants.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicClassConstants.cs
@@ -21,7 +21,6 @@
             "System.ComponentModel",
             "System.ComponentModel.DataAnnotations",
             "System.Linq", 
-            "OpenRiaServices.Hosting",
             "OpenRiaServices.Server",
         };
 


### PR DESCRIPTION
Fixes nuget issues found in #266

* update nuget package references to 5.0
* remove unused hosting namespace
* fix nuget references to work a lot better by downloading packages from nuget.org instead of looking in extension (where the were missing) 