### PR TITLE
AspNetCore: Prevention for DOS attacks where attacker specify large content-length

### DIFF
--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
@@ -72,16 +72,18 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
         protected async Task<(ServiceQuery, object[])> ReadParametersFromBodyAsync(HttpContext context)
         {
             var request = context.Request;
-            var contentLength = request.ContentLength;
-            if (!contentLength.HasValue || contentLength < 0 || contentLength > int.MaxValue)
-                throw new BadHttpRequestException("invalid lenght", (int)System.Net.HttpStatusCode.LengthRequired);
 
-            var length = (int)contentLength;
+            int initialCapacity = request.ContentLength switch
+            {
+                long contentLength and >= 0 and <= int.MaxValue => Math.Min((int)contentLength, 4096),
+                null => 4096,
+                _ => throw new BadHttpRequestException("invalid lenght", (int)System.Net.HttpStatusCode.BadRequest)
+            };
 
             // To prevent DOS attacks where an attacker can allocate arbitary large memory by setting content-length to a large value
             // We only allocate a maximum of 4K directly
             using var ms = new ArrayPoolStream(ArrayPool<byte>.Shared, maxBlockSize: 4 * 1024 * 1024);
-            ms.Reset(Math.Min(4096, length)); // Initial capacity up to 4K
+            ms.Reset(initialCapacity); // Initial capacity up to 4K
 
             await request.BodyReader.CopyToAsync(ms).ConfigureAwait(false);
             ArraySegment<byte> memory = ms.GetRentedArrayAndClear();

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using System.Xml;
@@ -386,21 +385,5 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
             domainService.Initialize(serviceContext);
             return domainService;
         }
-
-
-        private static async Task CopyToBufferAsync(HttpRequest request, byte[] buffer, int length)
-        {
-            int offset = 0;
-            var body = request.Body;
-            do
-            {
-                int read = await body.ReadAsync(buffer, offset, length - offset).ConfigureAwait(false);
-                offset += read;
-
-                if (read == 0)
-                    throw new BadHttpRequestException(InvalidContentMessage);
-            } while (offset < length);
-        }
-
     }
 }

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/ArrayPoolStream.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/ArrayPoolStream.cs
@@ -18,7 +18,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
     /// avoid allocations and be able to return memory directly without additional copies 
     /// (for small messages).
     /// </summary>
-    internal class ArrayPoolStream : Stream
+    internal sealed class ArrayPoolStream : Stream
     {
         private ArrayPool<byte> _arrayPool;
         private readonly int _maxSize;
@@ -89,15 +89,13 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
         }
 
         /// <summary>
-        /// Copies bytes from <paramref name="src"/> to <paramref name="dest"/> using fastes 
-        /// copy based on process bitness (x86 / x64) tested on .Net Framework 4.8
+        /// Copies bytes from <paramref name="src"/> to <paramref name="dest"/>
         /// </summary>
         private static unsafe void FastCopy(byte[] src, int srcOffset, byte[] dest, int destOffset, int count)
         {
             if (count == 0)
                 return;
 
-            // Buffer.BlockCopy(src, srcOffset, dest, destOffset, count);
             Unsafe.CopyBlockUnaligned(destination: ref dest[destOffset], source: ref src[srcOffset], (uint)count);
         }
 

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/ArrayPoolStream.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/ArrayPoolStream.cs
@@ -31,10 +31,10 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
         // String "position" (total size so far)
         private int _position;
 
-        public ArrayPoolStream(ArrayPool<byte> arrayPool, int maxAllocationSize)
+        public ArrayPoolStream(ArrayPool<byte> arrayPool, int maxBlockSize)
         {
             _arrayPool = arrayPool;
-            _maxSize = maxAllocationSize;
+            _maxSize = maxBlockSize;
         }
 
         public void Reset(int size)
@@ -97,6 +97,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
             if (count == 0)
                 return;
 
+            // Buffer.BlockCopy(src, srcOffset, dest, destOffset, count);
             Unsafe.CopyBlockUnaligned(destination: ref dest[destOffset], source: ref src[srcOffset], (uint)count);
         }
 
@@ -159,6 +160,60 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
             _bufferWritten = 0;
             _position = 0;
             return res;
