### PR TITLE
Improve Add/Attach performance for large graphs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,7 @@ steps:
     versionEnvVar: Build.BuildNumber
     packDestination: '$(Build.ArtifactStagingDirectory)' 
   continueOnError: true
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+#  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
 - task: CopyFiles@2
   displayName: 'Copy VS Extension: $(build.artifactstagingdirectory)'

--- a/src/OpenRiaServices.Client/Framework/Entity.cs
+++ b/src/OpenRiaServices.Client/Framework/Entity.cs
@@ -250,8 +250,8 @@ namespace OpenRiaServices.Client
                     EntitySet entitySet = this.LastSet;
                     if (entitySet != null)
                     {
-                        bool isInteresting = this._entityState != EntityState.Unmodified
-                            && this._entityState != EntityState.Detached;
+                        bool isInteresting = this._entityState is not EntityState.Unmodified
+                            and not EntityState.Detached;
                         entitySet.TrackAsInteresting(this, isInteresting);
                     }
 
@@ -302,12 +302,9 @@ namespace OpenRiaServices.Client
                 }
             }
 
-            if (this.EntitySet != null)
-            {
-                // when a child has been changed in any way, the parent becomes
-                // interesting
-                this.EntitySet.TrackAsInteresting(this, true);
-            }
+            // when a child has been changed in any way, the parent becomes
+            // interesting
+            this.EntitySet?.TrackAsInteresting(this, true);
         }
 
         /// <summary>
