### PR TITLE
Validate entity parameters passed to invoke operations 

### DIFF
--- a/src/OpenRiaServices.Client/Framework/ValidationUtilities.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationUtilities.cs
@@ -375,6 +375,12 @@ namespace OpenRiaServices.Client
         {
             bool breakOnFirstError = validationResults == null;
 
+            // TODO: Split property into, properties for attributes on method and on properties
+            if (!operationEntry.RequiresValidation)
+            {
+                return true;
+            }
+
             ValidationContext methodContext = CreateValidationContext(validationContext.ObjectInstance, validationContext);
             methodContext.MemberName = operationEntry.Name;
 

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -1198,13 +1198,6 @@ namespace OpenRiaServices.Server
             // First do an authentication check and throw immediately if unauthorized
             this.ValidateMethodPermissions(domainOperationEntry, /* entity */ null);
 
-            // Then do validaiton only if required
-            if (!domainOperationEntry.RequiresValidation)
-            {
-                validationResults = null;
-                return true;
-            }
-
             validationResults = new List<ValidationResult>();
             ValidationContext validationContext = ValidationUtilities.CreateValidationContext(this, this.ValidationContext);
 

--- a/src/OpenRiaServices.Server/Test/InvokeOperationServerTest.cs
+++ b/src/OpenRiaServices.Server/Test/InvokeOperationServerTest.cs
@@ -117,24 +117,37 @@ namespace OpenRiaServices.Server.Test
         }
 
         [TestMethod]
-        [Description("Invoking an invoke operation with invalid parameters")]
-        public async Task InvokeOperation_ServerValidationError()
+        [Description("Invoking an invoke operation should validate parameter validation attributes")]
+        public async Task InvokeOperation_ServerValidationError_Parameter_ValidationAttributes()
         {
             TestProvider_Scenarios provider = ServerTestHelper.CreateInitializedDomainService<TestProvider_Scenarios>(DomainOperationType.Invoke);
             DomainServiceDescription serviceDescription = DomainServiceDescription.GetDescription(typeof(TestProvider_Scenarios));
-            DomainOperationEntry incrementBid1ForAByMethod = serviceDescription.GetInvokeOperation("IncrementBid1ForABy");
-            Assert.IsNotNull(incrementBid1ForAByMethod);
+            DomainOperationEntry operationEntry = serviceDescription.GetInvokeOperation("VariousParameterTypes");
+            Assert.IsNotNull(operationEntry);
 
-            TestDomainServices.A inputA = new TestDomainServices.A()
-            {
-                BID1 = 1
-            };
-            var invokeResult = await provider.InvokeAsync(new InvokeDescription(incrementBid1ForAByMethod, new object[] { inputA, 2 }), CancellationToken.None);
+            // parameters string, int, bool and only string has validation attribute
+            var invokeResult = await provider.InvokeAsync(new InvokeDescription(operationEntry, new object[] { string.Empty, 2, false }), CancellationToken.None);
             Assert.IsNull(invokeResult.Result);
             Assert.IsNotNull(invokeResult.ValidationErrors);
-            Assert.AreEqual(2, invokeResult.ValidationErrors.Count);
-            Assert.AreEqual("The field delta must be between 5 and 10.", invokeResult.ValidationErrors.ElementAt(0).ErrorMessage);
-            Assert.AreEqual("The RequiredString field is required.", invokeResult.ValidationErrors.ElementAt(1).ErrorMessage);
+            Assert.AreEqual(1, invokeResult.ValidationErrors.Count);
+            Assert.AreEqual("The str field is required.", invokeResult.ValidationErrors.ElementAt(0).ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("Invoking an invoke operation with single entity should perform object level validation of the entity")]
+        public async Task InvokeOperation_ServerValidationError_Entity()
+        {
+            TestProvider_Scenarios provider = ServerTestHelper.CreateInitializedDomainService<TestProvider_Scenarios>(DomainOperationType.Invoke);
+            DomainServiceDescription serviceDescription = DomainServiceDescription.GetDescription(typeof(TestProvider_Scenarios));
+            DomainOperationEntry operationEntry = serviceDescription.GetInvokeOperation(nameof(TestProvider_Scenarios.IncrementBid1ForA));
+            Assert.IsNotNull(operationEntry);
+
+            TestDomainServices.A inputA = new TestDomainServices.A();
+            var invokeResult = await provider.InvokeAsync(new InvokeDescription(operationEntry, new object[] { inputA }), CancellationToken.None);
+            Assert.IsNull(invokeResult.Result, "Should have validation errors instead");
+            Assert.IsNotNull(invokeResult.ValidationErrors, "Should have validation errors");
+            Assert.AreEqual(1, invokeResult.ValidationErrors.Count);
+            Assert.AreEqual("The RequiredString field is required.", invokeResult.ValidationErrors.First().ErrorMessage);
         }
 
         [TestMethod]


### PR DESCRIPTION
Add test that entitites are validated for invoke operations 
* move validation "optimization" so that entities are always checked for

Fix #292 

This is a small fix for the issue, for 5.1 I hope to fix validation for ComplexTypes and maybe have some cleanup of the validation code. 