### PR TITLE
Improvements to AspNetCore endpoint metadata and net7 support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,8 @@
 * Code Generation
   * Switch to using Mono.Cecil to parse pdb files during code generation (#410)
     This should make it possible to use portable and embedded pdb's on the server
-* Asp Core
+  * 
+* AspNetCore
     * New extension method to add OpenRiaServices to services.
         ```C#
         services.AddOpenRiaServices<T>()
@@ -12,6 +13,12 @@
         ```C#
         endpoints.MapOpenRiaServices(opt => opt.AddDomainService<T>())
         ```
+    * Add Net7 build target to support "Finally Conventions" (`IEndpointConventionBuilder.Finally`)
+    * Add `OpenRiaServices.Server.DomainOperationEntry` to endpoint metadata
+        * This allows end user to easier implement additional conventions (such as Open Api or similar)
+    * Copy `AuthorizationAttribute`s to endpoint metadata for queries and invokes to support [AspNetCore Authorization](https://learn.microsoft.com/en-us/aspnet/core/security/authorization/simple?view=aspnetcore-7.0)
+        *  Attributes can be set on either method or class level
+        
         
 # 5.3.0 with EFCore 2.0.1
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,13 @@ variables:
 
 steps:
 
+# install dotnet 6 sdk so we can run tests against them
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '6.0.x'
+
+# install dotet 7 sdk to allow compilation target
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
@@ -17,7 +24,7 @@ steps:
 
 - task: NuGetToolInstaller@1
   inputs:
-    versionSpec: 6.3.0
+    versionSpec: 6.6.0
     
 - task: gitversion/setup@0
   displayName: Install GitVersion

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ steps:
 
 - task: NuGetToolInstaller@1
   inputs:
-    versionSpec: 6.6.0
+    versionSpec: 6.5.0
     
 - task: gitversion/setup@0
   displayName: Install GitVersion

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '6.0.x'
+    version: '7.0.x'
 
 - task: NuGetToolInstaller@1
   inputs:

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -49,9 +50,18 @@ namespace OpenRiaServices.Hosting.AspNetCore
             var getOrPost = new HttpMethodMetadata(new[] { "GET", "POST" });
             var postOnly = new HttpMethodMetadata(new[] { "POST" });
 
+
             foreach (var (name, domainService) in DomainServices)
             {
                 var serializationHelper = new SerializationHelper(domainService);
+                List<object> additionalMetadata = new List<object>();
+                foreach (Attribute attribute in domainService.Attributes)
+                {
+                    if (CopyAttributeToEndpointMetadata(attribute))
+                        additionalMetadata.Add(attribute);
+                }
+                // Consider adding additional metadata souch as route groups etc
+                //endpointBuilder.Metadata.Add(new EndpointGroupNameAttribute(domainService));
 
                 foreach (var operation in domainService.DomainOperationEntries)
                 {
@@ -72,14 +82,14 @@ namespace OpenRiaServices.Hosting.AspNetCore
                     else
                         continue;
 
-                    AddEndpoint(endpoints, name, invoker, hasSideEffects ? postOnly : getOrPost);
+                    AddEndpoint(endpoints, name, invoker, hasSideEffects ? postOnly : getOrPost, additionalMetadata);
                 }
 
                 var submit = new ReflectionDomainServiceDescriptionProvider.ReflectionDomainOperationEntry(domainService.DomainServiceType,
                     typeof(DomainService).GetMethod(nameof(DomainService.SubmitAsync)), DomainOperation.Custom);
 
                 var submitOperationInvoker = new SubmitOperationInvoker(submit, serializationHelper);
-                AddEndpoint(endpoints, name, submitOperationInvoker, postOnly);
+                AddEndpoint(endpoints, name, submitOperationInvoker, postOnly, additionalMetadata);
 
 
             }
@@ -87,15 +97,9 @@ namespace OpenRiaServices.Hosting.AspNetCore
             return endpoints;
         }
 
-        private void AddEndpoint(List<Endpoint> endpoints, string domainService, OperationInvoker invoker, HttpMethodMetadata httpMethod)
+        private void AddEndpoint(List<Endpoint> endpoints, string domainService, OperationInvoker invoker, HttpMethodMetadata httpMethod, List<object> additionalMetadata)
         {
             var route = RoutePatternFactory.Parse($"{Prefix}/{domainService}/{invoker.OperationName}");
-
-            // TODO: looka at adding authorization and authentication metadata to endpoiunt
-            // authorization - look for any attribute implementing microsoft.aspnetcore.authorization.iauthorizedata 
-            // https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authorization.iauthorizedata?view=aspnetcore-6.0
-
-            //var aut = operation.Attributes.Cast<Attribute>().OfType<Microsoft.spNetCore.Authorization.IAuthorizeData>().ToList();
 
             var endpointBuilder = new RouteEndpointBuilder(
                 invoker.Invoke,
@@ -106,13 +110,22 @@ namespace OpenRiaServices.Hosting.AspNetCore
             };
             endpointBuilder.Metadata.Add(httpMethod);
             endpointBuilder.Metadata.Add(invoker.DomainOperation);
-            // Try to add MethodInfo
-            if (TryGetMethodInfo(invoker) is MethodInfo method)
+
+            // Copy all AspNetCore Authorization attributes
+            foreach (Attribute attribute in invoker.DomainOperation.Attributes)
             {
-                endpointBuilder.Metadata.Add(method);
+                if (CopyAttributeToEndpointMetadata(attribute))
+                    endpointBuilder.Metadata.Add(attribute);
             }
 
-            //endpointBuilder.Metadata.Add(new EndpointGroupNameAttribute(domainService));
+            // Try to add MethodInfo
+            //if (TryGetMethodInfo(invoker) is MethodInfo method)
+            //{
+            //    endpointBuilder.Metadata.Add(method);
+            //}
+
+            foreach (var metadata in additionalMetadata)
+                endpointBuilder.Metadata.Add(metadata);
 
             foreach (var convention in _conventions)
             {
@@ -123,6 +136,11 @@ namespace OpenRiaServices.Hosting.AspNetCore
                 finallyConvention(endpointBuilder);
 
             endpoints.Add(endpointBuilder.Build());
+        }
+
+        private static bool CopyAttributeToEndpointMetadata(Attribute authorizeAttribute)
+        {
+            return authorizeAttribute is IAuthorizeData;
         }
 
         private static MethodInfo TryGetMethodInfo(OperationInvoker invoker)

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
@@ -49,6 +49,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
         }
 
         public virtual string OperationName => _operation.Name;
+        public DomainOperationEntry DomainOperation => _operation;
 
         public abstract Task Invoke(HttpContext context);
 

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SERVERFX;ASPNET_CORE</DefineConstants>
     <RootNamespace>OpenRiaServices.Hosting</RootNamespace>
     <!-- Ignore documentation varnings while experimental-->
@@ -40,8 +40,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <None Update="LICENSE.md" Pack="true" PackagePath="\" />
-    <None Update="README.md" Pack="true" PackagePath="\" />
+    <Content Include="LICENSE.md" Pack="true" PackagePath="" />
+    <Content Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/ChangeSetProcessor.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/ChangeSetProcessor.cs
@@ -203,7 +203,9 @@ namespace OpenRiaServices.Hosting.Wcf
             HashSet<int> visited = new HashSet<int>();
             foreach (var entityGroup in changeSetEntries.Where(p => (p.Associations != null && p.Associations.Count > 0) || (p.OriginalAssociations != null && p.OriginalAssociations.Count > 0)).GroupBy(p => p.Entity.GetType()))
             {
+#pragma warning disable CS0618 // Type or member is obsolete: AssociationAttribute
                 Dictionary<string, PropertyDescriptor> associationMemberMap = TypeDescriptor.GetProperties(entityGroup.Key).Cast<PropertyDescriptor>().Where(p => p.Attributes[typeof(AssociationAttribute)] != null).ToDictionary(p => p.Name);
+#pragma warning restore CS0618 // Type or member is obsolete
                 foreach (ChangeSetEntry changeSetEntry in entityGroup)
                 {
                     if (visited.Contains(changeSetEntry.Id))

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.200",
+    "version": "7.0.200",
     "rollForward": "major"
   }
 }


### PR DESCRIPTION
  * Add Net7 build target to support "Finally Conventions" (`IEndpointConventionBuilder.Finally`)
  * Add `OpenRiaServices.Server.DomainOperationEntry` to endpoint metadata
      * This allows end user to easier implement additional conventions (such as Open Api or similar)
  * Copy `AuthorizationAttribute`s to endpoint metadata for queries and invokes to support [AspNetCore Authorization](https://learn.microsoft.com/en-us/aspnet/core/security/authorization/simple?view=aspnetcore-7.0)
      *  Attributes can be set on either method or class level