### PR TITLE
Fix data corruption bug in and add AspNetCore Hosting test project

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,14 +64,13 @@ steps:
   displayName: 'Setup database'
 
 - task: VSTest@2
-  displayName: 'Run net4x tests'
+  displayName: 'Run tests'
   inputs:
     testAssemblyVer2: |
-     **\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
+     **\bin\$(BuildConfiguration)\*\OpenRiaServices.*Test.dll
      !src\VisualStudio\**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
      src\VisualStudio\Tools\Test\bin\$(BuildConfiguration)\net4*\OpenRiaServices.VisualStudio.*.Test.dll
      !**\obj\**
-
     runOnlyImpactedTests: false
     runInParallel: true
     runSettingsFile: 'src\test.runsettings'
@@ -80,14 +79,6 @@ steps:
     configuration: '$(BuildConfiguration)'
     diagnosticsEnabled: false
   timeoutInMinutes: 25
-
-- task: DotNetCoreCLI@2
-  displayName: 'Run net6.0 tests'
-  enabled: false
-  inputs:
-    command: 'test'
-    projects: '**\bin\$(BuildConfiguration)\net6.0\OpenRiaServices.*Test.dll;!**\bin\$(BuildConfiguration)\net6.0\OpenRiaServices.Common.*Test.dll'
-    arguments: '-f net6.0 --configuration $(BuildConfiguration) --no-build'
 
 - task: SonarCloudAnalyze@1
   displayName: 'Run Code Analysis'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,10 +64,28 @@ steps:
   displayName: 'Setup database'
 
 - task: VSTest@2
-  displayName: 'Run tests'
+  displayName: 'Run tests - net48'
   inputs:
     testAssemblyVer2: |
-     **\bin\$(BuildConfiguration)\*\OpenRiaServices.*Test.dll
+     **\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
+     !src\VisualStudio\**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
+     src\VisualStudio\Tools\Test\bin\$(BuildConfiguration)\net4*\OpenRiaServices.VisualStudio.*.Test.dll
+     !**\obj\**
+    runOnlyImpactedTests: false
+    runInParallel: true
+    runSettingsFile: 'src\test.runsettings'
+    codeCoverageEnabled: true
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    diagnosticsEnabled: false
+  timeoutInMinutes: 25
+
+- task: VSTest@2
+  displayName: 'Run tests - net6'
+  inputs:
+    testAssemblyVer2: |
+    **\bin\$(BuildConfiguration)\*\OpenRiaServices.*Test.dll
+     !**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
      !src\VisualStudio\**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
      src\VisualStudio\Tools\Test\bin\$(BuildConfiguration)\net4*\OpenRiaServices.VisualStudio.*.Test.dll
      !**\obj\**

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ steps:
     diagnosticsEnabled: false
   timeoutInMinutes: 25
 
