### PR TITLE
Test updates - nuget and msbuild code

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -74,7 +74,7 @@
   <!-- Enable source link, we really only want this for framework assemblies and CI builds
   -->
   <ItemGroup Condition="'$(IsFrameworkProject)' == 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
 
   </ItemGroup>
 

--- a/src/OpenRiaServices.Client/Test/Client.External.Test/OpenRiaServices.Client.External.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.External.Test/OpenRiaServices.Client.External.Test.csproj
@@ -4,7 +4,7 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/OpenRiaServices.Hosting.AspNetCore.Test.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/OpenRiaServices.Hosting.AspNetCore.Test.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
@@ -7,7 +7,7 @@
     <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.Wcf.Endpoint/Test/OpenRiaServices.Hosting.Wcf.Endpoint.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf.Endpoint/Test/OpenRiaServices.Hosting.Wcf.Endpoint.Test.csproj
@@ -5,7 +5,7 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.Wcf/Test/OpenRiaServices.Hosting.Wcf.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf/Test/OpenRiaServices.Hosting.Wcf.Test.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj
+++ b/src/OpenRiaServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj
@@ -10,7 +10,7 @@
     <Compile Include="..\..\OpenRiaServices.Server\Test\MockDataService.cs" Link="Shared\MockDataService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
+++ b/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Tools.CodeGenTask/OpenRiaServices.Tools.CodeGenTask.csproj
+++ b/src/OpenRiaServices.Tools.CodeGenTask/OpenRiaServices.Tools.CodeGenTask.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\OpenRiaServices.Tools\Framework\OpenRiaServices.Tools.csproj" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
@@ -41,10 +41,10 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />

--- a/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Win32;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,13 +14,10 @@ namespace OpenRiaServices.Tools.Test
     public class CompilerHelper
     {
         // The version of Silverlight we use in registry keys below
-        private const string SLVER = "v5.0";
-        private static ConcurrentDictionary<string, PortableExecutableReference> s_referenceCache = new();
-
-        private static ParseOptions s_cSharpParseOptions = new CSharpParseOptions(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp5, preprocessorSymbols: new
+        private static readonly ConcurrentDictionary<string, PortableExecutableReference> s_referenceCache = new();
+        private static readonly ParseOptions s_cSharpParseOptions = new CSharpParseOptions(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp5, preprocessorSymbols: new
                     [] { "SILVERLIGHT" });
-
-        private static ParseOptions s_VbParseOptions = new VisualBasicParseOptions(Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14,
+        private static readonly ParseOptions s_VbParseOptions = new VisualBasicParseOptions(Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.VisualBasic14,
                     preprocessorSymbols: new
                     [] { new KeyValuePair<string, object>("SILVERLIGHT", 1) });
 

--- a/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.VisualBasic;
-using System.Collections.Immutable;
+using System.Collections.Concurrent;
 
 namespace OpenRiaServices.Tools.Test
 {
@@ -16,7 +16,7 @@ namespace OpenRiaServices.Tools.Test
     {
         // The version of Silverlight we use in registry keys below
         private const string SLVER = "v5.0";
-        private static Dictionary<string, PortableExecutableReference> s_referenceCache = new Dictionary<string, PortableExecutableReference>();
+        private static ConcurrentDictionary<string, PortableExecutableReference> s_referenceCache = new();
 
         private static ParseOptions s_cSharpParseOptions = new CSharpParseOptions(Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp5, preprocessorSymbols: new
                     [] { "SILVERLIGHT" });
@@ -179,16 +179,7 @@ namespace OpenRiaServices.Tools.Test
         /// <param name="filename">full path to dll</param>
         private static PortableExecutableReference LoadReference(string filename)
         {
-            PortableExecutableReference reference;
-
-            if (s_referenceCache.TryGetValue(filename, out reference))
-            {
-                return reference;
-            }
-
-            reference = MetadataReference.CreateFromFile(filename);
-            s_referenceCache.Add(filename, reference);
-            return reference;
+            return s_referenceCache.GetOrAdd(filename, static key => MetadataReference.CreateFromFile(key));
         }
 
         /// <summary>

--- a/src/OpenRiaServices.Tools/Test/MsBuildHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/MsBuildHelper.cs
@@ -279,7 +279,7 @@ namespace OpenRiaServices.Tools.Test
                     if (disposing)
                     {
                         _projectInstance = null;
-                        BuildManager.ResetCaches();
+                        //BuildManager.ResetCaches();
                         //if (_buildManager != null)
                         //{
                         //    _buildManager.ResetCaches();

--- a/src/OpenRiaServices.Tools/Test/MsBuildHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/MsBuildHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,7 +18,7 @@ namespace OpenRiaServices.Tools.Test
     /// </summary>
     public static class MsBuildHelper
     {
-        private static readonly Dictionary<string, IList<string>> s_ReferenceAssembliesByProjectPath = new Dictionary<string, IList<string>>();
+        private static readonly ConcurrentDictionary<string, IList<string>> s_ReferenceAssembliesByProjectPath = new();
 
         /// <summary>
         /// Extract the list of assemblies both generated and referenced by the named project.
@@ -25,18 +26,12 @@ namespace OpenRiaServices.Tools.Test
         /// <returns></returns>
         public static List<string> GetReferenceAssemblies(string projectPath)
         {
-            IList<string> cachedAssemblies;
-
-            lock (s_ReferenceAssembliesByProjectPath)
+            IList<string> cachedAssemblies = s_ReferenceAssembliesByProjectPath.GetOrAdd(projectPath, static path =>
             {
-                if (!s_ReferenceAssembliesByProjectPath.TryGetValue(projectPath, out cachedAssemblies))
-                {
-                    cachedAssemblies = new List<string>();
-                    GetReferenceAssemblies(projectPath, cachedAssemblies);
-
-                    s_ReferenceAssembliesByProjectPath.Add(projectPath, cachedAssemblies);
-                }
-            }
+                var assemblies = new List<string>();
+                GetReferenceAssemblies(path, assemblies);
+                return assemblies;
+            });
 
             // Create a new copy to prevent modifications to original list
             return new List<string>(cachedAssemblies);
@@ -47,7 +42,7 @@ namespace OpenRiaServices.Tools.Test
         /// </summary>
         /// <param name="projectPath">Absolute path to the project file itself</param>
         /// <param name="assemblies">List to add assembly names to</param>
-        public static void GetReferenceAssemblies(string projectPath, IList<string> assemblies)
+        private static void GetReferenceAssemblies(string projectPath, IList<string> assemblies)
         {
             projectPath = Path.GetFullPath(projectPath);
 

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.8.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -20,15 +20,15 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.8.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/OpenRiaServices.Common.Test.csproj
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/OpenRiaServices.Common.Test.csproj
@@ -14,6 +14,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472' ">
-    <PackageReference Include="System.Management" Version="7.0.2" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/OpenRiaservices.EndToEnd.AspNetCore.Test.csproj
+++ b/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/OpenRiaservices.EndToEnd.AspNetCore.Test.csproj
@@ -11,7 +11,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OpenRiaservices.EndToEnd.Wcf.Test.csproj
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OpenRiaservices.EndToEnd.Wcf.Test.csproj
@@ -10,7 +10,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
+++ b/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
@@ -14,7 +14,7 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />


### PR DESCRIPTION
* Update test dependencies
* potential speed up of tooling test by not clearing msbuild caches 
* Fix some issues preventing parallel test execution of tooling tests (it does not work yet)