### PR TITLE
Enable collectionview support by net6 version of client

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,11 @@ This release **fully supports .NET 6+** for both server and client without havin
 ### Client
 * Ensure exceptions from xxxOperation callbacks and unhandled exceptions are rethrow on the SyncronizationContext. (#424)
     * This allows events such as `DispatcherUnhandledException` (for WPF) to be used for showing error messages immediately
+* Add **net6.0-windows** TargetFramework for client (#436)
+  * `EntitySet` and `EntityCollection` now implements `ICollectionViewFactory` for *net6.0-windows*. improving supprot with controls using CollectionView
+  * This change came in WCF Ria Services SP1  [WCF Ria Services SP1](https://jeffhandley.com/2011-03-10/riaservicesv1sp1rtm)
+    > DataForm Add/Remove for EntitySet and EntityCollection
+With our initial V1.0 release, many of you found that a DataForm bound to an EntitySet or an EntityCollection did not support the Add or Remove buttons.  This was a difficult cut to make in V1.0, so I’m pleased to announce that with V1.0 SP1, this is now supported.  Silverlight 4 introduced the [ICollectionViewFactory](http://msdn.microsoft.com/en-us/library/system.componentmodel.icollectionviewfactory(VS.95).aspx) interface, with support integrated into DataGrid and DataForm, and both EntitySet and EntityCollection now implement that interface to allow the Add/Remove features to light up.
 
 #  AspNetCore 0.4.0
 

--- a/NuGet/OpenRiaServices.Client.Core.nuspec
+++ b/NuGet/OpenRiaServices.Client.Core.nuspec
@@ -22,12 +22,16 @@
       <group targetFramework="netstandard2.0">
         <dependency id="System.ComponentModel.Annotations" version="5.0.0" />
         <dependency id="System.ServiceModel.Http" version="4.10.2" />
-		<dependency id="System.ServiceModel.Primitives" version="4.10.2" />
+        <dependency id="System.ServiceModel.Primitives" version="4.10.2" />
+      </group>
+      <group targetFramework="net6.0-windows">
+        <dependency id="System.ServiceModel.Http" version="4.10.2" />
+        <dependency id="System.ServiceModel.Primitives" version="4.10.2" />
       </group>
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" targetFramework="net472" />
-	  <frameworkAssembly assemblyName="System.Net.Http" targetFramework="net472" />
+      <frameworkAssembly assemblyName="System.Net.Http" targetFramework="net472" />
       <frameworkAssembly assemblyName="System.Runtime.Serialization" targetFramework="net472" />
       <frameworkAssembly assemblyName="System.ServiceModel" targetFramework="net472" />
       <frameworkAssembly assemblyName="System.ServiceModel.Web" targetFramework="net472" />
@@ -41,7 +45,7 @@
     <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.Web.dll" target="lib\netstandard2.0\OpenRiaServices.Client.Web.dll" />
     <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.Web.pdb" target="lib\netstandard2.0\OpenRiaServices.Client.Web.pdb" />
     <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.Web.xml" target="lib\netstandard2.0\OpenRiaServices.Client.Web.xml" />
-	<file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.dll" />
+    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.dll" />
     <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.pdb" target="lib\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.pdb" />
     <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.xml" target="lib\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.xml" />
 
@@ -52,9 +56,20 @@
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.Web.dll" target="lib\net472\OpenRiaServices.Client.Web.dll" />
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.Web.pdb" target="lib\net472\OpenRiaServices.Client.Web.pdb" />
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.Web.xml" target="lib\net472\OpenRiaServices.Client.Web.xml" />
-	<file src="..\src\bin\Release\net472\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\net472\OpenRiaServices.Client.DomainClients.Http.dll" />
+    <file src="..\src\bin\Release\net472\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\net472\OpenRiaServices.Client.DomainClients.Http.dll" />
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.DomainClients.Http.pdb" target="lib\net472\OpenRiaServices.Client.DomainClients.Http.pdb" />
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.DomainClients.Http.xml" target="lib\net472\OpenRiaServices.Client.DomainClients.Http.xml" />
+
+    <!-- Net6 binaries -->
+    <file src="..\src\bin\Release\net6.0-windows\OpenRiaServices.Client.dll" target="lib\net6.0-windows\OpenRiaServices.Client.dll" />
+    <file src="..\src\bin\Release\net6.0-windows\OpenRiaServices.Client.pdb" target="lib\net6.0-windows\OpenRiaServices.Client.pdb" />
+    <file src="..\src\bin\Release\net6.0-windows\OpenRiaServices.Client.xml" target="lib\net6.0-windows\OpenRiaServices.Client.xml" />
+    <file src="..\src\bin\Release\net6.0\OpenRiaServices.Client.Web.dll" target="lib\net6.0-windows\OpenRiaServices.Client.Web.dll" />
+    <file src="..\src\bin\Release\net6.0\OpenRiaServices.Client.Web.pdb" target="lib\net6.0-windows\OpenRiaServices.Client.Web.pdb" />
+    <file src="..\src\bin\Release\net6.0\OpenRiaServices.Client.Web.xml" target="lib\net6.0-windows\OpenRiaServices.Client.Web.xml" />
+    <file src="..\src\bin\Release\net6.0\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\net6.0-windows\OpenRiaServices.Client.DomainClients.Http.dll" />
+    <file src="..\src\bin\Release\net6.0\OpenRiaServices.Client.DomainClients.Http.pdb" target="lib\net6.0-windows\OpenRiaServices.Client.DomainClients.Http.pdb" />
+    <file src="..\src\bin\Release\net6.0\OpenRiaServices.Client.DomainClients.Http.xml" target="lib\net6.0-windows\OpenRiaServices.Client.DomainClients.Http.xml" />
 
   </files>
 </package>

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <RootNamespace>OpenRiaServices.Client.DomainClients</RootNamespace>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.2" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/OpenRiaServices.Client/Framework/DomainIdentifierAttribute.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainIdentifierAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace OpenRiaServices
 {
-#if SILVERLIGHT
+#if !SERVERFX
      /// <summary>
     /// A tagging attribute used to categorize a Type as being of a particular domain.
     /// </summary>

--- a/src/OpenRiaServices.Client/Framework/OpenRiaServices.Client.csproj
+++ b/src/OpenRiaServices.Client/Framework/OpenRiaServices.Client.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-  </PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.0;net6.0-windows</TargetFrameworks>
 
-  <ItemGroup>
-    <Compile Include="..\..\OpenRiaServices.Server\Framework\Data\CompositionAttribute.cs" />
-  </ItemGroup>
+      <!-- Disable obsolete warning (primarily AssociationAttribute) -->
+    <NoWarn Condition=" '$(TargetFramework)' != 'net472' ">$(NoWarn);CS0618</NoWarn>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net6.0-windows' ">$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
+    <UseWPF Condition=" '$(TargetFramework)' == 'net6.0-windows' ">true</UseWPF>
+  </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
@@ -15,7 +16,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="PresentationFramework" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Data.Linq" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="WindowsBase" />
     <Reference Include="System" />
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Server\Framework\Data\CompositionAttribute.cs" />
     <Compile Update="Resource.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -45,14 +46,5 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <!-- Disable obsolete warning (primarily AssociationAttribute) -->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <DefineConstants>$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
-  </PropertyGroup>
 
 </Project>

--- a/src/OpenRiaServices.Client/Test/Client.Test/Authentication/LoginParametersTest.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Authentication/LoginParametersTest.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Silverlight.Testing;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
 
 namespace OpenRiaServices.Client.Authentication.Test

--- a/src/OpenRiaServices.Client/Test/Client.Test/Authentication/WebContextBaseTest.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Authentication/WebContextBaseTest.cs
@@ -2,8 +2,6 @@
 using System.ComponentModel;
 using System.Security.Principal;
 using OpenRiaServices.Client.Test;
-using System.Windows;
-using Microsoft.Silverlight.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
 using DescriptionAttribute = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;

--- a/src/OpenRiaServices.Client/Test/Client.Test/Authentication/WindowsAuthenticationTest.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Authentication/WindowsAuthenticationTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Silverlight.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Client.Test;
 using OpenRiaServices.Silverlight.Testing;

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/DataAnnotationsTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/DataAnnotationsTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.Silverlight.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
 

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/DomainIdentifierTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/DomainIdentifierTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Microsoft.Silverlight.Testing;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
 
 namespace OpenRiaServices.Client.Test

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/DomainOperationExceptionTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/DomainOperationExceptionTests.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using Cities;
-using Microsoft.Silverlight.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace OpenRiaServices.Client.Test

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.cs
@@ -1,17 +1,13 @@
 ﻿extern alias SSmDsClient;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
-using DataTests.AdventureWorks.LTS;
-using Microsoft.Silverlight.Testing;
+using System.Runtime.CompilerServices;
+using Cities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
-using TestDomainServices;
-using Cities;
 using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
 
 namespace OpenRiaServices.Client.Test
@@ -353,11 +349,17 @@ namespace OpenRiaServices.Client.Test
         [TestMethod]
         [WorkItem(201155)]
         [Description("Tests that the memory leak in ICVF Proxies is fixed.")]
+
         public void ICVF_MemoryLeakTest()
         {
+            // Use NoInline so JIT will not keep temp variable alive 
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            WeakReference CreateCollectionViewWeakRef(EntityCollection<City> entityCollection)
+                => new WeakReference(this.GetICV(entityCollection));
+
             EntitySet<City> entitySet;
             EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
-            WeakReference weakRef = new WeakReference(this.GetICV(entityCollection));
+            WeakReference weakRef = CreateCollectionViewWeakRef(entityCollection);
             System.GC.Collect();
             Assert.IsFalse(weakRef.IsAlive);
         }

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityContainerTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityContainerTests.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using DataTests.AdventureWorks.LTS;
-using Microsoft.Silverlight.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
 using TestDomainServices;

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.cs
@@ -1,21 +1,18 @@
 ﻿extern alias SSmDsClient;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using Cities;
 using DataTests.Northwind.LTS;
-using Microsoft.Silverlight.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
-using TestDomainServices;
+using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
 
 namespace OpenRiaServices.Client.Test
 {
-    using Cities;
-    using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
 
     [TestClass]
     public class EntitySetTests : UnitTestBase
@@ -26,7 +23,7 @@ namespace OpenRiaServices.Client.Test
         public void ICVF_CreateView()
         {
             EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            Assert.IsNotNull(this.GetICV(entitySet), 
+            Assert.IsNotNull(this.GetICV(entitySet),
                 "View should not be null.");
         }
 
@@ -240,9 +237,14 @@ namespace OpenRiaServices.Client.Test
         [Description("Tests that the memory leak in ICVF Proxies is fixed.")]
         public void ICVF_MemoryLeakTest()
         {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();            
-            WeakReference weakRef = new WeakReference(this.GetICV(entitySet));
-            System.GC.Collect();         
+            // Use NoInline so JIT will not keep temp variable alive 
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            WeakReference CreateCollectionViewWeakRef(EntitySet<City> enitySet)
+                => new WeakReference(this.GetICV(enitySet));
+
+            EntitySet<City> entitySet = this.CreateEntitySet<City>();
+            WeakReference weakRef = CreateCollectionViewWeakRef(entitySet);
+            GC.Collect();
             Assert.IsFalse(weakRef.IsAlive);
         }
 #endif
@@ -261,7 +263,7 @@ namespace OpenRiaServices.Client.Test
             productsSet.EntityAdded += (obj, args) => productAdded += 1;
             productsSet.EntityRemoved += (obj, args) => productRemoved += 1;
             productsSet.PropertyChanged += (obj, args) => productPropertyChanged += 1;
-            ((INotifyCollectionChanged) productsSet).CollectionChanged += (obj, args) =>
+            ((INotifyCollectionChanged)productsSet).CollectionChanged += (obj, args) =>
                 productsCollectionChanged += 1;
 
             // create and add order to container

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/Reflection/MetaTypeTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/Reflection/MetaTypeTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Runtime.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/SubmitOperationExceptionTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/SubmitOperationExceptionTests.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using Cities;
-using Microsoft.Silverlight.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharedEntities;
 

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/TestHelpers.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/TestHelpers.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using DataTests.AdventureWorks.LTS;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Threading;
-using System.Diagnostics;
 
 namespace OpenRiaServices.Client.Test
 {

--- a/src/OpenRiaServices.Client/Test/Client.Test/Main.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Main.cs
@@ -1,12 +1,7 @@
 ﻿extern alias httpDomainClient; 
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using httpDomainClient::OpenRiaServices.Client.DomainClients;
@@ -23,9 +18,7 @@ namespace OpenRiaServices.Client.Test
                 = Thread.CurrentThread.CurrentCulture
                     = new System.Globalization.CultureInfo("en-US");
 
-
             DomainContext.DomainClientFactory = new BinaryHttpDomainClientFactory(new Uri("https://localhost:21312/DOES_NOT_EXISTS"), new HttpClientHandler() {});
-
         }
     }
 }

--- a/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
@@ -4,11 +4,9 @@
     <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
     <Version>1.0.0.0</Version>
     <UseWPF>true</UseWPF>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <DefineConstants>$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' != 'net472'">
     <!-- Disable obsolete warning (primarily AssociationAttribute) -->
     <NoWarn>$(NoWarn);CS0618</NoWarn>

--- a/src/OpenRiaServices.Client/Test/Client.Test/Properties/AssemblyInfo.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OperationAwaiter.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OperationAwaiter.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Reflection;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
This brings in the CollectionView support added in [WCF Ria Services SP1](https://jeffhandley.com/2011-03-10/riaservicesv1sp1rtm)

Qutoe from : https://jeffhandley.com/2011-03-10/riaservicesv1sp1rtm
> DataForm Add/Remove for EntitySet and EntityCollection
With our initial V1.0 release, many of you found that a DataForm bound to an EntitySet or an EntityCollection did not support the Add or Remove buttons.  This was a difficult cut to make in V1.0, so I’m pleased to announce that with V1.0 SP1, this is now supported.  Silverlight 4 introduced the [ICollectionViewFactory](http://msdn.microsoft.com/en-us/library/system.componentmodel.icollectionviewfactory(VS.95).aspx) interface, with support integrated into DataGrid and DataForm, and both EntitySet and EntityCollection now implement that interface to allow the Add/Remove features to light up.

> Be sure to keep an eye on [Kyle McClellan’s blog](http://blogs.msdn.com/kylemc) for more information on this feature.  You’ll hear us refer to it as ICollectionViewFactory or ICVF.