- - task: SonarCloudAnalyze@1
+- task: SonarCloudAnalyze@1
   displayName: 'Run Code Analysis'
   continueOnError: true
   condition: and(variables['sonarcloud-endpoint'], or(succeeded(), and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,7 @@ steps:
      !src\VisualStudio\**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
      src\VisualStudio\Tools\Test\bin\$(BuildConfiguration)\net4*\OpenRiaServices.VisualStudio.*.Test.dll
      !**\obj\**
+
     runOnlyImpactedTests: false
     runInParallel: true
     runSettingsFile: 'src\test.runsettings'
@@ -84,9 +85,10 @@ steps:
   displayName: 'Run tests - net6'
   inputs:
     testAssemblyVer2: |
-    **\bin\$(BuildConfiguration)\*\OpenRiaServices.*Test.dll
+     **\bin\$(BuildConfiguration)\*\OpenRiaServices.*Test.dll
      !**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
      !**\obj\**
+
     runOnlyImpactedTests: false
     # Needed to hardcode path to test adapters for NET48 tests
     pathtoCustomTestAdapters: '$(Build.SourcesDirectory)\src\OpenRiaServices.Server.UnitTesting\Test\bin\$(BuildConfiguration)\net6.0\'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,7 @@ steps:
     testAssemblyVer2: |
      **\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
      !src\VisualStudio\**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
+     !**\bin\$(BuildConfiguration)\*\OpenRiaServices.Common*Test.dll
      src\VisualStudio\Tools\Test\bin\$(BuildConfiguration)\net4*\OpenRiaServices.VisualStudio.*.Test.dll
      !**\obj\**
 
@@ -86,6 +87,7 @@ steps:
   inputs:
     testAssemblyVer2: |
      **\bin\$(BuildConfiguration)\*\OpenRiaServices.*Test.dll
+     !**\bin\$(BuildConfiguration)\*\OpenRiaServices.Common*Test.dll
      !**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
      !**\obj\**
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,10 +86,10 @@ steps:
     testAssemblyVer2: |
     **\bin\$(BuildConfiguration)\*\OpenRiaServices.*Test.dll
      !**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
-     !src\VisualStudio\**\bin\$(BuildConfiguration)\net4*\OpenRiaServices.*Test.dll
-     src\VisualStudio\Tools\Test\bin\$(BuildConfiguration)\net4*\OpenRiaServices.VisualStudio.*.Test.dll
      !**\obj\**
     runOnlyImpactedTests: false
+    # Needed to hardcode path to test adapters for NET48 tests
+    pathtoCustomTestAdapters: '$(Build.SourcesDirectory)\src\OpenRiaServices.Server.UnitTesting\Test\bin\$(BuildConfiguration)\net6.0\'
     runInParallel: true
     runSettingsFile: 'src\test.runsettings'
     codeCoverageEnabled: true
@@ -98,7 +98,7 @@ steps:
     diagnosticsEnabled: false
   timeoutInMinutes: 25
 
-- task: SonarCloudAnalyze@1
+ - task: SonarCloudAnalyze@1
   displayName: 'Run Code Analysis'
   continueOnError: true
   condition: and(variables['sonarcloud-endpoint'], or(succeeded(), and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))))

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
@@ -339,7 +339,6 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
         {
             var ct = context.RequestAborted;
             ct.ThrowIfCancellationRequested();
-            // TODO: Handle cancelled
 
             var messageWriter = BinaryMessageWriter.Rent();
             try

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
@@ -263,7 +263,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
                 }
             }
 
-            return WriteError(context, new DomainServiceFault { OperationErrors = errors, ErrorCode = 422 });
+            return WriteError(context, new DomainServiceFault { OperationErrors = errors, ErrorCode = StatusCodes.Status422UnprocessableEntity });
         }
 
 
@@ -339,6 +339,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
         {
             var ct = context.RequestAborted;
             ct.ThrowIfCancellationRequested();
+            // TODO: Handle cancelled
 
             var messageWriter = BinaryMessageWriter.Rent();
             try

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/ArrayPoolStream.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/ArrayPoolStream.cs
@@ -185,7 +185,10 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
                     if (_position <= _buffer.Length)
                     {
                         result = new ArraySegment<byte>(_buffer, 0, _position);
-                        FastCopy(_buffer, 0, result.Array, destOffset, _bufferWritten);
+
+                        // Src and destination can overlapp so Unsafe cannot be used
+                        // Using unsafe gives invalid result, but on x86 (not x64) so it is difficult to troubleshoot
+                        Buffer.BlockCopy(src: _buffer, srcOffset: 0, _buffer, destOffset, _bufferWritten);
                         _buffer = null; // prevent buffer from beeing returned twice
                     }
                     else

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
@@ -34,6 +34,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>OpenRiaServices.Hosting.AspNetCore.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001006165f2d838c2494ed8ed9644fbc060f22fea4941d552916f6ca7078f64b7d5a6053ff36e63eb312fa909ae4223e8393d20eed67217e46747cebb6fa5b348738c5785568d642b0bf499f7863829242e655372773636d6c974d2d5abd97c57640893f7dd390cfd1015268ee85611f51c71068e8a15a829a97ea9dad46d1619b3b0</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  
+  <ItemGroup>
     <None Update="LICENSE.md" Pack="true" PackagePath="\" />
     <None Update="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/OpenRiaServices.Hosting.AspNetCore.Test.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/OpenRiaServices.Hosting.AspNetCore.Test.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>OpenRiaServices.Hosting.AspNetCore</RootNamespace>
+    <Version>1.0.0.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Framework\OpenRiaServices.Hosting.AspNetCore.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/Serialization/ArrayPoolStreamTests.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/Serialization/ArrayPoolStreamTests.cs
@@ -167,7 +167,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
                 stream.Write(otherInput, 0, otherInput.Length);
 
                 var array = stream.GetRentedArrayAndClear();
-                VerifyBufferContents(array,  new ArraySegment<byte>(otherInput));
+                VerifyBufferContents(array, new ArraySegment<byte>(otherInput));
                 manager.Return(array.Array);
                 manager.AssertEverythingIsReturned();
             }