+        }
+
+        public ArraySegment<byte> GetRentedArrayAndClear()
+        {
+            ArraySegment<byte> result;
+
+            // We only have a single segment, return it directly with no copying
+            if (_bufferList is null)
+            {
+                result = new ArraySegment<byte>(_buffer, 0, _position);
+                System.Diagnostics.Debug.Assert(_bufferWritten == _position);
+                _buffer = null; // prevent buffer from beeing returned twice
+            }
+            else
+            {
+                // Copy in reverse order from filled to utilize CPU caches better
+                // _buffer might only be partially filled
+                int totalSize = _position;
+                int destOffset = totalSize - _bufferWritten;
+                result = default;
+
+                try
+                {
+                    // Reuse the "current" buffer if it is large enough
+                    if (_position <= _buffer.Length)
+                    {
+                        result = new ArraySegment<byte>(_buffer, 0, _position);
+                        FastCopy(_buffer, 0, result.Array, destOffset, _bufferWritten);
+                        _buffer = null; // prevent buffer from beeing returned twice
+                    }
+                    else
+                    {
+                        result = new ArraySegment<byte>(_arrayPool.Rent(totalSize), 0, _position);
+                        FastCopy(_buffer, 0, result.Array, destOffset, _bufferWritten);
+                    }
+
+                    // Buffers in list are all full
+                    for (int i = _bufferList.Count - 1; i >= 0; --i)
+                    {
+                        destOffset -= _bufferList[i].Length;
+                        FastCopy(_bufferList[i], 0, result.Array, destOffset, _bufferList[i].Length);
+                    }
+                }
+                catch
+                {
+                    if (result.Array != default)
+                        _arrayPool.Return(result.Array);
+                    throw;
+                }
+            }
+            Clear();
+            _bufferWritten = 0;
+            _position = 0;
+            return result;
         }
 
         public struct BufferMemory : IDisposable

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/BinaryMessageReader.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/BinaryMessageReader.cs
@@ -5,9 +5,7 @@ using System.Xml;
 namespace OpenRiaServices.Hosting.AspNetCore.Serialization
 {
     /// <summary>
-    /// Helper class to cache <see cref="XmlDictionaryWriter"/> and stream in order
-    /// to not have to allocated all memory used for the writer.
-    /// It also adds some estimates of the buffer size needde
+    /// Helper class to cache <see cref="XmlDictionaryReader"/>
     /// </summary>
     internal class BinaryMessageReader : IDisposable
     {

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/BinaryMessageReader.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/BinaryMessageReader.cs
@@ -7,7 +7,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
     /// <summary>
     /// Helper class to cache <see cref="XmlDictionaryReader"/>
     /// </summary>
-    internal class BinaryMessageReader : IDisposable
+    internal sealed class BinaryMessageReader : IDisposable
     {
         private readonly XmlDictionaryReader _reader;
 

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/BinaryMessageReader.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/BinaryMessageReader.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Buffers;
+using System.Xml;
+
+namespace OpenRiaServices.Hosting.AspNetCore.Serialization
+{
+    /// <summary>
+    /// Helper class to cache <see cref="XmlDictionaryWriter"/> and stream in order
+    /// to not have to allocated all memory used for the writer.
+    /// It also adds some estimates of the buffer size needde
+    /// </summary>
+    internal class BinaryMessageReader : IDisposable
+    {
+        private readonly XmlDictionaryReader _reader;
+
+        // Cache at most one writer per thread
+        [ThreadStatic]
+        private static BinaryMessageReader s_threadInstance;
+
+        /// <summary>
+        ///  Prevent creation from outside of this class
+        /// </summary>
+        private BinaryMessageReader()
+        {
+            _reader = XmlDictionaryReader.CreateBinaryReader(Array.Empty<byte>(), XmlDictionaryReaderQuotas.Max);
+        }
+
+        public static BinaryMessageReader Rent(ArraySegment<byte> bytes)
+        {
+            var messageReader = s_threadInstance ?? new BinaryMessageReader();
+
+            // Reentrancy is not expected, but if the operation throws we dont
+            // want to reuse the current messageWriter since XmlWriter might not be in starting state
+            s_threadInstance = null;
+
+            ((IXmlBinaryReaderInitializer)messageReader._reader).SetInput(bytes.Array, bytes.Offset, bytes.Count, dictionary: null, XmlDictionaryReaderQuotas.Max, null, null);
+            return messageReader;
+        }
+
+        public static void Return(BinaryMessageReader binaryMessageReader)
+        {
+            binaryMessageReader._reader.Close();
+            s_threadInstance = binaryMessageReader;
+        }
+
+        public void Dispose()
+        {
+            Return(this);
+        }
+
+        public XmlDictionaryReader XmlDictionaryReader => _reader;
+    }
+}

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/BinaryMessageWriter.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/BinaryMessageWriter.cs
@@ -9,7 +9,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
     /// to not have to allocated all memory used for the writer.
     /// It also adds some estimates of the buffer size needde
     /// </summary>
-    internal class BinaryMessageWriter
+    internal sealed class BinaryMessageWriter
     {
         private ArrayPoolStream _stream;
         private XmlDictionaryWriter _writer;


### PR DESCRIPTION
* Allocate max 4K up front when reading requests
     - Prevents DOS attacks where attacker sets content-length to large values (such as GBs)
* Reuse BinaryXmlReaders by pooling them (small improvement)