@@ -526,8 +523,7 @@ namespace OpenRiaServices.Client
                 this._isMerging = value;
                 foreach (MetaMember metaMember in MetaType.DataMembers.Where(f => f.IsComplex && !f.IsCollection))
                 {
-                    ComplexObject propertyValue = metaMember.GetValue(this) as ComplexObject;
-                    if (propertyValue != null)
+                    if (metaMember.GetValue(this) is ComplexObject propertyValue)
                     {
                         propertyValue.IsMergingState = this._isMerging;
                     }
@@ -647,10 +643,7 @@ namespace OpenRiaServices.Client
             this._editSession = null;
             this._trackChanges = false;
             UndoAllEntityActions(throwIfSubmitting: true);
-            if (this._validationErrors != null)
-            {
-                this._validationErrors.Clear();
-            }
+            this._validationErrors?.Clear();
             this.EntityConflict = null;
             this.EntitySet = null;
             this._lastSet = null;
@@ -682,8 +675,8 @@ namespace OpenRiaServices.Client
         /// </summary>
         protected void AcceptChanges()
         {
-            if (this.EntityState == EntityState.Unmodified ||
-                this.EntityState == EntityState.Detached)
+            if (this.EntityState is EntityState.Unmodified or
+                EntityState.Detached)
             {
                 // if we're detached or have no changes, noop after
                 // closing any in progress edit session
@@ -696,11 +689,7 @@ namespace OpenRiaServices.Client
             // Accept any child changes. Note, we must accept child changes before setting our own
             // state to Unmodified. This avoids a situation where we get notifications from child
             // entities that cause our state to flip back to Modified.
-            if (entitySet != null)
-            {
-                // accept any child changes
-                entitySet.EntityContainer.CompleteChildChanges(this, true);
-            }
+            entitySet?.EntityContainer.CompleteChildChanges(this, true);
 
             if (this.EntityState == EntityState.New)
             {
@@ -730,19 +719,13 @@ namespace OpenRiaServices.Client
             else if (this.EntityState == EntityState.Deleted)
             {
                 this.StopTracking();
-                if (entitySet != null)
-                {
-                    entitySet.RemoveFromCache(this);
-                }
+                entitySet?.RemoveFromCache(this);
                 // move back to the default state
                 this.EntityState = EntityState.Detached;
             }
 
-            if (entitySet != null)
-            {
-                // remove from the interesting entities set
-                entitySet.TrackAsInteresting(this, false);
-            }
+            // remove from the interesting entities set
+            entitySet?.TrackAsInteresting(this, false);
 
             // need to end any in progress edit session
             this._editSession = null;
@@ -750,10 +733,7 @@ namespace OpenRiaServices.Client
             // clear all custom method invocations
             this.UndoAllEntityActions(throwIfSubmitting: false);
 
-            if (this._validationErrors != null)
-            {
-                this._validationErrors.Clear();
-            }
+            this._validationErrors?.Clear();
             this.EntityConflict = null;
             this.IsInferred = false;
             this._hasChildChanges = false;
@@ -769,8 +749,8 @@ namespace OpenRiaServices.Client
         /// </summary>
         protected void RejectChanges()
         {
-            if (this.EntityState == EntityState.Unmodified ||
-                this.EntityState == EntityState.Detached)
+            if (this.EntityState is EntityState.Unmodified or
+                EntityState.Detached)
             {
                 // if we're detached or have no changes, noop after
                 // closing any in progress edit session
@@ -783,10 +763,7 @@ namespace OpenRiaServices.Client
             // Reject any child changes. Note, we must reject child changes before setting our own
             // state to Unmodified. This avoids a situation where we get notifications from child
             // entities that cause our state to flip back to Modified.
-            if (entitySet != null)
-            {
-                entitySet.EntityContainer.CompleteChildChanges(this, false);
-            }
+            entitySet?.EntityContainer.CompleteChildChanges(this, false);
 
             if (this._entityState == EntityState.Modified || this.Parent != null)
             {
@@ -830,10 +807,7 @@ namespace OpenRiaServices.Client
             UndoAllEntityActions();
 
             // Empty out the error collections
-            if (this._validationErrors != null)
-            {
-                this._validationErrors.Clear();
-            }
+            this._validationErrors?.Clear();
             this.EntityConflict = null;
             this._hasChildChanges = false;
             Debug.Assert(!this.HasChanges, "Entity.HasChanges should be false");
@@ -1845,7 +1819,7 @@ namespace OpenRiaServices.Client
             {
                 this._entity = entity;
                 this._lastState = entity.EntityState;
-                this._customMethodInvocations = entity._customMethodInvocations != null ? entity._customMethodInvocations.ToArray() : null;
+                this._customMethodInvocations = entity._customMethodInvocations?.ToArray();
                 this._validationErrors = entity.ValidationErrors.ToArray();
                 this._modifiedProperties = new List<string>();
             }

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -27,8 +27,8 @@ namespace OpenRiaServices.Client
         // backing entity list
         private IList _list;
         // set of entities, for fast lookup
-        private HashSet<Entity> _set;
-        private Dictionary<object, Entity> _identityCache = new();
+        private readonly HashSet<Entity> _set = new();
+        private readonly Dictionary<object, Entity> _identityCache = new();
         private readonly HashSet<Entity> _interestingEntities = new();
         private NotifyCollectionChangedEventHandler _collectionChangedEventHandler;
 
@@ -115,10 +115,10 @@ namespace OpenRiaServices.Client
                 entity.Reset();
             }
 
-            this._identityCache = new Dictionary<object, Entity>();
+            this._identityCache.Clear();
             this._interestingEntities.Clear();
             this._list = this.CreateList();
-            this._set = new HashSet<Entity>();
+            this._set.Clear();
 
             this.OnCollectionChanged(NotifyCollectionChangedAction.Reset, clearedEntities, -1);
 
@@ -265,7 +265,6 @@ namespace OpenRiaServices.Client
             this._supportedOperations = operationsToSupport;
 
             this._list = this.CreateList();
-            this._set = new HashSet<Entity>();
         }
 
         /// <summary>
@@ -484,7 +483,7 @@ namespace OpenRiaServices.Client
 
         internal bool Contains(Entity entity)
         {
-            return this._set != null && this._set.Contains(entity);
+            return this._set.Contains(entity);
         }
 
         /// <summary>

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -1063,11 +1063,23 @@ namespace OpenRiaServices.Client
                 }
 
                 EntitySet set = this._container.GetEntitySet(entity.GetType());
-                if (!this._isTopLevel && !set.IsAttached(entity))
+                if (!this._isTopLevel)
+                {
+                    if (!set.IsAttached(entity))
                 {
                     // infer for all detached entities except the root
                     entity.IsInferred = true;
                     this._action(set, entity);
+                }
+                    else
+                    {
+                        // Entity is attached so state must anything but Detached: New, Unmodified, Modified, Deleted
+                        // * For New, Unchanged, Modified then all changes to EntityRef/EntityCollections are tracked and corresponding entities are
+                        // added directly to the EntitySet, so any changes there will have been previously processed
+                        // * Deleted => Are not tracked (just as for Detached handled above) so they might point to new entities to discover
+                        if (entity.EntityState != EntityState.Deleted)
+                            return;
+                    }
                 }
 
                 this._visited.Add(entity, true);

--- a/src/OpenRiaServices.Client/Framework/Internal/MetaType.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MetaType.cs
@@ -31,6 +31,7 @@ namespace OpenRiaServices.Client.Internal
         private readonly ReadOnlyCollection<MetaMember> _dataMembers;
         private readonly ReadOnlyCollection<ValidationAttribute> _validationAttributes;
         private readonly Dictionary<string, EntityActionAttribute> _customUpdateMethods;
+        private readonly MetaMember[] _associationMembers;
 
         /// <summary>
         /// Returns the MetaType for the specified Type.
@@ -115,6 +116,7 @@ namespace OpenRiaServices.Client.Internal
             // for identity purposes, we need to make sure values are always ordered
             KeyMembers = new ReadOnlyCollection<MetaMember>(_metaMembers.Values.Where(m => m.IsKeyMember).OrderBy(m => m.Name).ToArray());
             _dataMembers = new ReadOnlyCollection<MetaMember>(_metaMembers.Values.Where(m => m.IsDataMember).ToArray());
+            _associationMembers = _metaMembers.Values.Where(m => m.IsAssociationMember).ToArray();
 
             if (!_requiresValidation && HasComplexMembers)
             {
@@ -219,13 +221,7 @@ namespace OpenRiaServices.Client.Internal
         /// <summary>
         /// Gets the collection of association members for this entity Type.
         /// </summary>
-        public IEnumerable<MetaMember> AssociationMembers
-        {
-            get
-            {
-                return this._metaMembers.Values.Where(m => m.IsAssociationMember);
-            }
-        }
+        public IEnumerable<MetaMember> AssociationMembers => _associationMembers;
 
         /// <summary>
         /// Gets the collection of child types this entity Type composes.

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityContainerTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityContainerTests.cs
@@ -3832,6 +3832,49 @@ namespace OpenRiaServices.Client.Test
             Assert.IsTrue(ec.GetChanges().IsEmpty);
         }
 
+
+        [TestMethod]
+        public void EntitySet_Remove_InfferedEntities()
+        {
+            TestEntityContainer ec = new TestEntityContainer();
+            EntitySet<Product> products = ec.GetEntitySet<Product>();
+
+            // attach a product
+            Product product = new Product
+            {
+                ProductID = 1,
+                Name = "Choco Crisp",
+            };
+            // EntityCollection
+            var order = new PurchaseOrder { PurchaseOrderID = 1 };
+            var detail1 = new PurchaseOrderDetail() { PurchaseOrder = order, PurchaseOrderID = 1, PurchaseOrderDetailID = 1 };
+            product.PurchaseOrderDetails.Add(detail1);
+            products.Attach(product);
+
+            // Delete the entity, it should be marked for deletion
+            products.Remove(product);
+            Assert.AreEqual(EntityState.Deleted, product.EntityState);
+            Assert.AreEqual(EntityState.Unmodified, product.PurchaseOrderDetails.First().EntityState);
+            Assert.AreEqual(EntityState.Unmodified, product.PurchaseOrderDetails.First().PurchaseOrder.EntityState);
+
+            var detail2 = new PurchaseOrderDetail() { PurchaseOrderDetailID = 2, Product = product, PurchaseOrderID = order.PurchaseOrderID };
+            var detail3 = new PurchaseOrderDetail() { PurchaseOrderDetailID = 3, Product = product, PurchaseOrderID = order.PurchaseOrderID };
+
+            product.PurchaseOrderDetails.Add(detail2);
+            product.PurchaseOrderDetails.Add(detail3);
+
+            Assert.AreEqual(EntityState.Detached, detail2.EntityState);
+            Assert.AreEqual(EntityState.Detached, detail3.EntityState);
+            Assert.AreEqual(EntityState.Deleted, product.EntityState);
+
+            // Add detail2 , which should trigger detail3 to be discovered
+            order.PurchaseOrderDetails.Add(detail2);
+
+            Assert.AreEqual(EntityState.New, detail2.EntityState);
+            Assert.AreEqual(EntityState.New, detail3.EntityState);
+            Assert.AreEqual(EntityState.Deleted, product.EntityState);
+        }
+
         [TestMethod]
         public void EntitySet_CollectionChangedEvents()
         {

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityContainerTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityContainerTests.cs
@@ -3834,7 +3834,7 @@ namespace OpenRiaServices.Client.Test
 
 
         [TestMethod]
-        public void EntitySet_Remove_InfferedEntities()
+        public void EntitySet_Remove_Inferred_Entities()
         {
             TestEntityContainer ec = new TestEntityContainer();
             EntitySet<Product> products = ec.GetEntitySet<Product>();
@@ -3854,8 +3854,8 @@ namespace OpenRiaServices.Client.Test
             // Delete the entity, it should be marked for deletion
             products.Remove(product);
             Assert.AreEqual(EntityState.Deleted, product.EntityState);
-            Assert.AreEqual(EntityState.Unmodified, product.PurchaseOrderDetails.First().EntityState);
-            Assert.AreEqual(EntityState.Unmodified, product.PurchaseOrderDetails.First().PurchaseOrder.EntityState);
+            Assert.AreEqual(EntityState.Unmodified, detail1.EntityState);
+            Assert.AreEqual(EntityState.Unmodified, order.EntityState);
 
             var detail2 = new PurchaseOrderDetail() { PurchaseOrderDetailID = 2, Product = product, PurchaseOrderID = order.PurchaseOrderID };
             var detail3 = new PurchaseOrderDetail() { PurchaseOrderDetailID = 3, Product = product, PurchaseOrderID = order.PurchaseOrderID };
@@ -3863,16 +3863,16 @@ namespace OpenRiaServices.Client.Test
             product.PurchaseOrderDetails.Add(detail2);
             product.PurchaseOrderDetails.Add(detail3);
 
+            Assert.AreEqual(EntityState.Deleted, product.EntityState);
             Assert.AreEqual(EntityState.Detached, detail2.EntityState);
             Assert.AreEqual(EntityState.Detached, detail3.EntityState);
-            Assert.AreEqual(EntityState.Deleted, product.EntityState);
 
-            // Add detail2 , which should trigger detail3 to be discovered
+            // Add detail2, which should trigger detail3 to be discovered via product (which should still be deleted)
             order.PurchaseOrderDetails.Add(detail2);
 
+            Assert.AreEqual(EntityState.Deleted, product.EntityState);
             Assert.AreEqual(EntityState.New, detail2.EntityState);
             Assert.AreEqual(EntityState.New, detail3.EntityState);
-            Assert.AreEqual(EntityState.Deleted, product.EntityState);
         }
 
         [TestMethod]


### PR DESCRIPTION
Makes adding n entities to an EntityCollection or similar roughly O(n) instead of O(n²)


Commit 1-2 are based on perf data from https://github.com/OpenRIAServices/OpenRiaServices/discussions/450

Commit 3 is mostly code cleanup, with some minor perf improvements

The performance for adding 20 000 entities to an EntityCollection is improved by more than 100x (just for commit 2)

Commit 2 performance difference:
| | With only commit 1 & 3 |  With commit 1,2,3 | diff |
|-|-|-| -|
|time | 35s| 314ms| >111 times better | 
| allocated | 18 624 MB | 85 MB| > 200 times better |