### PR TITLE
BinaryHttpDomainClientFactory: Properly handle nullable parameters for EntityActions

### DIFF
--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/Http/BinaryHttpDomainClient.cs
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/Http/BinaryHttpDomainClient.cs
@@ -157,7 +157,6 @@ namespace OpenRiaServices.Client.DomainClients.Http
         }
         #endregion
 
-
         #region Private methods for making requests
         /// <summary>
         /// Invokes a web request for the operation <paramref name="operationName"/>
@@ -492,7 +491,7 @@ namespace OpenRiaServices.Client.DomainClients.Http
                     var method = entityType.GetMethod(entityAction.Name);
                     foreach (var parameter in method.GetParameters())
                     {
-                        var type = parameter.ParameterType;
+                        var type = TypeUtility.GetNonNullableType(parameter.ParameterType);
                         if (visitedTypes.Add(type))
                         {
                             // Most "primitive types" are already registered

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/Http/BinaryHttpDomainClient.cs
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/Http/BinaryHttpDomainClient.cs
@@ -470,7 +470,6 @@ namespace OpenRiaServices.Client.DomainClients.Http
         /// <returns></returns>
         internal DataContractSerializerSettings GetSubmitDataContractSettings()
         {
-            var resolver = new SubmitDataContractResolver();
             var visitedTypes = new HashSet<Type>(EntityTypes);
             var knownTypes = new HashSet<Type>(visitedTypes);
             var toVisit = new Stack<Type>(knownTypes);
@@ -502,7 +501,7 @@ namespace OpenRiaServices.Client.DomainClients.Http
                                 if (typeof(DateTimeOffset) == type || type.IsEnum)
                                     knownTypes.Add(type);
                             }
-                            else if (resolver.TryGetEquivalentContractType(type, out var collectionType))
+                            else if (SubmitDataContractResolver.TryGetEquivalentContractType(type, out var collectionType))
                             {
                                 knownTypes.Add(collectionType);
                                 // Add elementType too ??
@@ -516,6 +515,7 @@ namespace OpenRiaServices.Client.DomainClients.Http
                 }
             }
 
+            var resolver = new SubmitDataContractResolver();
             return new DataContractSerializerSettings()
             {
                 KnownTypes = knownTypes,

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/Http/SubmitDataContractResolver.cs
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/Http/SubmitDataContractResolver.cs
@@ -51,30 +51,6 @@ namespace OpenRiaServices.Client.DomainClients.Http
                 return true;
             }
 
-            // Handle types with datacontract with Name or Namespace missing
-            // This might happen for types in other referenced assemblies in some scenarios
-            foreach (DataContractAttribute dataContract in type.GetCustomAttributes(typeof(DataContractAttribute), false))
-            {
-                var xmlDictionary = new XmlDictionary(2);
-
-                // Name defaults to type name if not set, special care is needed for genereic types 
-                // but as long as those use datacontract attributes to set Name it should work fine (the fallback here won't work for them)
-                // https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/data-contract-names#data-contract-names-1
-                typeName = xmlDictionary.Add(dataContract.Name ?? type.Name);
-
-                // Namespace seems to be populated by default even if not set, we do however include a fallback
-                // which works, except that it does not account for the ContractNamespaceAttribute set on the target 
-                // https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/data-contract-names#data-contract-namespaces
-                string @namespace = dataContract.Namespace;
-                if (@namespace is null)
-                    @namespace = "http://schemas.datacontract.org/2004/07/" + type.Namespace;
-
-                typeNamespace = xmlDictionary.Add(@namespace);
-                _knownTypes.TryAdd(type, (typeName, typeNamespace));
-
-                return true;
-            }
-
             typeName = null;
             typeNamespace = null;
             return true;


### PR DESCRIPTION
Types that are only exposed as nullable on EntityActions was not added to the KnownTypes