### PR TITLE
Improve perf of ReplaceErrors

### DIFF
--- a/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
@@ -73,20 +73,15 @@ namespace OpenRiaServices.Client
         /// <param name="newResults">The new errors for the property.</param>
         internal void ReplaceErrors(string propertyName, IEnumerable<ValidationResult> newResults)
         {
-            if (this.Count == 0)
-            {
-                ReplaceErrors(newResults);
-                return;
-            }
-
             // First determine the set of affected member names. We have to take nested member paths
             // into account.
             List<string> affectedMembers = this.SelectMany(p => p.MemberNames)
                 .Where(p => (p != null) 
                     && p.StartsWith(propertyName, StringComparison.Ordinal)
                     // name is exact name propertyName , or contains '.' after property name
-                    && (p.Length <= propertyName.Length || p[propertyName.Length] == '.'))
+                    && (p.Length > propertyName.Length && p[propertyName.Length] == '.'))
                 .ToList();
+            affectedMembers.Add(propertyName);
 
             // See if there are existing errors for the property
             int removedErrros = _results.RemoveAll(r => r.MemberNames.Any(member => affectedMembers.Contains(member)));

--- a/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
@@ -126,7 +126,6 @@ namespace OpenRiaServices.Client
             // Get the combined list of properties affected.  
             // SymmetricExceptWith - to get properties in error but aren't any longer or those newly in error
             // add all affected by the change
-            // PERF: origPropertiesInError is already a HashSet which we could potentially use (Saves 1/8 of time and <20% of allocations)
             HashSet<string> allPropertiesAffected = new HashSet<string>(origPropertiesInError);
             allPropertiesAffected.SymmetricExceptWith(_propertiesInError);
             allPropertiesAffected.UnionWith(propertiesAffected);

--- a/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
@@ -73,12 +73,11 @@ namespace OpenRiaServices.Client
         /// <param name="newResults">The new errors for the property.</param>
         internal void ReplaceErrors(string propertyName, IEnumerable<ValidationResult> newResults)
         {
-            // TODO: Uncomment fast path
-            //if (this.Count == 0)
-            //{
-            //    ReplaceErrors(newResults);
-            //    return;
-            //}
+            if (this.Count == 0)
+            {
+                ReplaceErrors(newResults);
+                return;
+            }
 
             // First determine the set of affected member names. We have to take nested member paths
             // into account.
@@ -156,7 +155,7 @@ namespace OpenRiaServices.Client
 
                 if (errors.Any(e => !e.MemberNames.Any()))
                 {
-                    propertiesInError = propertiesInError.Union(new string[] { null });
+                    propertiesInError = propertiesInError.Concat(new string[] { null });
                 }
             }
 

--- a/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
@@ -123,12 +123,13 @@ namespace OpenRiaServices.Client
                 this.OnHasErrorsChanged();
             }
 
-            // Find what properties were: in error but aren't any longer, newly in error, affected by the change
-            IEnumerable<string> noLongerInError = origPropertiesInError.Except(this._propertiesInError);
-            IEnumerable<string> newlyInError = this._propertiesInError.Except(origPropertiesInError);
-
-            // Get the combined list of properties affected.  The Union gives a Distinct result.
-            IEnumerable<string> allPropertiesAffected = noLongerInError.Union(newlyInError).Union(propertiesAffected);
+            // Get the combined list of properties affected.  
+            // SymmetricExceptWith - to get properties in error but aren't any longer or those newly in error
+            // add all affected by the change
+            // PERF: origPropertiesInError is already a HashSet which we could potentially use (Saves 1/8 of time and <20% of allocations)
+            HashSet<string> allPropertiesAffected = new HashSet<string>(origPropertiesInError);
+            allPropertiesAffected.SymmetricExceptWith(_propertiesInError);
+            allPropertiesAffected.UnionWith(propertiesAffected);
 
             // For each property affected, call the errors changed method
             foreach (string propertyName in allPropertiesAffected)

--- a/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
@@ -115,7 +115,7 @@ namespace OpenRiaServices.Client
 
             // Determine our new state
             this._hasErrors = (this.Count > 0);
-            this._propertiesInError = GetPropertiesInError(this).Distinct();
+            this._propertiesInError = new HashSet<string>(GetPropertiesInError(this)); // HashSet is used to make properties distinct
 
             // Call the notification method if the 'HasErrors' bit has changed
             if (this._hasErrors != origHasErrors)

--- a/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
@@ -97,7 +97,7 @@ namespace OpenRiaServices.Client
 
                 // Force the properties of the new results to receive notifications, ensuring that the
                 // affected members are included in that list
-                this.OnCollectionChanged(GetPropertiesInError(newResults).Union(affectedMembers));
+                this.OnCollectionChanged(GetPropertiesInError(newResults).Concat(affectedMembers));
             }
         }
 


### PR DESCRIPTION
Time to create 500 000 simple entities and set 3 properties each (where one property has no validation) 

Elapsed time : 5,6 seconds => 4,4 sseconds
Memory allocation 5093 MB => 3178 MB

|  | Elapsed time | RAM|
|-|-|-|
| original | 5,6s | 5093 MB |
| commit 6 - ReplaceErrors and Union => ConCat changes  | 4.4s | 3178 MB |
| commit 7 - Use HashSet instead of LINQ in OnCollectionChange  | < 4.0s | 2317 MB | 