### PR TITLE
Add new test that validate how object level validation interact with property level validation

### DIFF
--- a/src/OpenRiaServices.Client/Framework/Entity.cs
+++ b/src/OpenRiaServices.Client/Framework/Entity.cs
@@ -1309,6 +1309,12 @@ namespace OpenRiaServices.Client
                 validationContext.MemberName = propertyName;
                 this.ValidateProperty(validationContext, value);
             }
+            else if (MetaType.RequiresObjectValidation)
+            {
+                // Validation error must have been set by object level validation
+                // Clear it to mimic old behaviour where validate property was always called in these scenarios
+                this.ValidationResultCollection.ReplaceErrors(propertyName, Array.Empty<ValidationResult>());
+            }
         }
 
         /// <summary>

--- a/src/OpenRiaServices.Client/Framework/Internal/MetaType.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MetaType.cs
@@ -32,6 +32,7 @@ namespace OpenRiaServices.Client.Internal
         [ThreadStatic]
         private static Dictionary<Type, MetaType> s_metaTypes;
         private readonly bool _requiresValidation;
+        private readonly bool _requiresObjectValidation;
         private readonly Type[] _childTypes;
         private readonly Dictionary<string, MetaMember> _metaMembers = new Dictionary<string, MetaMember>();
         private readonly ReadOnlyCollection<MetaMember> _dataMembers;
@@ -121,7 +122,8 @@ namespace OpenRiaServices.Client.Internal
             this.Type = type;
 
             _validationAttributes = new ReadOnlyCollection<ValidationAttribute>(this.Type.GetCustomAttributes(typeof(ValidationAttribute), true).OfType<ValidationAttribute>().ToArray());
-            _requiresValidation = _requiresValidation || _validationAttributes.Any() || typeof(IValidatableObject).IsAssignableFrom(type);
+            _requiresObjectValidation = _validationAttributes.Any() || typeof(IValidatableObject).IsAssignableFrom(type);
+            _requiresValidation = _requiresValidation || _requiresObjectValidation;
 
             // for identity purposes, we need to make sure values are always ordered
             KeyMembers = new ReadOnlyCollection<MetaMember>(_metaMembers.Values.Where(m => m.IsKeyMember).OrderBy(m => m.Name).ToArray());
@@ -261,6 +263,12 @@ namespace OpenRiaServices.Client.Internal
         /// validation. The check is recursive through any complex type members.
         /// </summary>
         public bool RequiresValidation => this._requiresValidation;
