### PR TITLE
Don't use attributes reserved for compiler in CodeGen

### DIFF
--- a/src/OpenRiaServices.Tools/Test/CodeGenRequiredModifierTests.cs
+++ b/src/OpenRiaServices.Tools/Test/CodeGenRequiredModifierTests.cs
@@ -1,0 +1,31 @@
+﻿#if NET7_0_OR_GREATER //required modifier does not work before net7
+using System.ComponentModel.DataAnnotations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace OpenRiaServices.Tools.Test;
+
+/// <summary>
+/// CodeGen tests for the required modifier
+/// </summary>
+[TestClass]
+public class CodeGenRequiredModifierTests
+{
+    [TestMethod]
+    [Description("CodeGen does not apply compiler exclusive attribute for required")]
+    public void CodeGen_Required_Modifier_Dont_Use_Compiler_Attributes()
+    {
+        MockSharedCodeService sts = TestHelper.CreateCommonMockSharedCodeService();
+        string generatedCode = TestHelper.GenerateCodeAssertSuccess("C#", new Type[] {typeof(Mock_CG_Required_Entity_DomainService) }, null, sts);
+        TestHelper.AssertGeneratedCodeDoesNotContain(generatedCode, "RequiredMember");
+    }
+}
+
+public class Mock_CG_Required_Entity_DomainService : GenericDomainService<Mock_CG_Required_Entity> { }
+
+public class Mock_CG_Required_Entity
+{
+    [Key]
+    public required string RequiredProperty { get; set; }
+}
+#endif


### PR DESCRIPTION
Do not use attributes reserved by the compiler in codegen, such as RequiredMemberAttribute and NullableContextAttribute.

Will make it possible to use the `required` modifier for fields and properties