### PR TITLE
Change Uri serialization for nullable and complex types

### DIFF
--- a/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/Behaviors/WebHttpQueryStringConverter.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/Behaviors/WebHttpQueryStringConverter.cs
@@ -17,11 +17,12 @@ namespace OpenRiaServices.Client.Web.Behaviors
 {
     internal class WebHttpQueryStringConverter : QueryStringConverter
     {
+        // Specify datetime format so that the DateTimeKind can roundtrip, otherwise unspecified values are treated incorrect by server
+        // https://github.com/OpenRIAServices/OpenRiaServices/issues/75
         const string DateTimeFormat = @"yyyy\-MM\-ddTHH\:mm\:ss.FFFFFFFK";
         private static readonly DataContractJsonSerializerSettings s_jsonSettings
             = new DataContractJsonSerializerSettings()
             {
-                UseSimpleDictionaryFormat = true,
                 DateTimeFormat = new System.Runtime.Serialization.DateTimeFormat(DateTimeFormat, System.Globalization.CultureInfo.InvariantCulture)
             };
 

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/Behaviors/WebHttpQueryStringConverter.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/Behaviors/WebHttpQueryStringConverter.cs
@@ -80,7 +80,7 @@ namespace OpenRiaServices.Client.Web.Behaviors
                 }
                 catch (Exception)
                 {
-                    // Fallback to old serialization format
+                    // Fallback to old serialization format (default settings)
                     ms.Seek(0, SeekOrigin.Begin);
                     return new DataContractJsonSerializer(parameterType)
                         .ReadObject(ms);
@@ -99,7 +99,9 @@ namespace OpenRiaServices.Client.Web.Behaviors
             // without giving wrong result for string
             if (parameter == null)
                 return "null";
-            else if (TypeUtility.IsNullableType(parameterType))
+
+            // For nullable types (which are not null), try to just serialize it as the underlying type
+            if (TypeUtility.IsNullableType(parameterType))
             {
                 parameterType = TypeUtility.GetNonNullableType(parameterType);
                 if (base.CanConvert(parameterType))
@@ -115,7 +117,7 @@ namespace OpenRiaServices.Client.Web.Behaviors
 
                 if (ms.TryGetBuffer(out var buffer))
                 {
-                    string value = Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count);
+                    string value = Encoding.UTF8.GetString(buffer.Array, index: buffer.Offset, count: buffer.Count);
                     return HttpUtility.UrlEncode(value);
                 }
                 else

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/Behaviors/WebHttpQueryStringConverter.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/WCF/Behaviors/WebHttpQueryStringConverter.cs
@@ -17,6 +17,14 @@ namespace OpenRiaServices.Client.Web.Behaviors
 {
     internal class WebHttpQueryStringConverter : QueryStringConverter
     {
+        const string DateTimeFormat = @"yyyy\-MM\-ddTHH\:mm\:ss.FFFFFFFK";
+        private static readonly DataContractJsonSerializerSettings s_jsonSettings
+            = new DataContractJsonSerializerSettings()
+            {
+                UseSimpleDictionaryFormat = true,
+                DateTimeFormat = new System.Runtime.Serialization.DateTimeFormat(DateTimeFormat, System.Globalization.CultureInfo.InvariantCulture)
+            };
+
         public override bool CanConvert(Type type)
         {
             // Allow everything.
@@ -35,6 +43,9 @@ namespace OpenRiaServices.Client.Web.Behaviors
                 return base.ConvertStringToValue(parameter, parameterType);
             }
 
+            if (parameter == "null")
+                return null;
+
             // Nullable types have historically not been handled explicitly
             // so they habe been serialized to json
             // some of them (which are not represented as text) can be parsed directly
@@ -44,9 +55,6 @@ namespace OpenRiaServices.Client.Web.Behaviors
             if (TypeUtility.IsNullableType(parameterType)
                 && !parameter.StartsWith(@"%22", StringComparison.Ordinal))
             {
-                if (parameter == "null")
-                    return null;
-
                 var actualType = parameterType.GetGenericArguments()[0];
                 if (base.CanConvert(actualType))
                 {
@@ -64,7 +72,18 @@ namespace OpenRiaServices.Client.Web.Behaviors
             parameter = HttpUtility.UrlDecode(parameter);
             using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(parameter)))
             {
-                return new DataContractJsonSerializer(parameterType).ReadObject(ms);
+                try
+                {
+                    return new DataContractJsonSerializer(parameterType, s_jsonSettings)
+                        .ReadObject(ms);
+                }
+                catch (Exception)
+                {
+                    // Fallback to old serialization format
+                    ms.Seek(0, SeekOrigin.Begin);
+                    return new DataContractJsonSerializer(parameterType)
+                        .ReadObject(ms);
+                }
             }
         }
 
@@ -74,13 +93,32 @@ namespace OpenRiaServices.Client.Web.Behaviors
             {
                 return base.ConvertValueToString(parameter, parameterType);
             }
+
+            // Strings are handled above, so it should be save to return null here
+            // without giving wrong result for string
+            if (parameter == null)
+                return "null";
+            else if (TypeUtility.IsNullableType(parameterType))
+            {
+                parameterType = TypeUtility.GetNonNullableType(parameterType);
+                if (base.CanConvert(parameterType))
+                {
+                    return base.ConvertValueToString(parameter, parameterType);
+                }
+            }
+
             using (MemoryStream ms = new MemoryStream())
             {
-                new DataContractJsonSerializer(parameterType)
+                new DataContractJsonSerializer(parameterType, s_jsonSettings)
                     .WriteObject(ms, parameter);
-                byte[] result = ms.ToArray();
-                string value = Encoding.UTF8.GetString(result, 0, result.Length);
-                return HttpUtility.UrlEncode(value);
+
+                if (ms.TryGetBuffer(out var buffer))
+                {
+                    string value = Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count);
+                    return HttpUtility.UrlEncode(value);
+                }
+                else
+                    return string.Empty;
             }
         }
     }


### PR DESCRIPTION
1. Pass nullable types using same format as non-nullable types
- Requires 5.0.1 server at least
2. Change serialization of DateTimeOffset on complex objects to fix #75 

Server is backwards compatible with old clients, but a new client will require a new server

Open questions
- Does it makes sense to use DataContractSurrogates (ISerializationSurrogateProvider) in order to support reading datetime/datetimeoffset in both standard ISO format as well as the current approach of DataContractJsonSerializer ? (*update* this does not work good for deserialization if string is used as surrogate - "invalidcastexception", but might work with another type)
- Can and should we take a dependency on newtonsoft.json ? it might make sense for 6.0 but maybe not now ? how many additional dlls and assembiles are in such case required?

The second commit fixes #75 , but has the drawback of the new client requireing a new server (server was made backwards compatible)