### PR TITLE
Use portable pdb for .NET Framework

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* .NET Framework builds now includes the smaller portable pdb's instead of of the old "full" windows style pdb's
+  * NOTE: For .NET Framework apps ensure that *supportedRuntime* in *app.config* and corresponding setting in *web.config* does not specify an older runtime if you wan't line numbers in stack traces.
+
 # 5.4.2 / AspNetCore 1.0.0
 
 ### .NET8

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -51,13 +51,7 @@
     <AssemblyOriginatorKeyFile Condition="'$(AssemblyOriginatorKeyFile)' == '' And '$(IsTestProject)' == 'true'">$(MSBuildThisFileDirectory)\snk\Tests.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 
-    <!-- opt out from portable pdbs, for better compability with older net framework releases
-    This is required for several test related projects since code generation's 
-    pdb reader cannot read the portable ones
-    -->
     <DebugType>portable</DebugType>
-    <DebugType Condition="$(TargetFramework.StartsWith('net4')) OR '$(IsTestProject)'=='true'">pdbonly</DebugType>
-
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GitVersion_AssemblySemVer)' != ''">

--- a/src/OpenRiaServices.EntityFramework/Test/CodeFirstModel/EFCodeFirstModels.csproj
+++ b/src/OpenRiaServices.EntityFramework/Test/CodeFirstModel/EFCodeFirstModels.csproj
@@ -7,10 +7,6 @@
     <DefineConstants>$(DefineConstants);DBCONTEXT</DefineConstants>
     <Version>1.0.0.0</Version>
   </PropertyGroup>
-  <Target Name="WriteProjectPath">
-    <Message Text="Writing project path" />
-    <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
-  </Target>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>

--- a/src/OpenRiaServices.EntityFramework/Test/DbContextModel/EFDbContextModels.csproj
+++ b/src/OpenRiaServices.EntityFramework/Test/DbContextModel/EFDbContextModels.csproj
@@ -6,10 +6,6 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <Version>1.0.0.0</Version>
   </PropertyGroup>
-  <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <Message Text="Writing project path" />
-    <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
-  </Target>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
@@ -2,10 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
-  <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <Message Text="Writing project path" />
-    <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
-  </Target>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />

--- a/src/OpenRiaServices.Tools/Test/NotificationMethodGeneratorTest.cs
+++ b/src/OpenRiaServices.Tools/Test/NotificationMethodGeneratorTest.cs
@@ -82,7 +82,7 @@ namespace OpenRiaServices.Tools.Test
                 }
                 snippetstr += snippet.Text;
             }
-            Assert.AreEqual(snippetstr.Replace("\r\n", "").TrimEnd(), XmlReader.Value.Replace("\n", ""));
+            Assert.AreEqual(XmlReader.Value.Replace("\n", ""), snippetstr.Replace("\r\n", "").TrimEnd());
         }
 
         [TestMethod]
@@ -96,7 +96,7 @@ namespace OpenRiaServices.Tools.Test
         {
             NotificationMethodGenerator target = new NotificationMethodGenerator(CreateProxyGenerator(isCSharp));
 
-            Assert.AreEqual(target.OnCreatedMethodInvokeExpression.Method.MethodName, "OnCreated");
+            Assert.AreEqual("OnCreated", target.OnCreatedMethodInvokeExpression.Method.MethodName);
         }
 
         public static IEnumerable<object> OnCreatedMethodInvokeExpressionTestCases
@@ -130,12 +130,12 @@ namespace OpenRiaServices.Tools.Test
                 CodeExpressionStatement actual = target.GetMethodInvokeExpressionStatementFor(baseMethodName);
                 CodeMethodInvokeExpression actualExpression = actual.Expression as CodeMethodInvokeExpression;
 
-                Assert.AreEqual(actualExpression.Method.MethodName, "On" + baseMethodName);
+                Assert.AreEqual("On" + baseMethodName, actualExpression.Method.MethodName);
 
                 for (int idx = 0; idx < parameters.Length; idx++)
                 {
                     string paramName = ((CodeArgumentReferenceExpression)actualExpression.Parameters[idx]).ParameterName;
-                    Assert.AreEqual(paramName, parameters[idx].Name);
+                    Assert.AreEqual(parameters[idx].Name, paramName);
                 }
             }
         }
