### PR TITLE
Explicitly load task assemblies as x86

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# 4.6.4
+
+## Client
+
+1. Explicitly load MSBuild task assemblies as x86 when generating Silverlight client proxy classes
+
 # 4.6.3
 
 ## Client

--- a/OpenRiaServices.NuGet/OpenRiaServices.NuGet.csproj
+++ b/OpenRiaServices.NuGet/OpenRiaServices.NuGet.csproj
@@ -69,6 +69,7 @@
     <None Include="OpenRiaServices.Server\content\web.config.transform" />
     <None Include="OpenRiaServices.Server\tools\Install.ps1" />
     <None Include="OpenRiaServices.Server\tools\Uninstall.ps1" />
+    <None Include="OpenRiaServices.Silverlight.ComboBoxExtensions\OpenRiaServices.Silverlight.ComboBoxExtensions.nuspec" />
     <None Include="OpenRiaServices.Silverlight.Core\OpenRiaServices.Signed.Silverlight.Core.nuspec" />
     <None Include="OpenRiaServices.Silverlight.Core\OpenRiaServices.Silverlight.Core.nuspec" />
     <None Include="OpenRiaServices.Silverlight.DomainDataSource\OpenRiaServices.Signed.Silverlight.DomainDataSource.nuspec" />

--- a/OpenRiaServices.NuGet/OpenRiaServices.Silverlight.CodeGen/build/OpenRiaServices.Silverlight.CodeGen.targets
+++ b/OpenRiaServices.NuGet/OpenRiaServices.Silverlight.CodeGen/build/OpenRiaServices.Silverlight.CodeGen.targets
@@ -12,10 +12,10 @@ WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <UsingTask TaskName="OpenRiaServices.DomainServices.Tools.CreateOpenRiaClientFilesTask"
-             AssemblyFile="OpenRiaServices.DomainServices.Tools.dll" />
+             AssemblyFile="OpenRiaServices.DomainServices.Tools.dll" Architecture="x86" />
 
   <UsingTask TaskName="OpenRiaServices.DomainServices.Tools.CleanOpenRiaClientFilesTask"
-             AssemblyFile="OpenRiaServices.DomainServices.Tools.dll" />
+             AssemblyFile="OpenRiaServices.DomainServices.Tools.dll" Architecture="x86" />
 
 
   <PropertyGroup>

--- a/OpenRiaServices.NuGet/OpenRiaServices.Silverlight.ComboBoxExtensions/OpenRiaServices.Silverlight.ComboBoxExtensions.nuspec
+++ b/OpenRiaServices.NuGet/OpenRiaServices.Silverlight.ComboBoxExtensions/OpenRiaServices.Silverlight.ComboBoxExtensions.nuspec
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>OpenRiaServices.Silverlight.ComboBoxExtensions</id>
+    <version>4.4.0</version>
+    <title>Open RIA Services Silverlight ComboBoxExtensions</title>
+    <authors>Outercurve RIA Services</authors>
+    <owners>Outercurve</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">Apache-2.0</license>
+    <projectUrl>https://github.com/OpenRIAServices/OpenRiaServices</projectUrl>
+    <description>OpenRiaServices.Silverlight.ComboBoxExensions are a direct port of OpenRiaServices.ComboBoxExtensions.</description>
+    <summary>Open RIA Services - Silverlight DomainDataSource control</summary>
+    <releaseNotes>For release notes see https://github.com/OpenRIAServices/OpenRiaServices/releases</releaseNotes>
+    <copyright>2018 Outercurve Foundation</copyright>
+    <language>en-US</language>
+    <tags>WCF RIA Services RIAServices Silverlight DomainDataSource OpenRIAServices</tags>
+    <dependencies>
+      <group targetFramework="sl50">
+        <dependency id="OpenRiaServices.Client.Core" version="$version$"/>
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\..\bin\Release\OpenRiaServices.Silverlight.ComboBoxExtensions.dll" target="lib\sl5\OpenRiaServices.Silverlight.ComboBoxExtensions.dll" />
+    <file src="..\..\bin\Release\OpenRiaServices.Silverlight.ComboBoxExtensions.pdb" target="lib\sl5\OpenRiaServices.Silverlight.ComboBoxExtensions.pdb" />
+    <file src="..\..\bin\Release\OpenRiaServices.Silverlight.ComboBoxExtensions.xml" target="lib\sl5\OpenRiaServices.Silverlight.ComboBoxExtensions.xml" />
+  </files>
+</package>

