### PR TITLE
Allow method (parameter) injection

### DIFF
--- a/src/OpenRiaServices.Server.UnitTesting/Test/DomainServiceTestHostTests.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/DomainServiceTestHostTests.cs
@@ -22,7 +22,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
 
             var expectedResult = "Echo: Hello";
 
-            var result = await testHost.InvokeAsync(s => s.EchoWithDelay("Hello", TimeSpan.FromMilliseconds(1)), CancellationToken.None);
+            var result = await testHost.InvokeAsync(s => s.EchoWithDelay("Hello", TimeSpan.FromMilliseconds(1), CancellationToken.None), CancellationToken.None);
             
             Assert.AreEqual(expectedResult, result);
         }
@@ -34,7 +34,7 @@ namespace OpenRiaServices.Server.UnitTesting.Test
 
             var expectedResult = "Echo: Hello";
 
-            var result = testHost.Invoke(s => s.EchoWithDelay("Hello", TimeSpan.FromMilliseconds(1)));
+            var result = testHost.Invoke(s => s.EchoWithDelay("Hello", TimeSpan.FromMilliseconds(1), CancellationToken.None));
 
             Assert.AreEqual(expectedResult, result);
         }

--- a/src/OpenRiaServices.Server/Framework/Data/DynamicMethodUtility.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DynamicMethodUtility.cs
@@ -155,7 +155,7 @@ namespace OpenRiaServices.Server
                 parameterTypes = new Type[] { typeof(DomainService), typeof(object[]) };
             }
 
-            DynamicMethod proxyMethod = new DynamicMethod(method.Name, typeof(object), parameterTypes, /* restrictedSkipVisibility */ !method.IsPublic);
+            DynamicMethod proxyMethod = new DynamicMethod(method.Name, typeof(object), parameterTypes, restrictedSkipVisibility: true);
             ILGenerator generator = proxyMethod.GetILGenerator();
 
             // Cast the target object to its actual type.

--- a/src/OpenRiaServices.Server/Framework/Data/DynamicMethodUtility.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DynamicMethodUtility.cs
@@ -337,10 +337,5 @@ namespace OpenRiaServices.Server
         {
             return await valueTask.ConfigureAwait(false);
         }
-
-        private static ValueTask<object> ToValueTask(object obj)
-        {
-            return new ValueTask<object>(obj);
-        }
     }
 }

--- a/src/OpenRiaServices.Server/Framework/Data/InjectParameterAttribute.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/InjectParameterAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace OpenRiaServices.Server
+{
+    /// <summary>
+    ///  EXPERIMENTAL: support for injecting dependencies to <see cref="DomainService"/> methods similar to [FromServices] in ASP.NET Core
+    ///  <para>
+    ///  The services are resolved by calling <see cref="DomainServiceContext.GetService(Type)"/> on <see cref="DomainService.ServiceContext"/>
+    ///  </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class InjectParameterAttribute : Attribute
+    {
+    }
+}

--- a/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
@@ -452,22 +452,27 @@ namespace OpenRiaServices.Server
                 List<DomainOperationParameter> parameters = new List<DomainOperationParameter>();
                 foreach (ParameterInfo parameterInfo in actualParameters)
                 {
-                    // Skip cancellationtoken (it is passed dynamically)
-                    // TODO: only do for last parameter ??
-                    if (parameterInfo.ParameterType == typeof(CancellationToken))
+                    var attributes = parameterInfo.GetCustomAttributes(true).Cast<Attribute>().ToArray();
+                    if (IsInjectedParameter(parameterInfo, attributes))
                         continue;
 
                     bool isOut = parameterInfo.IsOut && parameterInfo.ParameterType.HasElementType;
                     DomainOperationParameter parameter = new DomainOperationParameter(
                         parameterInfo.Name,
                         parameterInfo.ParameterType,
-                        new AttributeCollection(parameterInfo.GetCustomAttributes(true).Cast<Attribute>().ToArray()),
+                        new AttributeCollection(attributes),
                         isOut);
 
                     parameters.Add(parameter);
                 }
 
                 return parameters;
+            }
+
+            internal static bool IsInjectedParameter(ParameterInfo parameterInfo, Attribute [] attributes)
+            {
+                return parameterInfo.ParameterType == typeof(CancellationToken)
+                    || attributes.Any(a => a is InjectParameterAttribute);
             }
 
             /// <summary>