@@ -257,7 +257,7 @@ namespace OpenRiaServices.Tools.Test
                     if (paramDecl != "")
                     {
                         string[] args = paramDecl.Split(new char[] { ',' });
-                        Assert.AreEqual(args.Length, 2, "Params definition file not in the correct format!");
+                        Assert.AreEqual(2, args.Length, "Params definition file not in the correct format!");
                         CodeParameterDeclarationExpression codeParam = new CodeParameterDeclarationExpression(args[0], args[1]);
                         parameters.Add(codeParam);
                     }

--- a/src/OpenRiaServices.Tools/Test/NotificationMethodGeneratorTest.cs
+++ b/src/OpenRiaServices.Tools/Test/NotificationMethodGeneratorTest.cs
@@ -2,7 +2,6 @@
 using System.CodeDom;
 using System.Collections.Generic;
 using OpenRiaServices.Server;
-using OpenRiaServices.Server.Test.Utilities;
 using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -41,7 +40,7 @@ namespace OpenRiaServices.Tools.Test
         DynamicData(nameof(PartialMethodsSnippetBlockTestCases))]
         public void PartialMethodsSnippetBlockTest(string comments, string baseMethodNames, string parameters)
         {
-            string[] baseMethodNamesArray = baseMethodNames.Split(new char[] { ',' });
+            string[] baseMethodNamesArray = baseMethodNames.Split(',');
 
             PartialMethodsSnippetBlockTest(true, comments, baseMethodNamesArray, parameters);
             PartialMethodsSnippetBlockTest(false, comments, baseMethodNamesArray, parameters);
@@ -108,7 +107,7 @@ namespace OpenRiaServices.Tools.Test
         ]
         public void GetMethodInvokeExpressionStatementForTest(string comments, string baseMethodNames, string parameters)
         {
-            string[] baseMethodNamesArray = baseMethodNames.Split(new char[] { ',' });
+            string[] baseMethodNamesArray = baseMethodNames.Split(',');
 
             GetMethodInvokeExpressionStatementForTest(true, comments, baseMethodNamesArray, parameters);
             GetMethodInvokeExpressionStatementForTest(false, comments, baseMethodNamesArray, parameters);
@@ -128,7 +127,7 @@ namespace OpenRiaServices.Tools.Test
                 target.AddMethodFor(baseMethodName, expressions, comments);
 
                 CodeExpressionStatement actual = target.GetMethodInvokeExpressionStatementFor(baseMethodName);
-                CodeMethodInvokeExpression actualExpression = actual.Expression as CodeMethodInvokeExpression;
+                CodeMethodInvokeExpression actualExpression = (CodeMethodInvokeExpression)actual.Expression;
 
                 Assert.AreEqual("On" + baseMethodName, actualExpression.Method.MethodName);
 
@@ -188,7 +187,7 @@ namespace OpenRiaServices.Tools.Test
             }
             else if (paramDeclArgs != "null")
             {
-                string[] args = paramDeclArgs.Split(new char[] { ',' });
+                string[] args = paramDeclArgs.Split(',');
                 parameterDeclaration = new CodeParameterDeclarationExpression(args[0], args[1]);
             }
 
@@ -251,12 +250,12 @@ namespace OpenRiaServices.Tools.Test
             {
                 parameters = new CodeParameterDeclarationExpressionCollection();
 
-                string[] paramDecls = paramDeclsArgs.Split(new char[] { ';' });
+                string[] paramDecls = paramDeclsArgs.Split(';');
                 foreach (string paramDecl in paramDecls)
                 {
                     if (paramDecl != "")
                     {
-                        string[] args = paramDecl.Split(new char[] { ',' });
+                        string[] args = paramDecl.Split(',');
                         Assert.AreEqual(2, args.Length, "Params definition file not in the correct format!");
                         CodeParameterDeclarationExpression codeParam = new CodeParameterDeclarationExpression(args[0], args[1]);
                         parameters.Add(codeParam);


### PR DESCRIPTION
Line numbers should work in stacktraces for 4.7.2
This makes nuget packages (and applications) slightly smaller