--- a/OpenRiaServices.Silverlight.ComboBoxExtensions/Framework/Silverlight/OpenRiaServices.Silverlight.ComboBoxExtensions.csproj
+++ b/OpenRiaServices.Silverlight.ComboBoxExtensions/Framework/Silverlight/OpenRiaServices.Silverlight.ComboBoxExtensions.csproj
@@ -11,7 +11,8 @@
     <ProjectGuid>{227B6165-3BC4-41F2-A8EE-FE1734ED0C8E}</ProjectGuid>
     <ProjectTypeGuids>{A1591282-1198-4647-A2B1-27E5FF5F6F3B};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
-    <OutputPath>..\..\..\bin\$(Configuration)\Silverlight\</OutputPath>
+    <OutputPath>..\..\..\bin\$(Configuration)</OutputPath>
+    <DocumentationFile>..\..\..\bin\$(Configuration)\OpenRiaServices.Silverlight.ComboBoxExtensions.xml</DocumentationFile>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenRiaServices.Silverlight.ComboBoxExtensions</RootNamespace>
     <AssemblyName>OpenRiaServices.Silverlight.ComboBoxExtensions</AssemblyName>
@@ -46,8 +47,6 @@
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>
-    </DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Signed|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -57,8 +56,6 @@
     <NoConfig>true</NoConfig>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>
-    </DocumentationFile>
   </PropertyGroup>
   <Import Project="$(FeaturePackageRoot)\FeaturePackage.targets" />
   <ItemGroup>

--- a/RiaServices.sln
+++ b/RiaServices.sln
@@ -143,6 +143,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRiaServicesLibrary", "V
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BusinessApplicationProjectTemplate", "VisualStudio\Templates\CSharp\BusinessApplication\BusinessApplicationProjectTemplate.csproj", "{C8814DD1-905D-41F8-B587-99FD85524F8B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Silverlight", "Silverlight", "{ABF04EF4-43D0-44AF-8A16-DD2BCB227E76}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRiaServices.Silverlight.ComboBoxExtensions", "OpenRiaServices.Silverlight.ComboBoxExtensions\Framework\Silverlight\OpenRiaServices.Silverlight.ComboBoxExtensions.csproj", "{227B6165-3BC4-41F2-A8EE-FE1734ED0C8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -349,6 +353,10 @@ Global
 		{C8814DD1-905D-41F8-B587-99FD85524F8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8814DD1-905D-41F8-B587-99FD85524F8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8814DD1-905D-41F8-B587-99FD85524F8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{227B6165-3BC4-41F2-A8EE-FE1734ED0C8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{227B6165-3BC4-41F2-A8EE-FE1734ED0C8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{227B6165-3BC4-41F2-A8EE-FE1734ED0C8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{227B6165-3BC4-41F2-A8EE-FE1734ED0C8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -415,6 +423,8 @@ Global
 		{546DB9D1-BA54-499A-854D-00D8A311B56A} = {2EDF0504-D588-4C91-A0B9-8209C5997405}
 		{B1D492E3-3283-43E3-8598-9892E3CD2F54} = {546DB9D1-BA54-499A-854D-00D8A311B56A}
 		{C8814DD1-905D-41F8-B587-99FD85524F8B} = {546DB9D1-BA54-499A-854D-00D8A311B56A}
+		{ABF04EF4-43D0-44AF-8A16-DD2BCB227E76} = {1CED8364-77AC-4254-869F-1E4EC5A33416}
+		{227B6165-3BC4-41F2-A8EE-FE1734ED0C8E} = {ABF04EF4-43D0-44AF-8A16-DD2BCB227E76}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C135CEC9-180C-4B67-92AC-3342375AE14C}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
 - powershell: |
    [string]$RepositoryRoot = "$(Build.SourcesDirectory)"
    
-   $url = "https://download.microsoft.com/download/3/A/3/3A35179D-5C87-4D0A-91EB-BF5FEDC601A4/sdk/silverlight_sdk.exe"
+   $url = "https://web.archive.org/web/20190126163602if_/http://download.microsoft.com/download/3/A/3/3A35179D-5C87-4D0A-91EB-BF5FEDC601A4/sdk/silverlight_sdk.exe"
    $fileName = "silverlight_5_sdk.exe"
    $fullPath = (join-path $RepositoryRoot $fileName)
    
@@ -43,6 +43,15 @@ steps:
    }
    
    dir $fullPath
+
+   $hash = Get-FileHash $fullPath -Algorithm "SHA256"
+   If ($hash.Hash -ne "F52FE767C2290D04B21E8DA0ABABDF710B7933A976B2EB1C99EEA2F5529F6D10")
+   {
+     echo "Hash doesn't match the expected value. Actual value: $hash.Hash."
+     $host.SetShouldExit(1)
+     exit 1
+   }
+
    echo "Installing Silverlight 5 SDK"
    "executing $fullPath /q  /norestart"
    


### PR DESCRIPTION
This adds support for Visual Studio 2022 which is 64-bit.