### PR TITLE
Speed up ValidateProperty

### DIFF
--- a/src/OpenRiaServices.Client/Framework/Entity.cs
+++ b/src/OpenRiaServices.Client/Framework/Entity.cs
@@ -1298,13 +1298,12 @@ namespace OpenRiaServices.Client
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.Property_Is_ReadOnly, propertyName));
             }
 
-            ComplexObject complexObject = value as ComplexObject;
-            if (complexObject != null && complexObject.IsAttached)
+            if (metaMember.IsComplex && value is ComplexObject complexObject && complexObject.IsAttached)
             {
                 throw new InvalidOperationException(Resource.ComplexType_InstancesCannotBeShared);
             }
 
-            if (this.MetaType.RequiresValidation)
+            if (metaMember.RequiresValidation)
             {
                 ValidationContext validationContext = this.CreateValidationContext();
                 validationContext.MemberName = propertyName;


### PR DESCRIPTION
Speeds up setting entity properties which does not have any validation attributes on them, by not performing data validation.

* Check metaMember.IsComplex before casting to ComplexObject for a slight perf increase for all properties
* Only do validation if property requires validation (don't check whole object)

