### PR TITLE
Aspnetcore: use route order 0 instead of 1

### DIFF
--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
@@ -98,7 +98,7 @@ namespace OpenRiaServices.Hosting.AspNetCore
             var endpointBuilder = new RouteEndpointBuilder(
                 invoker.Invoke,
                 route,
-                1)
+                0)
             {
                 DisplayName = $"{domainService}.{invoker.OperationName}"
             };

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
@@ -6,8 +6,7 @@
     <RootNamespace>OpenRiaServices.Hosting</RootNamespace>
     <!-- Ignore documentation varnings while experimental-->
     <NoWarn>$(NoWarn);CS1574;CS1573;CS1591;CS1572</NoWarn>
-    <AssemblyVersion>0.1.0</AssemblyVersion>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Daniel-Svensson</Authors>


### PR DESCRIPTION
Use order 0 så that they have same priority as most other routes