@@ -186,27 +186,28 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
             return buffer;
         }
 
-        private void VerifyBufferContents(ArraySegment<byte> buffer, ArraySegment<byte> expectedContents)
+        private void VerifyBufferContents(ReadOnlySpan<byte> buffer, ReadOnlySpan<byte> expectedContents)
         {
-            Assert.AreEqual(buffer.Offset, 0, "Wrong offset");
-            Assert.AreEqual(buffer.Count, expectedContents.Count, "Wrong count");
+            Assert.AreEqual(buffer.Length, expectedContents.Length, "Wrong count");
+            if (buffer.SequenceEqual(expectedContents))
+                return;
 
-            for (int i = 0; i < expectedContents.Count; ++i)
+            for (int i = 0; i < expectedContents.Length; ++i)
             {
-                byte expected = expectedContents.Array[expectedContents.Offset + i];
-                byte actual = buffer.Array[buffer.Offset + i];
+                byte expected = expectedContents[i];
+                byte actual = buffer[i];
                 if (expected != actual)
                 {
-                    Dump(buffer.Array, expectedContents.Count);
+                    Dump(buffer);
 
-                    Assert.Fail($"Buffer contents is wrong, expected {expected} but buffer[{buffer.Offset} + {i}] = {actual}");
+                    Assert.Fail($"Buffer contents is wrong, expected {expected} but buffer[{i}] = {actual}");
                 }
             }
         }
 
