### PR TITLE
Update nugets for .csproj and .nuspec files

### DIFF
--- a/NuGet/OpenRiaServices.Client.CodeGen/OpenRiaServices.Client.CodeGen.nuspec
+++ b/NuGet/OpenRiaServices.Client.CodeGen/OpenRiaServices.Client.CodeGen.nuspec
@@ -21,7 +21,7 @@
       </dependencies>
     </metadata>
     <files>
-        <file src="src\OpenRiaServices.Tools\Framework\build\OpenRiaServices.CodeGen.targets" target="build\OpenRiaServices.Client.CodeGen.targets"/>
+        <file src="..\..\src\OpenRiaServices.Tools\Framework\build\OpenRiaServices.CodeGen.targets" target="build\OpenRiaServices.Client.CodeGen.targets"/>
         <file src="..\..\src\bin\Release\net472\OpenRiaServices.Tools.dll" target="tasks\net472\OpenRiaServices.Tools.dll"/>
         <file src="..\..\src\bin\Release\net472\Mono.Cecil.dll" target="tasks\net472\Mono.Cecil.dll"/>
         <file src="..\..\src\bin\Release\net472\Mono.Cecil.Pdb.dll" target="tasks\net472\Mono.Cecil.Pdb.dll"/>

--- a/NuGet/OpenRiaServices.Client.Core.nuspec
+++ b/NuGet/OpenRiaServices.Client.Core.nuspec
@@ -21,8 +21,8 @@
       <group targetFramework="net472" />
       <group targetFramework="netstandard2.0">
         <dependency id="System.ComponentModel.Annotations" version="5.0.0" />
-        <dependency id="System.ServiceModel.Http" version="4.8.1" />
-		<dependency id="System.ServiceModel.Primitives" version="4.8.1" />
+        <dependency id="System.ServiceModel.Http" version="4.10.2" />
+		<dependency id="System.ServiceModel.Primitives" version="4.10.2" />
       </group>
     </dependencies>
     <frameworkAssemblies>

--- a/NuGet/OpenRiaServices.Hosting.Wcf/OpenRiaServices.Hosting.Wcf.nuspec
+++ b/NuGet/OpenRiaServices.Hosting.Wcf/OpenRiaServices.Hosting.Wcf.nuspec
@@ -22,7 +22,7 @@
 	<dependencies>
 		<group targetFramework="net472">
 			<dependency id="OpenRiaServices.Server" version="$version$"/>
-			<dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0"/>
+			<dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="7.0.0"/>
 		</group>
 	</dependencies>
   </metadata>

--- a/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
+++ b/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
@@ -29,11 +29,11 @@
 		<group targetFramework="netstandard2.0">
 			<dependency id="System.ComponentModel.Annotations" version="5.0.0"/>
 			<dependency id="System.Reflection.Emit.Lightweight" version="4.7.0"/>
-			<dependency id="System.CodeDom" version="6.0.0"/>
+			<dependency id="System.CodeDom" version="7.0.0"/>
 			<dependency id="System.Threading.Tasks.Extensions" version="4.5.4"/>
 		</group>
 		<group targetFramework="net6.0">
-			<dependency id="System.CodeDom" version="6.0.0"/>
+			<dependency id="System.CodeDom" version="7.0.0"/>
 		</group>
 	</dependencies>
   </metadata>

--- a/NuGet/OpenRiaServices.T4.nuspec
+++ b/NuGet/OpenRiaServices.T4.nuspec
@@ -17,7 +17,7 @@
     <tags>WCF RIA Services RIAServices T4 OpenRiaServices</tags>
     <dependencies>
       <dependency id="OpenRiaServices.Server" version="$version$" />
