### PR TITLE
Remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is the evolved Open Source version of *WCF RIA Services*.
 
 The source code and issue list is currently kept at github (https://github.com/OpenRiaServices/OpenRiaServices).
 
-Some of their features are: 
+Some of the features are: 
  * Client side entity change tracking similar in concept to Entity Framework
    * Batch save (all or nothing) and undo functionality
  * Excellent support for data binding in with built in support for validation, INotifyPropertyChanged, INotifyCollectionChanged .. 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is the evolved Open Source version of *WCF RIA Services*.
 
 The source code and issue list is currently kept at github (https://github.com/OpenRiaServices/OpenRiaServices).
 
-Some of ther features are: 
+Some of their features are: 
  * Client side entity change tracking similar in concept to Entity Framework
    * Batch save (all or nothing) and undo functionality
  * Excellent support for data binding in with built in support for validation, INotifyPropertyChanged, INotifyCollectionChanged .. 
@@ -39,7 +39,7 @@ Some of ther features are:
    
 **Release Notes / Changelog**
 
-* A [Change log](https://github.com/OpenRIAServices/OpenRiaServices/blob/main/Changelog.md) is keept keeping track of changes made and write down release notes as features are developed
+* A [Change log](https://github.com/OpenRIAServices/OpenRiaServices/blob/main/Changelog.md) is kept keeping track of changes made and write down release notes as features are developed
 * [Github releases with changes and Release Notes](https://github.com/OpenRIAServices/OpenRiaServices/releases) for specific versions are created when a new version is released to nuget.
 
    


### PR DESCRIPTION
## Description:
This Pull Request fixes a typographical error in the README.md file.

## Changes Made:
Corrected "ther" to "their" in the README.md file.
Corrected "keept" to "kept" in the README.md file.

## Additional Information:
This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.