### PR TITLE
[AspNetCore]: Set more metadata on endpoints and allow conventions per service

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,20 @@
+# Unreleased
+
+* AspNetCore
+     *   Copies "All" attributes to endpoint metadata      
+         * Some attributes sucha as Validation, Authorization and other attributes specific to OpenRiaServices are not copied
+     * `AddDomainService()` methods inside `MapOpenRiaServices` now returns `IEndpointConventionBuilder` allowing conventions to be specified per `DomainService`
+        ```C#
+        app.MapOpenRiaServices(builder =>
+        {
+            builder.AddDomainService<Cities.CityDomainService>()
+                .WithGroupName("Cities");
+        });
+        ```
+     * CHANGES:
+        * `services.AddOpenRiaServices<T>()` now requires T to derive from DomainServce
+        * `services.AddOpenRiaServices<T>()` has different return type
+
 # 5.3.1 with EFCore 2.0.2 and AspNetCore 0.3.0
 
 * Code Generation

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
@@ -138,9 +138,21 @@ namespace OpenRiaServices.Hosting.AspNetCore
             endpoints.Add(endpointBuilder.Build());
         }
 
-        private static bool CopyAttributeToEndpointMetadata(Attribute authorizeAttribute)
+        /// <summary>
+        /// Copy all attributes except for attributes handled internally by OpenRiaServices
+        /// </summary>
+        /// <remarks>
+        /// This should enable all middlewares using attributes to control their behaviour to work.
+        /// </remarks>
+        /// <param name="attribute"></param>
+        /// <returns></returns>
+        private static bool CopyAttributeToEndpointMetadata(Attribute attribute)
         {
-            return authorizeAttribute is IAuthorizeData;
+           
+            return attribute.GetType().Assembly != typeof(DomainService).Assembly
+                && attribute is not System.ComponentModel.DataAnnotations.ValidationAttribute
+                && attribute is not System.ComponentModel.DataAnnotations.AuthorizationAttribute
+                && !attribute.GetType().FullName.StartsWith("System.Diagnostics");
         }
 
         private static MethodInfo TryGetMethodInfo(OperationInvoker invoker)

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 using OpenRiaServices.Hosting.AspNetCore.Operations;

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
@@ -4,11 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 using OpenRiaServices.Hosting.AspNetCore.Operations;
@@ -16,17 +16,28 @@ using OpenRiaServices.Server;
 
 namespace OpenRiaServices.Hosting.AspNetCore
 {
-    internal class OpenRiaServicesEndpointDataSource : EndpointDataSource, IEndpointConventionBuilder
+    internal sealed class OpenRiaServicesEndpointDataSource : EndpointDataSource, IEndpointConventionBuilder
     {
         private readonly List<Action<EndpointBuilder>> _conventions = new();
         private readonly List<Action<EndpointBuilder>> _finallyConventions = new();
+        private readonly HttpMethodMetadata _getOrPost = new(new[] { "GET", "POST" });
+        private readonly HttpMethodMetadata _postOnly = new(new[] { "POST" });
 
-        public Dictionary<string, DomainServiceDescription> DomainServices { get; } = new();
+        private readonly Dictionary<string, DomainServiceEndpointBuilder> _endpointBuilders = new();
         private List<Endpoint> _endpoints;
 
         public OpenRiaServicesEndpointDataSource()
         {
 
+        }
+
+        internal IEndpointConventionBuilder AddDomainService(string path, Type type)
+        {
+            var description = DomainServiceDescription.GetDescription(type);
+            var endpointBuilder = new DomainServiceEndpointBuilder(description);
+
+            _endpointBuilders.Add(path, endpointBuilder);
+            return endpointBuilder;
         }
 
         public override IReadOnlyList<Endpoint> Endpoints
@@ -47,57 +58,87 @@ namespace OpenRiaServices.Hosting.AspNetCore
         private List<Endpoint> BuildEndpoints()
         {
             var endpoints = new List<Endpoint>();
-            var getOrPost = new HttpMethodMetadata(new[] { "GET", "POST" });
-            var postOnly = new HttpMethodMetadata(new[] { "POST" });
 
-
-            foreach (var (name, domainService) in DomainServices)
+            foreach (var (name, domainServiceBuilder) in _endpointBuilders)
             {
+                var domainService = domainServiceBuilder.Description;
                 var serializationHelper = new SerializationHelper(domainService);
-                List<object> additionalMetadata = new List<object>();
-                foreach (Attribute attribute in domainService.Attributes)
-                {
-                    if (CopyAttributeToEndpointMetadata(attribute))
-                        additionalMetadata.Add(attribute);
-                }
+
+                // We could consider using Add and Finally on domainServiceBuilder to copy metadata instead
                 // Consider adding additional metadata souch as route groups etc
-                //endpointBuilder.Metadata.Add(new EndpointGroupNameAttribute(domainService));
+                List<object> additionalMetadata = new List<object>();
+                CopyAttributesToEndpointMetadata(domainService.Attributes, additionalMetadata);
 
                 foreach (var operation in domainService.DomainOperationEntries)
                 {
-                    bool hasSideEffects;
                     OperationInvoker invoker;
-
                     if (operation.Operation == DomainOperation.Query)
                     {
                         invoker = (OperationInvoker)Activator.CreateInstance(typeof(QueryOperationInvoker<>).MakeGenericType(operation.AssociatedType),
                             new object[] { operation, serializationHelper });
-                        hasSideEffects = ((QueryAttribute)operation.OperationAttribute).HasSideEffects;
                     }
                     else if (operation.Operation == DomainOperation.Invoke)
                     {
                         invoker = new InvokeOperationInvoker(operation, serializationHelper);
-                        hasSideEffects = ((InvokeAttribute)operation.OperationAttribute).HasSideEffects;
                     }
-                    else
+                    else // Submit related methods are not directly accessible
                         continue;
 
-                    AddEndpoint(endpoints, name, invoker, hasSideEffects ? postOnly : getOrPost, additionalMetadata);
+                    endpoints.Add(BuildEndpoint(name, invoker, domainServiceBuilder, additionalMetadata));
                 }
 
                 var submit = new ReflectionDomainServiceDescriptionProvider.ReflectionDomainOperationEntry(domainService.DomainServiceType,
                     typeof(DomainService).GetMethod(nameof(DomainService.SubmitAsync)), DomainOperation.Custom);
 
                 var submitOperationInvoker = new SubmitOperationInvoker(submit, serializationHelper);
-                AddEndpoint(endpoints, name, submitOperationInvoker, postOnly, additionalMetadata);
-
-
+                endpoints.Add(BuildEndpoint(name, submitOperationInvoker, domainServiceBuilder, additionalMetadata));
             }
 
             return endpoints;
         }
 
-        private void AddEndpoint(List<Endpoint> endpoints, string domainService, OperationInvoker invoker, HttpMethodMetadata httpMethod, List<object> additionalMetadata)
+        /// <summary>
+        /// Per DomainSerivce build 
+        /// </summary>
+        sealed class DomainServiceEndpointBuilder : IEndpointConventionBuilder
+        {
+            private readonly DomainServiceDescription _description;
+            private readonly List<Action<EndpointBuilder>> _conventions = new();
+            private readonly List<Action<EndpointBuilder>> _finallyConventions = new();
+
+            public DomainServiceEndpointBuilder(DomainServiceDescription description)
+            {
+                _description = description;
+            }
+
+            public DomainServiceDescription Description { get { return _description; } }
+
+            public void Add(Action<EndpointBuilder> convention)
+            {
+                _conventions.Add(convention);
+            }
+
+#if NET7_0_OR_GREATER
+            public void Finally(System.Action<Microsoft.AspNetCore.Builder.EndpointBuilder> finallyConvention)
+            {
+                _finallyConventions.Add(finallyConvention);
+            }
+#endif
+
+            public void ApplyConventions(EndpointBuilder endpointBuilder)
+            {
+                foreach (var convention in _conventions)
+                    convention(endpointBuilder);
+            }
+
+            public void ApplyFinallyConventions(EndpointBuilder endpointBuilder)
+            {
+                foreach (var convention in _finallyConventions)
+                    convention(endpointBuilder);
+            }
+        }
+
+        private Endpoint BuildEndpoint(string domainService, OperationInvoker invoker, DomainServiceEndpointBuilder domainServiceEndpointBuilder, List<object> additionalMetadata)
         {
             var route = RoutePatternFactory.Parse($"{Prefix}/{domainService}/{invoker.OperationName}");
 
@@ -108,34 +149,36 @@ namespace OpenRiaServices.Hosting.AspNetCore
             {
                 DisplayName = $"{domainService}.{invoker.OperationName}"
             };
-            endpointBuilder.Metadata.Add(httpMethod);
+
+            endpointBuilder.Metadata.Add(invoker.HasSideEffects ? _postOnly : _getOrPost);
             endpointBuilder.Metadata.Add(invoker.DomainOperation);
 
             // Copy all AspNetCore Authorization attributes
-            foreach (Attribute attribute in invoker.DomainOperation.Attributes)
-            {
-                if (CopyAttributeToEndpointMetadata(attribute))
-                    endpointBuilder.Metadata.Add(attribute);
-            }
-
-            // Try to add MethodInfo
-            //if (TryGetMethodInfo(invoker) is MethodInfo method)
-            //{
-            //    endpointBuilder.Metadata.Add(method);
-            //}
-
+            CopyAttributesToEndpointMetadata(invoker.DomainOperation.Attributes, endpointBuilder.Metadata);
             foreach (var metadata in additionalMetadata)
                 endpointBuilder.Metadata.Add(metadata);
 
+            domainServiceEndpointBuilder.ApplyConventions(endpointBuilder);
+            ApplyConventions(endpointBuilder);
+
+            domainServiceEndpointBuilder.ApplyFinallyConventions(endpointBuilder);
+            ApplyFinallyConventions(endpointBuilder);
+
+            return endpointBuilder.Build();
+        }
+
+        private void ApplyFinallyConventions(RouteEndpointBuilder endpointBuilder)
+        {
+            foreach (var finallyConvention in _finallyConventions)
+                finallyConvention(endpointBuilder);
+        }
+
+        private void ApplyConventions(RouteEndpointBuilder endpointBuilder)
+        {
             foreach (var convention in _conventions)
             {
                 convention(endpointBuilder);
             }
-
-            foreach (var finallyConvention in _finallyConventions)
-                finallyConvention(endpointBuilder);
-
-            endpoints.Add(endpointBuilder.Build());
         }
 
         /// <summary>
@@ -144,26 +187,21 @@ namespace OpenRiaServices.Hosting.AspNetCore
         /// <remarks>
         /// This should enable all middlewares using attributes to control their behaviour to work.
         /// </remarks>
-        /// <param name="attribute"></param>
-        /// <returns></returns>
-        private static bool CopyAttributeToEndpointMetadata(Attribute attribute)
+        private static void CopyAttributesToEndpointMetadata(System.ComponentModel.AttributeCollection attributes, IList<object> metadata)
         {
-           
-            return attribute.GetType().Assembly != typeof(DomainService).Assembly
-                && attribute is not System.ComponentModel.DataAnnotations.ValidationAttribute
-                && attribute is not System.ComponentModel.DataAnnotations.AuthorizationAttribute
-                && !attribute.GetType().FullName.StartsWith("System.Diagnostics");
-        }
-
-        private static MethodInfo TryGetMethodInfo(OperationInvoker invoker)
-        {
-            MethodInfo method = invoker.DomainOperation.DomainServiceType.GetMethod(invoker.DomainOperation.Name);
-            if (method == null && invoker.DomainOperation.IsTaskAsync)
+            static bool ShouldCopyAttributeToEndpointMetadata(Attribute attribute)
             {
-                method = invoker.DomainOperation.DomainServiceType.GetMethod(invoker.DomainOperation.Name + "Async");
+                return attribute.GetType().Assembly != typeof(DomainService).Assembly
+                    && attribute is not System.ComponentModel.DataAnnotations.ValidationAttribute
+                    && attribute is not System.ComponentModel.DataAnnotations.AuthorizationAttribute
+                    && !attribute.GetType().FullName.StartsWith("System.Diagnostics");
             }
 
-            return method;
+            foreach (Attribute attribute in attributes)
+            {
+                if (ShouldCopyAttributeToEndpointMetadata(attribute))
+                    metadata.Add(attribute);
+            }
         }
 
         public override IChangeToken GetChangeToken()

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesEndpointDataSource.cs
@@ -192,7 +192,8 @@ namespace OpenRiaServices.Hosting.AspNetCore
                 return attribute.GetType().Assembly != typeof(DomainService).Assembly
                     && attribute is not System.ComponentModel.DataAnnotations.ValidationAttribute
                     && attribute is not System.ComponentModel.DataAnnotations.AuthorizationAttribute
-                    && !attribute.GetType().FullName.StartsWith("System.Diagnostics");
+                    && !(attribute.GetType().FullName.StartsWith("System.Diagnostics")
+                        || attribute.GetType().FullName.StartsWith("System.Runtime"));
             }
 
             foreach (Attribute attribute in attributes)

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/InvokeOperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/InvokeOperationInvoker.cs
@@ -12,6 +12,8 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
         {
         }
 
+        public override bool HasSideEffects => ((InvokeAttribute)DomainOperation.OperationAttribute).HasSideEffects;
+
         public override async Task Invoke(HttpContext context)
         {
             try

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
@@ -51,6 +51,8 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
         public virtual string OperationName => _operation.Name;
         public DomainOperationEntry DomainOperation => _operation;
 
+        public abstract bool HasSideEffects { get; }
+
         public abstract Task Invoke(HttpContext context);
 
         protected object[] GetParametersFromUri(HttpContext context)

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/QueryOperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/QueryOperationInvoker.cs
@@ -17,6 +17,8 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
         {
         }
 
+        public override bool HasSideEffects => ((QueryAttribute)DomainOperation.OperationAttribute).HasSideEffects;
+
         public override async Task Invoke(HttpContext context)
         {
             try

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/SubmitOperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/SubmitOperationInvoker.cs
@@ -13,6 +13,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
         private readonly DataContractSerializer _parameterSerializer;
 
         public override string OperationName => "SubmitChanges";
+        public override bool HasSideEffects => true;
 
         public SubmitOperationInvoker(DomainOperationEntry operation, SerializationHelper serializationHelper)
                 : base(operation, DomainOperationType.Submit, serializationHelper, serializationHelper.GetSerializer(typeof(IEnumerable<ChangeSetEntry>)))

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>OpenRiaServices.Hosting</RootNamespace>
     <!-- Ignore documentation varnings while experimental-->
     <NoWarn>$(NoWarn);CS1574;CS1573;CS1591;CS1572</NoWarn>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Daniel-Svensson</Authors>
     <PackageTags>OpenRiaServices AspNetCore Hosting DomainServices AspNet WCF RIA Services Server</PackageTags>

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/TODO.md
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/TODO.md
@@ -45,7 +45,10 @@ app.MapDomainServices/MapOpenRiaServices("/Services", x =>
 
 * look at adding authorization and authentication metadata to endpoiunt
  - this is handled inside DomainServer at the moment
-* look at copying/adding attributes applied from query/invoke methods to endpoints
+ - For RequiresAuthentication attribute we should be able to 
+   validate authentication early in the pipeline (via metadata?) 
+   so we don't need to check in ValidateMethodPermissions
+
 
 ## Reliability / "production" ready
 


### PR DESCRIPTION
* AspNetCore
     *   Copies "All" attributes to endpoint metadata      
         * Some attributes sucha as Validation, Authorization and other attributes specific to OpenRiaServices are not copied
     * `AddDomainService()` methods inside `MapOpenRiaServices` now returns `IEndpointConventionBuilder` allowing conventions to be specified per `DomainService`
        ```C#
        app.MapOpenRiaServices(builder =>
        {
            builder.AddDomainService<Cities.CityDomainService>()
                .WithGroupName("Cities");
        });
        ```
     * CHANGES:
        * `services.AddOpenRiaServices<T>()` now requires T to derive from DomainServce
        * `services.AddOpenRiaServices<T>()` has different return type