### PR TITLE
Obsolete WCF based Web DomainClient Factory

### DIFF
--- a/src/OpenRiaServices.Client.Web/Framework/Data/WebDomainClient.cs
+++ b/src/OpenRiaServices.Client.Web/Framework/Data/WebDomainClient.cs
@@ -112,7 +112,9 @@ namespace OpenRiaServices.Client
 #if !NETFRAMEWORK
             return new SoapDomainClientFactory();
 #else
+#pragma warning disable CS0618 // Type or member is obsolete
             return new WebDomainClientFactory();
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
         }
 

--- a/src/OpenRiaServices.Client.Web/Framework/Web/WebDomainClientFactory.cs
+++ b/src/OpenRiaServices.Client.Web/Framework/Web/WebDomainClientFactory.cs
@@ -18,6 +18,7 @@ namespace OpenRiaServices.Client.Web
         /// <summary>
         /// Initializes a new instance of the <see cref="WebDomainClientFactory" /> class.
         /// </summary>
+        [Obsolete("The WCF based WebDomainClientFactory will not receive any new changes. It is recommeded to switch to OpenRiaServices.Client.DomainClients.BinaryHttpDomainClientFactory instead.")]
         public WebDomainClientFactory()
             : base("binary")
         {

--- a/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/Main.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/Main.cs
@@ -34,10 +34,12 @@ namespace OpenRiaServices.Client.Test
                 AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip,
             });
 #if NETFRAMEWORK
+#pragma warning disable CS0618 // Type or member is obsolete
             DomainContext.DomainClientFactory = new Web.WebDomainClientFactory()
             {
                 ServerBaseUri = TestURIs.RootURI,
             };
+#pragma warning restore CS0618 // Type or member is obsolete
 #endif
 
             // Note: Below gives errors when running (at least BinaryHttpDomainClientFactory) against AspNetCore

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/WebDomainClientTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/WebDomainClientTests.cs
@@ -539,10 +539,12 @@ namespace OpenRiaServices.Client.Web.Test
     public class WebDomainClientTests_Globalization : UnitTestBase
     {
         private CultureInfo _defaultCulture;
-        private WebDomainClientFactory _webDomainClientfactory = new WebDomainClientFactory()
+#pragma warning disable CS0618 // Type or member is obsolete
+        private readonly WebDomainClientFactory _webDomainClientfactory = new WebDomainClientFactory()
         {
              ServerBaseUri = TestURIs.RootURI,
         };
+#pragma warning restore CS0618 // Type or member is obsolete
 
         [TestInitialize]
         public void SetUp()

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Main.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Main.cs
@@ -29,10 +29,12 @@ namespace OpenRiaServices.Client.Test
             StartWebServer();
 
 #if NETFRAMEWORK
+#pragma warning disable CS0618 // Type or member is obsolete
             DomainContext.DomainClientFactory = new Web.WebDomainClientFactory()
             {
                 ServerBaseUri = TestURIs.RootURI,
             };
+#pragma warning restore CS0618 // Type or member is obsolete
 
             //// Uncomment below to run tests using BinaryHttpDomainClientFactory instead:
             ///


### PR DESCRIPTION
We want to enable new uri naming standards on the server (such as removing ".svc/binary" and optionally removing the namespace) which will be difficult to do with the WCF based domain client.

We might want to add an obsolete attribute for 5.4 so that users have a lot of time to migrate to the newer handler which should be able to replace the WCF based one.