+
+        /// <summary>
+        /// Gets a value indicating whether the Type requires any Type level
+        /// validation.
+        /// </summary>
+        internal bool RequiresObjectValidation => this._requiresObjectValidation;
 
         /// <summary>
         /// Gets a value indicating whether the Type has any members marked with

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/EntityValidationTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/EntityValidationTests.cs
@@ -475,7 +475,7 @@ namespace OpenRiaServices.Client.Test
         public void ValidationErrors_ObjectLevelValidation()
         {
             MockEntity_ObjectValidation entity = new MockEntity_ObjectValidation();
-            INotifyDataErrorInfo notifier = (INotifyDataErrorInfo)entity;
+            INotifyDataErrorInfo notifier = entity;
 
             List<string> actualChanges = new List<string>();
             notifier.ErrorsChanged += (s, e) => actualChanges.Add(e.PropertyName);
@@ -487,8 +487,9 @@ namespace OpenRiaServices.Client.Test
             Assert.AreEqual(0, actualChanges.Count, "No errors should be detected");
 
             // Force object level validation
-            ((IEditableObject)entity).BeginEdit();
-            ((IEditableObject)entity).EndEdit();
+            IEditableObject editableObject = entity;
+            editableObject.BeginEdit();
+            editableObject.EndEdit();
 
             Assert.IsTrue(entity.HasValidationErrors, "Erros should be detected");
             Assert.AreEqual(1, entity.ValidationErrors.Count);
@@ -501,8 +502,8 @@ namespace OpenRiaServices.Client.Test
 
             // Setting property will remove object level validation
             entity.OnlyObjectValidation = null;
-            Assert.IsFalse(entity.HasValidationErrors, "No errors should be detected");
-            Assert.AreEqual(2, actualChanges.Count, "1 errors should be detected");
+            Assert.IsFalse(entity.HasValidationErrors, "Errors should have been removed");
+            Assert.AreEqual(2, actualChanges.Count, "change notification should have happened when clearing error");
         }
 
         [TestMethod]

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/EntityValidationTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/EntityValidationTests.cs
@@ -25,7 +25,7 @@ namespace OpenRiaServices.Client.Test
         public void Entity_Validation_Property_Fail_ReadOnly_Throws()
         {
             MockEntity entity = new MockEntity();
-            ExceptionHelper.ExpectInvalidOperationException(delegate()
+            ExceptionHelper.ExpectInvalidOperationException(delegate ()
             {
                 entity.ReadOnlyProperty = "x";
             }, "The 'ReadOnlyProperty' property is read only.");
@@ -54,7 +54,7 @@ namespace OpenRiaServices.Client.Test
         public void Entity_Validation_Property_Fail_NonPublic_Throws()
         {
             MockEntity entity = new MockEntity();
-            ExceptionHelper.ExpectArgumentException(delegate()
+            ExceptionHelper.ExpectArgumentException(delegate ()
             {
                 entity.NonPublicProperty = "x";
             }, "Type 'MockEntity' does not contain a public property named 'NonPublicProperty'.\r\nParameter name: propertyName");
@@ -65,7 +65,7 @@ namespace OpenRiaServices.Client.Test
         public void Entity_Validation_Property_Fail_Bogus_Throws()
         {
             MockEntity entity = new MockEntity();
-            ExceptionHelper.ExpectArgumentException(delegate()
+            ExceptionHelper.ExpectArgumentException(delegate ()
             {
                 entity.BogusProperty = "x";
             }, "Type 'MockEntity' does not contain a public property named 'XXX'.\r\nParameter name: propertyName");
@@ -144,7 +144,7 @@ namespace OpenRiaServices.Client.Test
         {
             MockEntity entity = new MockEntity();
             ValidationContext context = new ValidationContext(entity, null, null);
-            ExceptionHelper.ExpectValidationException(delegate()
+            ExceptionHelper.ExpectValidationException(delegate ()
             {
                 System.ComponentModel.DataAnnotations.Validator.ValidateObject(entity, context);
             }, "The ReadWriteProperty field is required.", typeof(RequiredAttribute), null);
@@ -228,7 +228,7 @@ namespace OpenRiaServices.Client.Test
         [Description("When a ValidationContext is provided to the DomainContext, it should be used for Property Validation")]
         public void ValidationContextUsedForPropertyValidation()
         {
-            Dictionary<object, object> items = new Dictionary<object,object>();
+            Dictionary<object, object> items = new Dictionary<object, object>();
             items.Add("TestMethod", "ValidationContextUsedForPropertyValidation");
             ValidationContext providedValidationContext = new ValidationContext(this, null, items);
 
@@ -467,6 +467,42 @@ namespace OpenRiaServices.Client.Test
             Assert.IsTrue(actualChanges.SequenceEqual(affectedMemberNames), "Events when setting to a valid value");
             Assert.AreEqual<int>(0, errors.Count(), "Expect no errors after setting to a valid value");
             actualChanges.Clear();
+        }
+
+
+        [TestMethod]
+        [Description("Test how object level validation interacts with property level validation")]
+        public void ValidationErrors_ObjectLevelValidation()
+        {
+            MockEntity_ObjectValidation entity = new MockEntity_ObjectValidation();
+            INotifyDataErrorInfo notifier = (INotifyDataErrorInfo)entity;
+
+            List<string> actualChanges = new List<string>();
+            notifier.ErrorsChanged += (s, e) => actualChanges.Add(e.PropertyName);
+
+            // Setting property directly will not catch any error
+            entity.OnlyObjectValidation = string.Empty;
+
+            Assert.IsFalse(entity.HasValidationErrors, "No errors should be detected");
+            Assert.AreEqual(0, actualChanges.Count, "No errors should be detected");
+
+            // Force object level validation
+            ((IEditableObject)entity).BeginEdit();
+            ((IEditableObject)entity).EndEdit();
+
+            Assert.IsTrue(entity.HasValidationErrors, "Erros should be detected");
+            Assert.AreEqual(1, entity.ValidationErrors.Count);
+
+            var actualError = entity.ValidationErrors.First();
+            Assert.AreEqual("Required", actualError.ErrorMessage);
+            CollectionAssert.AreEqual(new[] { nameof(MockEntity_ObjectValidation.OnlyObjectValidation) }, actualError.MemberNames.ToList(), "membernames");
+
+            Assert.AreEqual(1, actualChanges.Count, "1 errors should be detected");
+
+            // Setting property will remove object level validation
+            entity.OnlyObjectValidation = null;
+            Assert.IsFalse(entity.HasValidationErrors, "No errors should be detected");
+            Assert.AreEqual(2, actualChanges.Count, "1 errors should be detected");
         }
 
         [TestMethod]
@@ -940,6 +976,27 @@ namespace OpenRiaServices.Client.Test
         public void CallValidateProperty(ValidationContext validationContext, object value)
         {
             this.ValidateProperty(validationContext, value);
+        }
+    }
+
+    public class MockEntity_ObjectValidation : Entity, IValidatableObject
+    {
+        private string _onlyObjectValidation;
+
+        public string OnlyObjectValidation
+        {
+            get => _onlyObjectValidation;
+            set
+            {
+                this.ValidateProperty(nameof(OnlyObjectValidation), value);
+                _onlyObjectValidation = value;
+            }
+        }
+
+        IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+        {
+            if (string.IsNullOrEmpty(_onlyObjectValidation))
+                yield return new ValidationResult("Required", new[] { nameof(OnlyObjectValidation) });
         }
     }
 


### PR DESCRIPTION
There is a change that #453 changed behaviour for properties which are only validated using object level validation (either IValidatableObject or Validation attributes on the type) but does not have any property level validation attributes.

Previously such object level validation errors where cleared when if the property was modified.