-      <dependency id="Mono.Cecil" version="0.11.4" />
+      <dependency id="Mono.Cecil" version="0.11.5" />
     </dependencies>
   </metadata>
   <files>

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.Client.Web/Framework/OpenRiaServices.Client.Web.csproj
+++ b/src/OpenRiaServices.Client.Web/Framework/OpenRiaServices.Client.Web.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.ServiceModel.Http" Version="4.8.1" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.10.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>OpenRiaServices.Hosting</RootNamespace>
     <!-- Ignore documentation varnings while experimental-->
     <NoWarn>$(NoWarn);CS1574;CS1573;CS1591;CS1572</NoWarn>
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Daniel-Svensson</Authors>
     <PackageTags>OpenRiaServices AspNetCore Hosting DomainServices AspNet WCF RIA Services Server</PackageTags>

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/OpenRiaServices.Hosting.Wcf.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/OpenRiaServices.Hosting.Wcf.csproj
@@ -18,7 +18,7 @@
     <Reference Include="system" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\OpenRiaServices.Client.Web\Framework\Data\Behaviors\MessageUtility.cs" Link="WCF\Behaviors\MessageUtility.cs" />

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'=='netstandard2.0'" Version="3.1.24" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'=='netstandard2.0'" Version="3.1.24" />
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'!='netstandard2.0'" Version="7.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'!='netstandard2.0'" Version="7.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'!='netstandard2.0'" Version="6.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'!='netstandard2.0'" Version="6.0.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\OpenRiaServices.Server\Framework\OpenRiaServices.Server.csproj" />

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'=='netstandard2.0'" Version="3.1.24" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'=='netstandard2.0'" Version="3.1.24" />
 
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'!='netstandard2.0'" Version="6.0.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'!='netstandard2.0'" Version="6.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'!='netstandard2.0'" Version="7.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'!='netstandard2.0'" Version="7.0.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\OpenRiaServices.Server\Framework\OpenRiaServices.Server.csproj" />

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
@@ -3,8 +3,8 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SERVERFX;EFCORE</DefineConstants>
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <VersionPrefix>2.0.1</VersionPrefix>
-    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <VersionPrefix>2.0.2</VersionPrefix>
+    <AssemblyVersion>2.0.2</AssemblyVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Test/DbContextModel/EFCoreModels.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Test/DbContextModel/EFCoreModels.csproj
@@ -5,9 +5,9 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.*" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.32" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.32" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.32" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Test/DbContextModel/EFCoreModels.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Test/DbContextModel/EFCoreModels.csproj
@@ -5,9 +5,9 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.24" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.24" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.24" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.*" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.Server/Framework/OpenRiaServices.Server.csproj
+++ b/src/OpenRiaServices.Server/Framework/OpenRiaServices.Server.csproj
@@ -18,12 +18,12 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.CodeDom" Version="6.0.0" />
+    <PackageReference Include="System.CodeDom" Version="7.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.CodeDom" Version="6.0.0" />
+    <PackageReference Include="System.CodeDom" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Test/WebsiteFullTrust/Web.config
+++ b/src/Test/WebsiteFullTrust/Web.config
@@ -72,8 +72,36 @@
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.32.0" newVersion="3.1.32.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.32.0" newVersion="3.1.32.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.32.0" newVersion="3.1.32.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.32.0" newVersion="3.1.32.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.32.0" newVersion="3.1.32.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFrameworkCore.Relational" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.32.0" newVersion="3.1.32.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.EntityFrameworkCore" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.1.32.0" newVersion="3.1.32.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
@@ -84,38 +112,17 @@
 				<bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.1.24.0" newVersion="3.1.24.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.1.24.0" newVersion="3.1.24.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.1.24.0" newVersion="3.1.24.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.1" newVersion="6.0.0.1"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.1.24.0" newVersion="3.1.24.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.1.24.0" newVersion="3.1.24.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
 			</dependentAssembly>
-		
 		</assemblyBinding>
 	</runtime>
 </configuration>

--- a/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
+++ b/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
@@ -144,7 +144,7 @@
       <Version>6.4.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer">
-      <Version>3.1.24</Version>
+      <Version>3.1.32</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>7.0.0</Version>

--- a/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
+++ b/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
@@ -147,7 +147,7 @@
       <Version>3.1.24</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>6.0.1</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Threading.Tasks.Extensions">
       <Version>4.5.4</Version>


### PR DESCRIPTION
Updated nugets

- System.ServiceModel.Http: 4.10.2 from 4.8.1 
- System.ServiceModel.Primitives: 4.10.2 from 4.8.1
- Microsoft.Extensions.DependencyInjection.Abstractions: 7.0.0 from 6.0.0 
- Microsoft.Extensions.DependencyInjection: 7.0.0 from 6.0.1
- System.CodeDom: 7.0.0 from 6.0.0 
- Mono.Cecil: 0.11.5 from 0.11.4
- Microsoft.EntityFrameworkCore.*: 3.1.32 from 3.1.24