-        private static void Dump(byte[] buf, int count)
+        private static void Dump(ReadOnlySpan<byte> buf)
         {
-            for (int j = 0; j < count; ++j)
+            for (int j = 0; j < buf.Length; ++j)
             {
                 Console.Write("{0} ", (int)buf[j]);
             }

--- a/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/Serialization/ArrayPoolStreamTests.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/Serialization/ArrayPoolStreamTests.cs
@@ -1,0 +1,260 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OpenRiaServices.Hosting.AspNetCore.Serialization
+{
+    [TestClass]
+    public class ArrayPoolStreamTests
+    {
+        private readonly byte[] _input;
+
+        public ArrayPoolStreamTests()
+        {
+            _input = new byte[255];
+            for (int i = 0; i < _input.Length; ++i)
+            {
+                _input[i] = (byte)(i + 1);
+            }
+        }
+
+        /// <summary>
+        /// Only partially fill first buffer
+        /// </summary>
+        [TestMethod]
+        public void SmallWrite()
+        {
+            const int BufferSize = 4;
+            var manager = new ArrayPoolMock();
+            using (var stream = new ArrayPoolStream(manager, 1024))
+            {
+                stream.Reset(BufferSize);
+                stream.Write(_input, 0, 2);
+
+                var buffer = VerifyStreamContents(stream, 2, manager);
+                Assert.AreEqual(1, manager.Allocated.Count, "Should only have allocated a single buffer");
+                Assert.AreSame(manager.Allocated[0], buffer.Array, "Should reuse initial array");
+            }
+        }
+
+        /// <summary>
+        /// Only partially fill first buffer
+        /// </summary>
+        [TestMethod]
+        public void SmallWriteFullBuffer()
+        {
+            const int BufferSize = 4;
+            var manager = new ArrayPoolMock();
+            using (var stream = new ArrayPoolStream(manager, 1024))
+            {
+                // Set initial capacity to same as buffer size
+                stream.Reset(BufferSize);
+
+                stream.Write(_input, 0, BufferSize);
+                var buffer = VerifyStreamContents(stream, BufferSize, manager);
+                Assert.AreEqual(1, manager.Allocated.Count, "Should only have allocated a single buffer");
+                Assert.AreSame(manager.Allocated[0], buffer.Array, "Should reuse initial array");
+            }
+        }
+
+        [TestMethod]
+        public void LargeWrite()
+        {
+            var manager = new ArrayPoolMock();
+            using (var stream = new ArrayPoolStream(manager, 1024))
+            {
+                // Set initial capacity of 4
+                stream.Reset(4);
+
+                stream.Write(_input, 0, 40);
+                VerifyStreamContents(stream, 40, manager);
+                Assert.IsTrue(manager.Allocated.Count > 2, "Multiple buffers should have been used");
+            }
+        }
+
+        [TestMethod]
+        public void ReuseLastBufferIfPossible()
+        {
+            int initalBufferSize = 4;
+            int buffer2Size = initalBufferSize * 2;
+            int buffer3Size = initalBufferSize + buffer2Size;
+            var manager = new ArrayPoolMock();
+            using (var stream = new ArrayPoolStream(manager, 1024))
+            {
+                stream.Reset(initalBufferSize);
+
+                // Fill first and second buffers full
+                stream.Write(_input, 0, initalBufferSize);
+                stream.Write(_input, initalBufferSize, buffer2Size);
+                Assert.AreEqual(buffer2Size, manager.Allocated[1].Length, "This test assumed allocation size was wrong");
+
+                // Write next one up just a little so that everyhing should fit in the 3rd
+                int streamOffsetLastBuffer = (int)stream.Position;
+                stream.Write(_input, streamOffsetLastBuffer, streamOffsetLastBuffer);
+
+                Assert.AreEqual(3, manager.Allocated.Count, "Test assumes 3 buffers");
+                Assert.AreEqual((int)stream.Position, manager.Allocated[2].Length, "This test assumes allocation size is enough");
+
+                var buffer = VerifyStreamContents(stream, streamOffsetLastBuffer * 2, manager);
+                Assert.AreSame(manager.Allocated[2], buffer.Array);
+            }
+        }
+
+        [TestMethod]
+        public void MultipleWrites()
+        {
+            var manager = new ArrayPoolMock();
+            using (var stream = new ArrayPoolStream(manager, 1024))
+            {
+                stream.Reset(4);
+
+                stream.Write(_input, 0, 2); // Write partial buffer
+                stream.Write(_input, 2, 2); // Fill next buffer, next shoul be 4 
+
+                stream.Write(_input, 4, 2);
+                stream.Write(_input, 6, manager.Allocated[1].Length); // Write past buffer into next one
+
+                VerifyStreamContents(stream, 6 + manager.Allocated[1].Length, manager);
+                Assert.IsTrue(manager.Allocated.Count > 2, "Multiple buffers should have been used");
+            }
+        }
+
+        [TestMethod]
+        public void ShouldHandleThrowingAllocationWithoutMemoryLeak()
+        {
+            bool shouldTrow = false;
+            Func<int, int> getBufferSize = size =>
+            {
+                if (shouldTrow) throw new InsufficientMemoryException();
+                else return size;
+            };
+
+            var manager = new ArrayPoolMock(getBufferSize);
+
+            using (var stream = new ArrayPoolStream(manager, 1024))
+            {
+                stream.Reset(4);
+
+                stream.Write(_input, 0, 2); // Write some into first buffer
+
+                shouldTrow = true;
+                Assert.ThrowsException<InsufficientMemoryException>(() =>
+                    stream.Write(_input, 2, 10)
+                    );
+            }
+
+            manager.AssertEverythingIsReturned();
+        }
+
+        [TestMethod]
+        public void ResetShouldAllowStreamReuse()
+        {
+            var manager = new ArrayPoolMock();
+            using (var stream = new ArrayPoolStream(manager, 1024))
+            {
+                stream.Reset(4);
+
+                stream.Write(_input, 0, 4);
+                manager.Return(stream.GetRentedArrayAndClear().Array);
+                manager.AssertEverythingIsReturned();
+
+                stream.Reset(4);
+
+                Assert.AreEqual(stream.Position, 0, "Position should be 0 after reset");
+
+                byte[] otherInput = new byte[] { 3, 2, 1 };
+                stream.Write(otherInput, 0, otherInput.Length);
+
+                var array = stream.GetRentedArrayAndClear();
+                VerifyBufferContents(array,  new ArraySegment<byte>(otherInput));
+                manager.Return(array.Array);
+                manager.AssertEverythingIsReturned();
+            }
+        }
+
+        private ArraySegment<byte> VerifyStreamContents(ArrayPoolStream stream, int count, ArrayPoolMock manager, byte[] expectedContents = null)
+        {
+            Assert.AreEqual(count, stream.Position, "Stream position should equal count");
+
+            var buffer = stream.GetRentedArrayAndClear();
+            VerifyBufferContents(buffer, new ArraySegment<byte>(expectedContents ?? _input, 0, count));
+
+            // By returning buffer we also ensure that it was allocated through the buffer manager
+            manager.Return(buffer.Array);
+            manager.AssertEverythingIsReturned();
+            return buffer;
+        }
+
+        private void VerifyBufferContents(ArraySegment<byte> buffer, ArraySegment<byte> expectedContents)
+        {
+            Assert.AreEqual(buffer.Offset, 0, "Wrong offset");
+            Assert.AreEqual(buffer.Count, expectedContents.Count, "Wrong count");
+
+            for (int i = 0; i < expectedContents.Count; ++i)
+            {
+                byte expected = expectedContents.Array[expectedContents.Offset + i];
+                byte actual = buffer.Array[buffer.Offset + i];
+                if (expected != actual)
+                {
+                    Dump(buffer.Array, expectedContents.Count);
+
+                    Assert.Fail($"Buffer contents is wrong, expected {expected} but buffer[{buffer.Offset} + {i}] = {actual}");
+                }
+            }
+        }
+
+        private static void Dump(byte[] buf, int count)
+        {
+            for (int j = 0; j < count; ++j)
+            {
+                Console.Write("{0} ", (int)buf[j]);
+            }
+            Console.WriteLine();
+        }
+
+        sealed class ArrayPoolMock : ArrayPool<byte>
+        {
+            private readonly HashSet<byte[]> _rented = new HashSet<byte[]>();
+            private readonly List<byte[]> _allocated = new();
+            private readonly Func<int, int> _getBufferSize;
+
+            public IReadOnlyCollection<byte[]> Rented => _rented;
+            public IReadOnlyList<byte[]> Allocated => _allocated;
+
+            public ArrayPoolMock(Func<int, int> getBufferSize = null)
+            {
+                _getBufferSize = getBufferSize ?? ((int i) => i);
+            }
+
+            public override byte[] Rent(int minimumLength)
+            {
+                var buff = new byte[_getBufferSize(minimumLength)];
+                _rented.Add(buff);
+                _allocated.Add(buff);
+                return buff;
+            }
+
+            public override void Return(byte[] array, bool clearArray = false)
+            {
+                if (!_rented.Remove(array))
+                {
+                    Assert.Fail("Buffer was not rented (returned twice?");
+                }
+            }
+
+            public void Clear()
+            {
+                if (_rented.Count > 0)
+                    throw new InvalidOperationException();
+                _rented.Clear();
+                _allocated.Clear();
+            }
+
+            public void AssertEverythingIsReturned()
+            {
+                Assert.AreEqual(0, _rented.Count, "Not all buffers were returned");
+            }
+        }
+    }
+}

--- a/src/RiaServices.sln
+++ b/src/RiaServices.sln
@@ -148,6 +148,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRiaServices.Hosting.Asp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreWebsite", "Test\AspNetCoreWebsite\AspNetCoreWebsite.csproj", "{7F378F98-E1B2-411A-809E-B1894E768936}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenRiaServices.Hosting.AspNetCore.Test", "OpenRiaServices.Hosting.AspNetCore\Test\OpenRiaServices.Hosting.AspNetCore.Test\OpenRiaServices.Hosting.AspNetCore.Test.csproj", "{A9C063D1-4451-47C9-AACE-908FFC8C9F35}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -358,6 +360,10 @@ Global
 		{7F378F98-E1B2-411A-809E-B1894E768936}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F378F98-E1B2-411A-809E-B1894E768936}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F378F98-E1B2-411A-809E-B1894E768936}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9C063D1-4451-47C9-AACE-908FFC8C9F35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9C063D1-4451-47C9-AACE-908FFC8C9F35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9C063D1-4451-47C9-AACE-908FFC8C9F35}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9C063D1-4451-47C9-AACE-908FFC8C9F35}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -426,6 +432,7 @@ Global
 		{6F468ADB-5799-4C24-93C5-765120AAAA4E} = {E8CAC11B-50B6-4243-A12A-D831EBB064CB}
 		{5A3B6E67-822E-44EA-8B68-A043555CC86F} = {2095B11C-903C-47FF-B812-82DFA7A068AC}
 		{7F378F98-E1B2-411A-809E-B1894E768936} = {BB0E26DD-14D3-4CD5-8F2B-B5C1CA281719}
+		{A9C063D1-4451-47C9-AACE-908FFC8C9F35} = {E8CAC11B-50B6-4243-A12A-D831EBB064CB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C135CEC9-180C-4B67-92AC-3342375AE14C}


### PR DESCRIPTION
Prevent problem where output buffer becomes incorrect when parsing large requests from the client.
It only happens on x86 

Fix #378

Also add tests for  AspNetCore Hosting 
