### PR TITLE
Improve Tooling support for projects targeting multiple TargetFrameworks

### DIFF
--- a/src/OpenRiaServices.Client/Test/Client.External.Test/OpenRiaServices.Client.External.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.External.Test/OpenRiaServices.Client.External.Test.csproj
@@ -4,7 +4,7 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>OpenRiaServices.Client.Test</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
@@ -7,7 +7,7 @@
     <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Hosting.Wcf.Endpoint/Test/OpenRiaServices.Hosting.Wcf.Endpoint.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf.Endpoint/Test/OpenRiaServices.Hosting.Wcf.Endpoint.Test.csproj
@@ -5,7 +5,7 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Hosting.Wcf.OData/Test/OpenRiaServices.Hosting.Wcf.OData.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf.OData/Test/OpenRiaServices.Hosting.Wcf.OData.Test.csproj
@@ -14,7 +14,7 @@
     </EntityDeploy>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Hosting.Wcf/Test/OpenRiaServices.Hosting.Wcf.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf/Test/OpenRiaServices.Hosting.Wcf.Test.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj
+++ b/src/OpenRiaServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj
@@ -10,7 +10,7 @@
     <Compile Include="..\..\OpenRiaServices.Server\Test\MockDataService.cs" Link="Shared\MockDataService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
+++ b/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
@@ -48,15 +48,15 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.Build" Version="17.2.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.2.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.2.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
 </Project>

--- a/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
+++ b/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
@@ -119,7 +119,7 @@ namespace OpenRiaServices.Tools
                             // if only a single target without ";" then that will be the the single result of split
                             var firstFramework = targetFrameworks.Split(';')[0].Trim();
                             project.SetGlobalProperty("TargetFramework", firstFramework);
-                            this._logger.LogMessage($"Project '{projectPath}' has multiple TargetFrameworks. Choosing first framework: '{firstFramework}'");
+                            this._logger.LogMessage(string.Format(Resource.Project_Is_MultiTarget_Using_TargetFramework, projectPath, firstFramework));
                         }
 
                         project.ReevaluateIfNecessary();

--- a/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
+++ b/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
@@ -107,6 +107,23 @@ namespace OpenRiaServices.Tools
                 if (project == null)
                 {
                     project = this._projectCollection.LoadProject(projectPath);
+
+                    // Check if 'IsCrossTargetingBuild' is true
+                    // * this means 'TargetFramework' is missing, but 'TargetFrameworks' are not
+                    if (project.GetProperty("IsCrossTargetingBuild")?.EvaluatedValue == "true")
+                    {
+                        var targetFrameworks = project.GetProperty("TargetFrameworks")?.EvaluatedValue;
+                        if (targetFrameworks != null)
+                        {
+                            // fallback to first item (ideally we should loop all or take based on referenced project)
+                            // if only a single target without ";" then that will be the the single result of split
+                            var firstFramework = targetFrameworks.Split(';')[0].Trim();
+                            project.SetGlobalProperty("TargetFramework", firstFramework);
+                            this._logger.LogMessage($"Project {projectPath} has targets multiple frameworks. Choosing first target '{firstFramework}'");
+                        }
+
+                        project.ReevaluateIfNecessary();
+                    }
                 }
 #else
                 project = null;
@@ -216,7 +233,8 @@ namespace OpenRiaServices.Tools
             this._logger.LogMessage(string.Format(CultureInfo.CurrentCulture, Resource.Analyzing_Project_Files, Path.GetFileName(projectPath)));
 
 #if NET40
-            sources = project.GetItems("Compile").Select(i => ConvertToFullPath(i.EvaluatedInclude, projectPath));
+            sources = project.GetItems("Compile").Select(i => ConvertToFullPath(i.EvaluatedInclude, projectPath))
+                .ToArray();
 #else
             BuildItemGroup buildItemGroup = project.GetEvaluatedItemsByName("Compile");
             if (buildItemGroup != null)
@@ -244,6 +262,6 @@ namespace OpenRiaServices.Tools
                 this._projectCollection = null;
             }
         }
-#endregion
+        #endregion
     }
 }

--- a/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
+++ b/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
@@ -119,7 +119,7 @@ namespace OpenRiaServices.Tools
                             // if only a single target without ";" then that will be the the single result of split
                             var firstFramework = targetFrameworks.Split(';')[0].Trim();
                             project.SetGlobalProperty("TargetFramework", firstFramework);
-                            this._logger.LogMessage($"Project {projectPath} has targets multiple frameworks. Choosing first target '{firstFramework}'");
+                            this._logger.LogMessage($"Project '{projectPath}' has multiple TargetFrameworks. Choosing first framework: '{firstFramework}'");
                         }
 
                         project.ReevaluateIfNecessary();

--- a/src/OpenRiaServices.Tools/Framework/Resource.Designer.cs
+++ b/src/OpenRiaServices.Tools/Framework/Resource.Designer.cs
@@ -19,7 +19,7 @@ namespace OpenRiaServices.Tools {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resource {
@@ -1359,6 +1359,15 @@ namespace OpenRiaServices.Tools {
         internal static string Project_Does_Not_Exist {
             get {
                 return ResourceManager.GetString("Project_Does_Not_Exist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project &apos;{0}&apos; has multiple TargetFrameworks. Choosing first framework: &apos;{1}&apos;.
+        /// </summary>
+        internal static string Project_Is_MultiTarget_Using_TargetFramework {
+            get {
+                return ResourceManager.GetString("Project_Is_MultiTarget_Using_TargetFramework", resourceCulture);
             }
         }
         

--- a/src/OpenRiaServices.Tools/Framework/Resource.resx
+++ b/src/OpenRiaServices.Tools/Framework/Resource.resx
@@ -650,4 +650,7 @@ Gets a user representing the authenticated identity.
   <data name="ClientCodeGen_SignedTools_UnsignedServer" xml:space="preserve">
     <value>You are usigned the signed code generation but the server assemblies are unsigned, consider using the unsigned code generation package instead since code generation might fail.</value>
   </data>
+  <data name="Project_Is_MultiTarget_Using_TargetFramework" xml:space="preserve">
+    <value>Project '{0}' has multiple TargetFrameworks. Choosing first framework: '{1}'</value>
+  </data>
 </root>

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -9,13 +9,13 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Microsoft.Build" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.0.461" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.2.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.2.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.2.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/OpenRiaServices.Tools/Test/ServerClassLib2/ServerClassLib2.csproj
+++ b/src/OpenRiaServices.Tools/Test/ServerClassLib2/ServerClassLib2.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Data.DataSetExtensions" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
+++ b/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
@@ -14,7 +14,7 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">


### PR DESCRIPTION
This fix ensures that sdk style implicit included code files are detected for server projects targeting multiple target frameworks.

With this fix detection of shared source files and related tasks works as expected.