### PR TITLE
Use BinaryHttpDomainClient in AspNetCore Test

### DIFF
--- a/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
@@ -260,5 +260,12 @@ namespace OpenRiaServices.Client.Test
             Assert.AreEqual(webExceptionStatus, e.Status);
             return e;
         }
+
+        public static InvalidCastException ExpectInvalidCastException(GenericDelegate del, string message)
+        {
+            InvalidCastException e = ExpectExceptionHelper<InvalidCastException>(del);
+            Assert.AreEqual(message, e.Message);
+            return e;
+        }
     }
 }

--- a/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/Main.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/Main.cs
@@ -31,14 +31,6 @@ namespace OpenRiaServices.Client.Test
                 UseCookies = true,
                 AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip,
             });
-#if NETFRAMEWORK
-#pragma warning disable CS0618 // Type or member is obsolete
-            DomainContext.DomainClientFactory = new Web.WebDomainClientFactory()
-            {
-                ServerBaseUri = TestURIs.RootURI,
-            };
-#pragma warning restore CS0618 // Type or member is obsolete
-#endif
 
             // Note: Below gives errors when running (at least BinaryHttpDomainClientFactory) against AspNetCore
             // It seems to cache results even with "private, no-store"

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/DataServiceTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/DataServiceTests.cs
@@ -486,6 +486,9 @@ namespace OpenRiaServices.Client.Test
         /// Verify that if an invalid DomainOperationEntry name is specified, that the Load
         /// operation finishes with the expected WebResponse.StatusCode.
         /// </summary>
+#if ASPNETCORE
+        [Ignore("Does not work the same way with AspNetCore")]
+#endif
         [TestMethod]
         public void TestInvalidMethodName()
         {

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/DataServiceTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/DataServiceTests.cs
@@ -487,7 +487,7 @@ namespace OpenRiaServices.Client.Test
         /// operation finishes with the expected WebResponse.StatusCode.
         /// </summary>
 #if ASPNETCORE
-        [Ignore("Does not work the same way with AspNetCore")]
+        [Ignore("BinaryHttpDomainClientFactory does not validate if method exists, and since name is always specified by code generation it is not important to validate it")]
 #endif
         [TestMethod]
         public void TestInvalidMethodName()

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/QueryTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/QueryTests.cs
@@ -2006,6 +2006,9 @@ namespace OpenRiaServices.Client.Test
             });
         }
 
+#if ASPNETCORE
+        [Ignore("BinaryHttpDomainClientFactory does not validate if method exists, and since name is always specified by code generation it is not important to validate it")]
+#endif
         [TestMethod]
         public async Task TestServerExceptions_QueryOnNonExistentMethod()
         {
@@ -2013,15 +2016,10 @@ namespace OpenRiaServices.Client.Test
             var query = ctxt.CreateQuery<Product>("NonExistentMethod", null, false, true);
             await ValidateQueryException(ctxt, query, ex =>
             {
-#if ASPNETCORE
-                Assert.IsNotNull(ex as DomainOperationException, "Expected DomainOperationException");
-                Assert.IsTrue(ex.Message == "Load operation failed for query 'NonExistentMethod'. Unexpected server statuscode 404 'NotFound'");
-#else
                 Assert.IsTrue(ex.Message.StartsWith("Load operation failed for query 'NonExistentMethod'. An error occurred while receiving the HTTP response to"));
                 Assert.IsTrue(ex.Message.EndsWith("This could be due to the service endpoint binding not using the HTTP protocol. This could also be due to an HTTP request context being aborted by the server (possibly due to the service shutting down). See server logs for more details."));
                 Assert.IsNotNull(ex.InnerException as CommunicationException, "Expected CommunicationException");
                 Assert.IsNotNull(ex.InnerException.InnerException as WebException, "Expected WebException");
-#endif
             });
         }
 

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/QueryTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/QueryTests.cs
@@ -1952,12 +1952,19 @@ namespace OpenRiaServices.Client.Test
             paramValues["subCategoryID"] = "Foobar";
             paramValues["minListPrice"] = 50;
             paramValues["color"] = "Yellow";
-
+#if ASPNETCORE
+            ExceptionHelper.ExpectInvalidCastException(delegate
+            {
+                var query = ctxt.CreateQuery<Product>("GetProductsMultipleParams", paramValues, false, true);
+                ctxt.Load(query, false);
+            }, "Specified cast is not valid.");
+#else
             ExceptionHelper.ExpectArgumentException(delegate
             {
                 var query = ctxt.CreateQuery<Product>("GetProductsMultipleParams", paramValues, false, true);
                 ctxt.Load(query, false);
             }, "Object of type 'System.String' cannot be converted to type 'System.Int32'.");
+#endif
         }
 
         /// <summary>
@@ -2006,9 +2013,15 @@ namespace OpenRiaServices.Client.Test
             var query = ctxt.CreateQuery<Product>("NonExistentMethod", null, false, true);
             await ValidateQueryException(ctxt, query, ex =>
             {
-                // REVIEW: Assert the error message.
+#if ASPNETCORE
+                Assert.IsNotNull(ex as DomainOperationException, "Expected DomainOperationException");
+                Assert.IsTrue(ex.Message == "Load operation failed for query 'NonExistentMethod'. Unexpected server statuscode 404 'NotFound'");
+#else
+                Assert.IsTrue(ex.Message.StartsWith("Load operation failed for query 'NonExistentMethod'. An error occurred while receiving the HTTP response to"));
+                Assert.IsTrue(ex.Message.EndsWith("This could be due to the service endpoint binding not using the HTTP protocol. This could also be due to an HTTP request context being aborted by the server (possibly due to the service shutting down). See server logs for more details."));
                 Assert.IsNotNull(ex.InnerException as CommunicationException, "Expected CommunicationException");
                 Assert.IsNotNull(ex.InnerException.InnerException as WebException, "Expected WebException");
+#endif
             });
         }
 


### PR DESCRIPTION
Remove obsolete WebDomainClientFactory from AspNetCore tests and use BinaryHttpDomainClientFactory instead.
Modify tests that does not pass 