### PR TITLE
AspNetCore documentation, FrozenSet and C#12

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,8 @@
     <DeterministicSourcePaths Condition="'$(BUILD_BUILDID)' != '' and '$(IsFrameworkProject)' == 'true'">true</DeterministicSourcePaths>
     <ContinuousIntegrationBuild Condition="'$(BUILD_BUILDID)' != '' and '$(IsFrameworkProject)' == 'true'">true</ContinuousIntegrationBuild>
 
-    <!-- Use csharp 10.0 for all projects -->
-    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">11.0</LangVersion>
+    <!-- Use csharp 12.0 for all projects -->
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.csproj'">12.0</LangVersion>
     <AnalysisMode Condition="'$(IsFrameworkProject)' == 'true'">Recommended</AnalysisMode>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
@@ -1,18 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SERVERFX;ASPNET_CORE</DefineConstants>
     <RootNamespace>OpenRiaServices.Hosting</RootNamespace>
     <!-- Ignore documentation varnings while experimental-->
     <NoWarn>$(NoWarn);CS1574;CS1573;CS1591;CS1572</NoWarn>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Daniel-Svensson</Authors>
     <PackageTags>OpenRiaServices AspNetCore Hosting DomainServices AspNet WCF RIA Services Server</PackageTags>
     <Description>
       Asp.Net Core Hosting for OpenRiaservices
-      Public API will change before 1.0.0 release
 
       See README at https://github.com/OpenRIAServices/OpenRiaServices/tree/main/src/OpenRiaServices.Hosting.AspNetCore/Framework for usage.
     </Description>
@@ -26,6 +25,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" Condition="'$(TargetFramework)' != 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SERVERFX;ASPNET_CORE</DefineConstants>
     <RootNamespace>OpenRiaServices.Hosting</RootNamespace>
     <!-- Ignore documentation varnings while experimental-->

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/README.md
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/README.md
@@ -96,7 +96,7 @@ You can still (and probably should) use the OpenRiaServices specific attributes 
 ### AspNetCore Authentication and Authorization
 
 You can use standard [aspnetcore Authentication and Authorization](https://learn.microsoft.com/en-us/aspnet/core/security/?view=aspnetcore-7.0)
-to validate most requests (but **NOT** indivudual Insert,Update,Delete methods, you can apply atttributes to your DomainService class for those).
+to validate most requests (but **NOT** indivudual Insert, Update, Delete methods, you can apply atttributes to your DomainService class for those).
 The validation will happen before the DomainService is even created, making them more powerful than built in attributes.
 
 The **[AspNetCore Sample](https://github.com/OpenRIAServices/Samples/tree/main/WpfCore_AspNetCore)** shows how cookie based login similar to ASP.NET Membership provider *can* be handled.

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/SystemServiceModel.Dispatcher/QueryStringConverter.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/SystemServiceModel.Dispatcher/QueryStringConverter.cs
@@ -5,47 +5,48 @@
 //------------------------------------------------------------
 using OpenRiaServices;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
+using System.Collections.Frozen;
 using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Xml;
 
-#pragma warning disable 1634, 1691
 namespace System.ServiceModel.Dispatcher
 {
     // Thread Safety: This class is thread safe
     class QueryStringConverter
     {
-        private readonly HashSet<Type> _defaultSupportedQueryStringTypes = new();
+        private readonly FrozenSet<Type> _defaultSupportedQueryStringTypes;
         // the cache does not have a quota since it is per endpoint and is
         // bounded by the number of types in the contract at the endpoint
         private readonly ConcurrentDictionary<Type, TypeConverter> _typeConverterCache = new();
 
         public QueryStringConverter()
         {
-            this._defaultSupportedQueryStringTypes.Add(typeof(byte));
-            this._defaultSupportedQueryStringTypes.Add(typeof(sbyte));
-            this._defaultSupportedQueryStringTypes.Add(typeof(short));
-            this._defaultSupportedQueryStringTypes.Add(typeof(int));
-            this._defaultSupportedQueryStringTypes.Add(typeof(long));
-            this._defaultSupportedQueryStringTypes.Add(typeof(ushort));
-            this._defaultSupportedQueryStringTypes.Add(typeof(uint));
-            this._defaultSupportedQueryStringTypes.Add(typeof(ulong));
-            this._defaultSupportedQueryStringTypes.Add(typeof(float));
-            this._defaultSupportedQueryStringTypes.Add(typeof(double));
-            this._defaultSupportedQueryStringTypes.Add(typeof(bool));
-            this._defaultSupportedQueryStringTypes.Add(typeof(char));
-            this._defaultSupportedQueryStringTypes.Add(typeof(decimal));
-            this._defaultSupportedQueryStringTypes.Add(typeof(string));
-            this._defaultSupportedQueryStringTypes.Add(typeof(object));
-            this._defaultSupportedQueryStringTypes.Add(typeof(DateTime));
-            this._defaultSupportedQueryStringTypes.Add(typeof(TimeSpan));
-            this._defaultSupportedQueryStringTypes.Add(typeof(byte[]));
-            this._defaultSupportedQueryStringTypes.Add(typeof(Guid));
-            this._defaultSupportedQueryStringTypes.Add(typeof(Uri));
-            this._defaultSupportedQueryStringTypes.Add(typeof(DateTimeOffset));
+            this._defaultSupportedQueryStringTypes = FrozenSet.ToFrozenSet(new Type[] {
+                typeof(byte),
+                typeof(sbyte),
+                typeof(short),
+                typeof(int),
+                typeof(long),
+                typeof(ushort),
+                typeof(uint),
+                typeof(ulong),
+                typeof(float),
+                typeof(double),
+                typeof(bool),
+                typeof(char),
+                typeof(decimal),
+                typeof(string),
+                typeof(object),
+                typeof(DateTime),
+                typeof(TimeSpan),
+                typeof(byte[]),
+                typeof(Guid),
+                typeof(Uri),
+                typeof(DateTimeOffset),
+            });
         }
 
         public virtual bool CanConvert(Type type)
@@ -157,7 +158,7 @@ namespace System.ServiceModel.Dispatcher
         {
             ArgumentNullException.ThrowIfNull(parameterType);
             if (parameterType.IsValueType)
-            ArgumentNullException.ThrowIfNull(parameter);
+                ArgumentNullException.ThrowIfNull(parameter);
 
             switch (Type.GetTypeCode(parameterType))
             {

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Linq/DefaultQueryResolver.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Linq/DefaultQueryResolver.cs
@@ -23,7 +23,7 @@ namespace System.Linq.Dynamic
             MemberExpression mex = null;
             IDictionary<PropertyDescriptor, IncludeAttribute[]> entityIncludeMap = MetaType.GetMetaType(type).ProjectionMemberMap;
 
-            if (entityIncludeMap.Any())
+            if (entityIncludeMap.Count > 0)
             {
                 // Do a reverse lookup in the include map for the type, looking
                 // for the source of the member (if present)


### PR DESCRIPTION
Use C# 12.0 for all projects
AspNetCore updates
- Add authentication documentation
- Use FrozenSet in first location (QueryStringConverter)
- Update versionprefix to 1.0.0 (for next release)

Minor:
- Replace Any() with `Count > 0`