--- a/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
@@ -452,6 +452,11 @@ namespace OpenRiaServices.Server
                 List<DomainOperationParameter> parameters = new List<DomainOperationParameter>();
                 foreach (ParameterInfo parameterInfo in actualParameters)
                 {
+                    // Skip cancellationtoken (it is passed dynamically)
+                    // TODO: only do for last parameter ??
+                    if (parameterInfo.ParameterType == typeof(CancellationToken))
+                        continue;
+
                     bool isOut = parameterInfo.IsOut && parameterInfo.ParameterType.HasElementType;
                     DomainOperationParameter parameter = new DomainOperationParameter(
                         parameterInfo.Name,

--- a/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
@@ -393,7 +393,7 @@ namespace OpenRiaServices.Server
         internal class ReflectionDomainOperationEntry : DomainOperationEntry
         {
             private bool _isInferred;
-            private readonly Func<DomainService, object[], object> _method;
+            private readonly Func<DomainService, object[], ValueTask<object>> _method;
 
             /// <summary>
             /// Creates an instance of a <see cref="ReflectionDomainOperationEntry"/>.
@@ -443,7 +443,7 @@ namespace OpenRiaServices.Server
             /// <returns>The return value of the invoked method.</returns>
             public override ValueTask<object> InvokeAsync(DomainService domainService, object[] parameters, CancellationToken cancellationToken)
             {
-                return UnwrapTaskResult(this._method(domainService, parameters));
+                return this._method(domainService, parameters);
             }
 
             private static IEnumerable<DomainOperationParameter> GetMethodParameters(MethodInfo methodInfo)

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.ServiceModel;
+using System.Threading;
 using System.Threading.Tasks;
 using OpenRiaServices;
 using OpenRiaServices.Server;
@@ -292,8 +293,11 @@ namespace Cities
         }
 
         [Invoke]
-        public async Task<string> EchoWithDelay(string msg, TimeSpan delay)
+        public async Task<string> EchoWithDelay(string msg, TimeSpan delay, CancellationToken cancellationToken)
         {
+            if (!cancellationToken.Equals(ServiceContext.CancellationToken))
+                throw new DomainException("CancellationToken parameter does not work");
+
             // This method is used to test cancellation of invoke operations
             // Since the method might return to soon otherwise we add a delay
             await Task.Delay(delay, ServiceContext.CancellationToken);

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Cities/CityDomainService.cs
@@ -99,8 +99,13 @@ namespace Cities
         }
 
         [Query]
-        public IQueryable<State> GetStatesInShippingZone(ShippingZone shippingZone)
+        public IQueryable<State> GetStatesInShippingZone(ShippingZone shippingZone, [InjectParameter] System.Web.HttpContext httpContext, [InjectParameter] System.Security.Principal.IPrincipal principal)
         {
+            if (!object.ReferenceEquals(httpContext, System.Web.HttpContext.Current))
+                throw new DomainException("DomainService parameter injection does not work");
+            if (!object.ReferenceEquals(principal, ServiceContext.User))
+                throw new DomainException("DomainService parameter injection does not work");
+
             return this._cityData.States.Where(s => s.ShippingZone == shippingZone).AsQueryable<State>();
         }
 

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/ServerSideAsyncDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/ServerSideAsyncDomainService.cs
@@ -98,12 +98,10 @@ namespace TestDomainServices
         /// </summary>
         /// <param name="id">The identifier.</param>
         /// <returns></returns>
-        public Task<RangeItem> GetRangeByIdAsync(int id)
+        public async ValueTask<RangeItem> GetRangeByIdAsync(int id)
         {
-            return Delay(1)
-                .ContinueWith(_ =>
-                    _items.FirstOrDefault(a => a.Id == id)
-                );
+            await Delay(1);
+            return _items.FirstOrDefault(a => a.Id == id);
         }
 
         /// <summary>
@@ -125,7 +123,7 @@ namespace TestDomainServices
         /// <param name="rangeItem">Item to update</param>
         /// <returns></returns>
         [Update]
-        public async Task UpdateRangeAsync(RangeItem rangeItem)
+        public async ValueTask UpdateRangeAsync(RangeItem rangeItem)
         {
             await Delay(5);
             rangeItem.Text = "updated";

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/ServerSideAsyncDomainService.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Mocks/ServerSideAsyncDomainService.cs
@@ -60,8 +60,11 @@ namespace TestDomainServices
         /// Query returing a queryable range in a task
         /// </summary>
         /// <returns></returns>
-        public Task<IQueryable<RangeItem>> GetQueryableRangeAsync()
+        public Task<IQueryable<RangeItem>> GetQueryableRangeAsync(CancellationToken cancellationToken)
         {
+            if (!cancellationToken.Equals(ServiceContext.CancellationToken))
+                throw new DomainException("CancellationToken parameter does not work");
+
             return Delay(1)
                .ContinueWith(_ =>
                    _items.AsQueryable()

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/IISExpressWebserver.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/IISExpressWebserver.cs
@@ -43,7 +43,7 @@ namespace OpenRiaServices.Common.Test
 
             _iisProcess = Process.Start(startInfo);
 
-            string str;
+            string str, last = string.Empty;
             while ((str = _iisProcess.StandardOutput.ReadLine()) != null)
             {
                 if (str.Contains("IIS Express is running")
@@ -54,10 +54,10 @@ namespace OpenRiaServices.Common.Test
 
                     return true;
                 }
-
+                last = str;
             }
 
-            throw new Exception("Failed to start IIS express");
+            throw new Exception("Failed to start IIS express: " + last);
         }
 
         // Read and discard output from the web server so that 


### PR DESCRIPTION
* allow parameters of type CancellationToken for all kinds of service methods
* Make the generated method return ValueTask<object> so that the UnwrapTaskResult logic from ReflectionDomainServiceDescriptionProvider can be removed (and better perf)
* allow injecting services to parameters.
   *  would probably add an attribute similar to asp.net core's [FromService] or similar
   *  It uses ServiceContext.ServiceContaier to resolve instances, so the actual container can be replaced in the DomainService's  intitialize method 
     * to make it more usefull WCF hosting should probably add support for Microsoft.Extensions .DI,  with support for scopes and allow setting the Container (would "replace" the current IDomainServiceFactory)