### PR TITLE
- Shadow Properties in EF Core are properties that exists usually in …

### DIFF
--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/DbContextEFCoreExtensions.cs
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/DbContextEFCoreExtensions.cs
@@ -109,17 +109,20 @@ namespace OpenRiaServices.Server.EntityFrameworkCore
 
             foreach (var member in stateEntry.CurrentValues.Properties)
             {
-                stateEntry.OriginalValues[member] = originalValues[member];
-
-                // For any members that don't have RoundtripOriginal applied, EF can't determine modification
-                // state by doing value comparisons. To avoid losing updates in these cases, we must explicitly
-                // mark such members as modified.
                 PropertyDescriptor property = properties[member.Name];
-                if (property != null &&
-                    (!isRoundtripType && property.Attributes[typeof(RoundtripOriginalAttribute)] == null) &&
-                    property.Attributes[typeof(ExcludeAttribute)] == null)
+
+                if (property != null)
                 {
-                    stateEntry.Property(member.Name).IsModified = true;
+                    stateEntry.OriginalValues[member] = originalValues[member];
+
+                    // For any members that don't have RoundtripOriginal applied, EF can't determine modification
+                    // state by doing value comparisons. To avoid losing updates in these cases, we must explicitly
+                    // mark such members as modified.
+                    if ((!isRoundtripType && property.Attributes[typeof(RoundtripOriginalAttribute)] == null) &&
+                         property.Attributes[typeof(ExcludeAttribute)] == null)
+                    {
+                        stateEntry.Property(member.Name).IsModified = true;
+                    }
                 }
             }
         }

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/DbContextEFCoreExtensions.cs
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/DbContextEFCoreExtensions.cs
@@ -113,6 +113,10 @@ namespace OpenRiaServices.Server.EntityFrameworkCore
 
                 if (property != null)
                 {
+                    // If the prop is the same as before, don't mark it as modified
+                    if (stateEntry.OriginalValues[member].Equals(originalValues[member]))
+                        return;
+
                     stateEntry.OriginalValues[member] = originalValues[member];
 
                     // For any members that don't have RoundtripOriginal applied, EF can't determine modification


### PR DESCRIPTION
- Shadow Props are not supposed to be copied in AttachAsModifiedInternal as they only exist in the DB and are generated.

- Shadow Properties should always be null as a property discriptor - just checking property is not null after creating the PropertyDiscriptor should make sure shadow props are not copied