### PR TITLE
Collection performance improvements

### DIFF
--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/SystemServiceModel.Dispatcher/QueryStringConverter.cs
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/SystemServiceModel.Dispatcher/QueryStringConverter.cs
@@ -159,9 +159,9 @@ namespace System.ServiceModel.Dispatcher
         [SuppressMessage("Reliability", "Reliability104:CaughtAndHandledExceptionsRule", Justification = "The exception is traced in the finally clause")]
         TypeConverter GetStringConverter(Type parameterType)
         {
-            if (this._typeConverterCache.ContainsKey(parameterType))
+            if (this._typeConverterCache.TryGetValue(parameterType, out TypeConverter typeConverter))
             {
-                return (TypeConverter)this._typeConverterCache[parameterType];
+                return typeConverter;
             }
             TypeConverterAttribute[] typeConverterAttrs = parameterType.GetCustomAttributes(typeof(TypeConverterAttribute), true) as TypeConverterAttribute[];
             if (typeConverterAttrs != null)

--- a/src/OpenRiaServices.Client/Framework/ChangeSetBuilder.cs
+++ b/src/OpenRiaServices.Client/Framework/ChangeSetBuilder.cs
@@ -149,7 +149,7 @@ namespace OpenRiaServices.Client
         /// </summary>
         internal class UnmodifiedOperationAdder : EntityVisitor
         {
-            private readonly Dictionary<object, bool> _visited = new Dictionary<object, bool>();
+            private readonly HashSet<object> _visited = new HashSet<object>();
             private readonly List<ChangeSetEntry> _changeSetEntries;
             private int _id;
             private bool _isChild;
@@ -180,7 +180,7 @@ namespace OpenRiaServices.Client
 
             public override void Visit(Entity entity)
             {
-                if (this._visited.ContainsKey(entity))
+                if (!this._visited.Add(entity))
                 {
                     return;
                 }
@@ -191,8 +191,6 @@ namespace OpenRiaServices.Client
                     ChangeSetEntry op = new ChangeSetEntry(entity, this._id++, EntityOperationType.None);
                     this._changeSetEntries.Add(op);
                 }
-
-                this._visited.Add(entity, true);
 
                 base.Visit(entity);
             }

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -259,7 +259,7 @@ namespace OpenRiaServices.Client
 
                 // we may have to check for containment once more, since the EntitySet.Add calls
                 // above can cause a dynamic add to this EntityCollection behind the scenes
-                if (!addedToSet && TryAddEntity(entity))
+                if (TryAddEntity(entity) || addedToSet)
                 {
                     this.RaiseCollectionChangedNotification(NotifyCollectionChangedAction.Add, entity, this.Entities.Count - 1);
                 }

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -259,9 +259,8 @@ namespace OpenRiaServices.Client
 
                 // we may have to check for containment once more, since the EntitySet.Add calls
                 // above can cause a dynamic add to this EntityCollection behind the scenes
-                if (!addedToSet || !this.EntitiesHashSet.Contains(entity))
+                if (!addedToSet && TryAddEntity(entity))
                 {
-                    this.AddEntity(entity);
                     this.RaiseCollectionChangedNotification(NotifyCollectionChangedAction.Add, entity, this.Entities.Count - 1);
                 }
 
@@ -350,28 +349,34 @@ namespace OpenRiaServices.Client
         /// should be done through this method.
         /// </summary>
         /// <param name="entity">The <see cref="Entity"/>to add.</param>
-        private void AddEntity(TEntity entity)
+        private bool TryAddEntity(TEntity entity)
         {
-            Debug.Assert(!this.EntitiesHashSet.Contains(entity), "Entity is already in this collection!");
-
-            this.Entities.Add(entity);
-            this.EntitiesHashSet.Add(entity);
-
-            if (this.IsComposition)
+            if (this.EntitiesHashSet.Add(entity))
             {
-                entity.SetParent(this._parent, this.AssocAttribute);
+                this.Entities.Add(entity);
+
+                if (this.IsComposition)
+                {
+                    entity.SetParent(this._parent, this.AssocAttribute);
+                }
+
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
 
         private bool RemoveEntity(TEntity entity)
         {
-            var isRemoved = this.Entities.Remove(entity);
-            var isRemovedInHashSet = this.EntitiesHashSet.Remove(entity);
-            Debug.Assert(isRemoved == isRemovedInHashSet
-                , "The entity should be present in both Entities and EntitiesHashSet"
-                , "Entities.Removed: {0}, EntitiesHashSet.Removed: {1}", isRemoved, isRemovedInHashSet
-            );
-            return isRemoved;
+            if (this.EntitiesHashSet.Remove(entity))
+            {
+                bool isRemoved = this.Entities.Remove(entity);
+                Debug.Assert(isRemoved, "The entity should be present in both Entities and EntitiesHashSet");
+                return true;
+            }
+            return false;
         }
 
         /// <summary>
@@ -431,10 +436,7 @@ namespace OpenRiaServices.Client
             EntitySet set = this._parent.EntitySet.EntityContainer.GetEntitySet(typeof(TEntity));
             foreach (TEntity entity in set.OfType<TEntity>().Where(this.Filter))
             {
-                if (!this.EntitiesHashSet.Contains(entity))
-                {
-                    this.AddEntity(entity);
-                }
+                this.TryAddEntity(entity);
             }
 
             // once we've loaded entities, we're caching them, so we need to update
@@ -618,7 +620,7 @@ namespace OpenRiaServices.Client
                 {
                     // Add matching entity to our set. When adding, we use the stronger Filter to
                     // filter out New entities
-                    this.AddEntity(typedEntity);
+                    _ = this.TryAddEntity(typedEntity);
                     this.RaiseCollectionChangedNotification(NotifyCollectionChangedAction.Add, typedEntity, this.Entities.Count - 1);
                 }
                 else if (containsEntity && !this._entityPredicate(typedEntity))
@@ -653,9 +655,8 @@ namespace OpenRiaServices.Client
                     foreach (TEntity newEntity in newEntities)
                     {
                         newStartingIdx = this.Entities.Count;
-                        if (!this.EntitiesHashSet.Contains(newEntity))
+                        if (this.TryAddEntity(newEntity))
                         {
-                            this.AddEntity(newEntity);
                             affectedEntities.Add(newEntity);
                         }
                     }
@@ -1029,9 +1030,9 @@ namespace OpenRiaServices.Client
         }
         bool ICollection<TEntity>.Remove(TEntity item)
         {
-            int idx = Entities.IndexOf(item);
+            bool removed = this.EntitiesHashSet.Contains(item);
             Remove(item);
-            return idx != -1;
+            return removed;
         }
         /// <summary>
         /// Removes all items.

--- a/src/OpenRiaServices.Client/Framework/EntityContainer.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityContainer.cs
@@ -93,7 +93,8 @@ namespace OpenRiaServices.Client
             }
 
             Type entityType = entitySet.EntityType;
-            if (this._entitySets.ContainsKey(entityType) || this._referencedEntitySets.ContainsKey(entityType))
+            if (this._entitySets.ContainsKey(entityType) 
+                || !this._referencedEntitySets.TryAdd(entityType, entitySet))
             {
                 throw new ArgumentException(
                     string.Format(
@@ -101,8 +102,6 @@ namespace OpenRiaServices.Client
                         Resource.EntityContainer_EntitySetAlreadyExists,
                         entityType));
             }
-
-            this._referencedEntitySets.Add(entityType, entitySet);
         }
 
         /// <summary>

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -1425,12 +1425,10 @@ namespace OpenRiaServices.Client
 
                 int countBefore = this.Source.Count;
                 this.Source.Add(entity);
-                int countAfter = this.Source.Count;
 
-                if (this.Source.Count == countBefore + 1)
-                    return countBefore;
-                else 
-                    return ((List<T>)this.Source.List).IndexOf(entity, countBefore);
+                return this.Source.Count == countBefore + 1 
+                    ? countBefore
+                    : ((List<T>)this.Source.List).IndexOf(entity, countBefore);
             }
 
             public void Clear()

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -1427,8 +1427,10 @@ namespace OpenRiaServices.Client
                 this.Source.Add(entity);
                 int countAfter = this.Source.Count;
 
-                // If count increased then the item was added last, otherwise return -1 for "not added"
-                return (countAfter > countBefore) ? countBefore : -1;
+                if (this.Source.Count == countBefore + 1)
+                    return countBefore;
+                else 
+                    return ((List<T>)this.Source.List).IndexOf(entity, countBefore);
             }
 
             public void Clear()

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -730,7 +730,7 @@ namespace OpenRiaServices.Client
             if (cachedEntity == null)
             {
                 // add the entity to the cache
-                this.AddToCache(entity);
+                this._identityCache.Add(identity, entity);
                 cachedEntity = entity;
 
                 int idx = 0;

--- a/src/OpenRiaServices.Client/Framework/ObjectStateUtility.cs
+++ b/src/OpenRiaServices.Client/Framework/ObjectStateUtility.cs
@@ -28,13 +28,9 @@ namespace OpenRiaServices.Client
             MetaType metaType = MetaType.GetMetaType(o.GetType());
             Dictionary<string, object> extractedState = new Dictionary<string, object>();
 
-            if (visited.Contains(o))
+            if (!visited.Add(o))
             {
                 throw new InvalidOperationException(Resource.CyclicReferenceError);
-            }
-            else
-            {
-                visited.Add(o);
             }
 
             foreach (MetaMember metaMember in metaType.DataMembers)

--- a/src/OpenRiaServices.Client/Framework/Polyfills.cs
+++ b/src/OpenRiaServices.Client/Framework/Polyfills.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿#if !NET
+using System;
 
 namespace System.Collections.Generic
 {
-#if !NET
     /// <summary>
     /// Helper methods to allow "newer" .NET methods on older frameworks
     /// </summary>
@@ -24,5 +24,5 @@ namespace System.Collections.Generic
             }
         }
     }
-#endif
 }
+#endif

--- a/src/OpenRiaServices.Client/Framework/Polyfills.cs
+++ b/src/OpenRiaServices.Client/Framework/Polyfills.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 
-namespace OpenRiaServices.Client
+namespace System.Collections.Generic
 {
 #if !NET
     /// <summary>

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.cs
@@ -50,6 +50,28 @@ namespace OpenRiaServices.Client.Test
         }
 
         [TestMethod]
+        [Description("Tests that ListCollectionViewProxy returns correct index")]
+        public void ICVF_ListCollectionViewProxy_Add()
+        {
+            EntitySet<City> entitySet;
+            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
+            EntityCollection<City>.ListCollectionViewProxy<City> collection = new(entityCollection);
+
+            for (int i=0; i < 3; ++i)
+            {
+                var city = new City() {  ZoneID = i };
+
+                Assert.IsFalse(collection.Contains(city));
+                int idx = collection.Add(city);
+
+                Assert.AreEqual(i, idx);
+                Assert.AreSame(city, collection[idx]);
+                Assert.IsTrue(collection.Contains(city));
+                Assert.IsTrue(entityCollection.Contains(city));
+            }
+        }
+
+        [TestMethod]
         [Description("Tests that calling AddNew on the View adds to the EntityCollection and EntitySet and CancelNew removes both.")]
         public void ICVF_CancelNew()
         {

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Linq/DynamicQueryable.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Linq/DynamicQueryable.cs
@@ -359,9 +359,8 @@ namespace System.Linq.Dynamic
 
         void AddSymbol(string name, object value)
         {
-            if (symbols.ContainsKey(name))
+            if (!symbols.TryAdd(name, value))
                 throw ParseError(Resource.DuplicateIdentifier, name);
-            symbols.Add(name, value);
         }
 
         public Expression Parse(Type resultType)

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/ChangeSetProcessor.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/ChangeSetProcessor.cs
@@ -208,11 +208,10 @@ namespace OpenRiaServices.Hosting.Wcf
 #pragma warning restore CS0618 // Type or member is obsolete
                 foreach (ChangeSetEntry changeSetEntry in entityGroup)
                 {
-                    if (visited.Contains(changeSetEntry.Id))
+                    if (!visited.Add(changeSetEntry.Id))
                     {
                         continue;
                     }
-                    visited.Add(changeSetEntry.Id);
 
                     // set current associations
                     if (changeSetEntry.Associations != null)

--- a/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
@@ -458,25 +458,22 @@ namespace OpenRiaServices.Server
                 // first get any current child operations
                 List<ChangeSetEntry> associatedChangesList = new List<ChangeSetEntry>();
                 ChangeSetEntry changeSetEntry = this._changeSetEntries.Single(p => p.Entity == entity);
-                if (changeSetEntry.Associations != null)
+
+                if (changeSetEntry.Associations != null
+                    && changeSetEntry.Associations.TryGetValue(compositionMember.Name, out int[] associatedIds))
                 {
-                    if (changeSetEntry.Associations.TryGetValue(compositionMember.Name, out int[] associatedIds))
-                    {
-                        IEnumerable<ChangeSetEntry> childOperations = associatedIds.Select(p => entityOperationMap[p]);
-                        associatedChangesList.AddRange(childOperations);
-                    }
+                    IEnumerable<ChangeSetEntry> childOperations = associatedIds.Select(p => entityOperationMap[p]);
+                    associatedChangesList.AddRange(childOperations);
                 }
 
                 // next get any child delete operations
-                if (changeSetEntry.OriginalAssociations != null)
+                if (changeSetEntry.OriginalAssociations != null
+                    && changeSetEntry.OriginalAssociations.TryGetValue(compositionMember.Name, out int[] originalAssociatedIds))
                 {
-                    if (changeSetEntry.OriginalAssociations.TryGetValue(compositionMember.Name, out int[] originalAssociatedIds))
-                    {
-                        IEnumerable<ChangeSetEntry> deletedChildOperations = originalAssociatedIds
-                            .Select(p => entityOperationMap[p])
-                            .Where(p => p.Operation == DomainOperation.Delete);
-                        associatedChangesList.AddRange(deletedChildOperations);
-                    }
+                    IEnumerable<ChangeSetEntry> deletedChildOperations = originalAssociatedIds
+                        .Select(p => entityOperationMap[p])
+                        .Where(p => p.Operation == DomainOperation.Delete);
+                    associatedChangesList.AddRange(deletedChildOperations);
                 }
 
                 associatedChanges[compositionMember] = associatedChangesList;
@@ -515,21 +512,17 @@ namespace OpenRiaServices.Server
 
                         // add any current associations
                         List<int> childIds = new List<int>();
-                        if (operation.Associations != null)
+                        if (operation.Associations != null 
+                            && operation.Associations.TryGetValue(compositionMember.Name, out int[] associatedIds))
                         {
-                            if (operation.Associations.TryGetValue(compositionMember.Name, out int[] associatedIds))
-                            {
-                                childIds.AddRange(associatedIds);
-                            }
+                            childIds.AddRange(associatedIds);
                         }
 
                         // add any original associations
-                        if (operation.OriginalAssociations != null)
+                        if (operation.OriginalAssociations != null
+                            && operation.OriginalAssociations.TryGetValue(compositionMember.Name, out int[] associatedIds))
                         {
-                            if (operation.OriginalAssociations.TryGetValue(compositionMember.Name, out int[] associatedIds))
-                            {
-                                childIds.AddRange(associatedIds);
-                            }
+                            childIds.AddRange(associatedIds);
                         }
 
                         // foreach identified child operation, set the parent

--- a/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
@@ -520,7 +520,7 @@ namespace OpenRiaServices.Server
 
                         // add any original associations
                         if (operation.OriginalAssociations != null
-                            && operation.OriginalAssociations.TryGetValue(compositionMember.Name, out int[] associatedIds))
+                            && operation.OriginalAssociations.TryGetValue(compositionMember.Name, out associatedIds))
                         {
                             childIds.AddRange(associatedIds);
                         }

--- a/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
@@ -68,7 +68,7 @@ namespace OpenRiaServices.Server
             this._changeSetEntries = changeSetEntries;
             if (requiresOrdering)
             {
-                this._changeSetEntries = this.OrderChangeset(changeSetEntries);
+                this._changeSetEntries = OrderChangeset(changeSetEntries);
             }
         }
 
@@ -90,21 +90,19 @@ namespace OpenRiaServices.Server
                 }
 
                 // ensure unique client IDs
-                if (idSet.Contains(entry.Id))
+                if (!idSet.Add(entry.Id))
                 {
                     throw new InvalidOperationException(
                         string.Format(CultureInfo.CurrentCulture, Resource.InvalidChangeSet, Resource.InvalidChangeSet_DuplicateId));
                 }
-                idSet.Add(entry.Id);
 
                 // ensure unique entity instances - there can only be a single entry
                 // for a given entity instance
-                if (entitySet.Contains(entry.Entity))
+                if (!entitySet.Add(entry.Entity))
                 {
                     throw new InvalidOperationException(
                         string.Format(CultureInfo.CurrentCulture, Resource.InvalidChangeSet, Resource.InvalidChangeSet_DuplicateEntity));
                 }
-                entitySet.Add(entry.Entity);
 
                 // entities must be of the same type
                 if (entry.OriginalEntity != null && !(entry.Entity.GetType() == entry.OriginalEntity.GetType()))
@@ -498,7 +496,7 @@ namespace OpenRiaServices.Server
         /// </summary>
         /// <param name="changeSetEntries">The changeset operations to order.</param>
         /// <returns>The ordered operations.</returns>
-        private IEnumerable<ChangeSetEntry> OrderChangeset(IEnumerable<ChangeSetEntry> changeSetEntries)
+        private static IEnumerable<ChangeSetEntry> OrderChangeset(IEnumerable<ChangeSetEntry> changeSetEntries)
         {
             Dictionary<int, ChangeSetEntry> cudOpIdMap = changeSetEntries.ToDictionary(p => p.Id);
             Dictionary<ChangeSetEntry, List<ChangeSetEntry>> operationChildMap = new Dictionary<ChangeSetEntry, List<ChangeSetEntry>>();
@@ -582,7 +580,7 @@ namespace OpenRiaServices.Server
             IEnumerable<ChangeSetEntry> rootOperations = changeSetEntries.Where(p => p.ParentOperation == null);
             foreach (ChangeSetEntry operation in rootOperations)
             {
-                this.OrderOperations(operation, operationChildMap, orderedOperations);
+                OrderOperations(operation, operationChildMap, orderedOperations);
             }
 
             // now add any remaining operations
@@ -596,7 +594,7 @@ namespace OpenRiaServices.Server
         /// <param name="operation">The operation to order.</param>
         /// <param name="operationChildMap">Map of operation to child operations.</param>
         /// <param name="orderedOperations">The list of ordered operations.</param>
-        private void OrderOperations(ChangeSetEntry operation, Dictionary<ChangeSetEntry, List<ChangeSetEntry>> operationChildMap, List<ChangeSetEntry> orderedOperations)
+        private static void OrderOperations(ChangeSetEntry operation, Dictionary<ChangeSetEntry, List<ChangeSetEntry>> operationChildMap, List<ChangeSetEntry> orderedOperations)
         {
             // first add the operation
             orderedOperations.Add(operation);
@@ -609,7 +607,7 @@ namespace OpenRiaServices.Server
             }
             foreach (ChangeSetEntry childOperation in childOps)
             {
-                this.OrderOperations(childOperation, operationChildMap, orderedOperations);
+                OrderOperations(childOperation, operationChildMap, orderedOperations);
             }
         }
 

--- a/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
@@ -460,9 +460,8 @@ namespace OpenRiaServices.Server
                 ChangeSetEntry changeSetEntry = this._changeSetEntries.Single(p => p.Entity == entity);
                 if (changeSetEntry.Associations != null)
                 {
-                    if (changeSetEntry.Associations.ContainsKey(compositionMember.Name))
+                    if (changeSetEntry.Associations.TryGetValue(compositionMember.Name, out int[] associatedIds))
                     {
-                        int[] associatedIds = changeSetEntry.Associations[compositionMember.Name];
                         IEnumerable<ChangeSetEntry> childOperations = associatedIds.Select(p => entityOperationMap[p]);
                         associatedChangesList.AddRange(childOperations);
                     }
@@ -471,9 +470,8 @@ namespace OpenRiaServices.Server
                 // next get any child delete operations
                 if (changeSetEntry.OriginalAssociations != null)
                 {
-                    if (changeSetEntry.OriginalAssociations.ContainsKey(compositionMember.Name))
+                    if (changeSetEntry.OriginalAssociations.TryGetValue(compositionMember.Name, out int[] originalAssociatedIds))
                     {
-                        int[] originalAssociatedIds = changeSetEntry.OriginalAssociations[compositionMember.Name];
                         IEnumerable<ChangeSetEntry> deletedChildOperations = originalAssociatedIds
                             .Select(p => entityOperationMap[p])
                             .Where(p => p.Operation == DomainOperation.Delete);
@@ -519,18 +517,18 @@ namespace OpenRiaServices.Server
                         List<int> childIds = new List<int>();
                         if (operation.Associations != null)
                         {
-                            if (operation.Associations.ContainsKey(compositionMember.Name))
+                            if (operation.Associations.TryGetValue(compositionMember.Name, out int[] associatedIds))
                             {
-                                childIds.AddRange(operation.Associations[compositionMember.Name]);
+                                childIds.AddRange(associatedIds);
                             }
                         }
 
                         // add any original associations
                         if (operation.OriginalAssociations != null)
                         {
-                            if (operation.OriginalAssociations.ContainsKey(compositionMember.Name))
+                            if (operation.OriginalAssociations.TryGetValue(compositionMember.Name, out int[] associatedIds))
                             {
-                                childIds.AddRange(operation.OriginalAssociations[compositionMember.Name]);
+                                childIds.AddRange(associatedIds);
                             }
                         }
 

--- a/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescription.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescription.cs
@@ -1619,12 +1619,10 @@ namespace OpenRiaServices.Server
                 this._submitMethods[entityType] = entitySubmitMethods;
             }
 
-            if (entitySubmitMethods.ContainsKey(method.Operation))
+            if (!entitySubmitMethods.TryAdd(method.Operation, method))
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.DomainService_DuplicateCUDMethod, methodName, entitySubmitMethods[method.Operation].Name));
             }
-
-            entitySubmitMethods[method.Operation] = method;
         }
 
         /// <summary>
@@ -1879,11 +1877,11 @@ namespace OpenRiaServices.Server
                 entityCustomMethods = new Dictionary<string, DomainOperationEntry>();
                 this._customMethods[entityType] = entityCustomMethods;
             }
-            else if (entityCustomMethods.ContainsKey(methodName))
+
+            if (!entityCustomMethods.TryAdd(methodName, method))
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.DomainOperationEntryOverload_NotSupported, methodName));
             }
-            entityCustomMethods[methodName] = method;
         }
 
         /// <summary>
@@ -1896,12 +1894,10 @@ namespace OpenRiaServices.Server
             ValidateMethodSignature(this, method);
 
             string methodName = method.Name;
-            if (this._invokeOperations.ContainsKey(methodName))
+            if (!this._invokeOperations.TryAdd(methodName, method))
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.DomainOperationEntryOverload_NotSupported, methodName));
             }
-
-            this._invokeOperations[methodName] = method;
         }
 
         /// <summary>

--- a/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescription.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescription.cs
@@ -1311,12 +1311,10 @@ namespace OpenRiaServices.Server
             // If we have already visited this entity type, its composition map
             // entry is accurate and can be used as is.
             this._compositionMap.TryGetValue(entityType, out parentAssociations);
-            if (fixedEntities.Contains(entityType))
+            if (!fixedEntities.Add(entityType))
             {
                 return parentAssociations;
             }
-
-            fixedEntities.Add(entityType);
 
             // Get the base class's associations.  This will re-entrantly walk back
             // the hierarchy and repair the composition map as it goes.
@@ -1995,11 +1993,10 @@ namespace OpenRiaServices.Server
             }
 
             // Avoid infinite recursion in the case of composition cycles
-            if (visited.Contains(entityType))
+            if (!visited.Add(entityType))
             {
                 return false;
             }
-            visited.Add(entityType);
 
             // for compositional children, if the parent supports the operation (or supports
             // Update) the operation is supported.

--- a/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
@@ -127,13 +127,9 @@ namespace OpenRiaServices.Server
                 {
                     currentType = attribute.MetadataClassType;
                     // If we find a cyclic reference, throw an error. 
-                    if (metadataTypeReferences.Contains(currentType))
+                    if (!metadataTypeReferences.Add(currentType))
                     {
                         throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resource.CyclicMetadataTypeAttributesFound, type.FullName));
-                    }
-                    else
-                    {
-                        metadataTypeReferences.Add(currentType);
                     }
                 }
             }

--- a/src/OpenRiaServices.Server/Framework/OpenRiaServices.Server.csproj
+++ b/src/OpenRiaServices.Server/Framework/OpenRiaServices.Server.csproj
@@ -31,6 +31,7 @@
     <Compile Include="..\..\OpenRiaServices.Client\Framework\DomainException.cs" Link="Data\DomainException.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\DomainIdentifierAttribute.cs" Link="Data\DomainIdentifierAttribute.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\ExternalReferenceAttribute.cs" Link="Data\ExternalAttribute.cs" />
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Data\Polyfills.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\RoundtripOriginalAttribute.cs" Link="Data\RoundtripOriginalAttribute.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\Serialization\KeyValue.cs" Link="Data\Serialization\KeyValue.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\TypeUtility.cs" Link="Data\TypeUtility.cs" />

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/DomainContextGenerator.partial.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/DomainContextGenerator.partial.cs
@@ -120,10 +120,8 @@ namespace OpenRiaServices.Tools.TextTemplate
                 this._queryMethods.Add(domainOperationEntry);
 
                 Type entityType = TypeUtility.GetElementType(domainOperationEntry.ReturnType);
-                if (!visitedEntityTypes.Contains(entityType))
+                if (visitedEntityTypes.Add(entityType))
                 {
-                    visitedEntityTypes.Add(entityType);
-
                     bool isComposedType = this.DomainServiceDescription
                         .GetParentAssociations(entityType).Any(p => p.ComponentType != entityType);
 

--- a/src/OpenRiaServices.Tools/Framework/DomainOperationEntryProxyGenerator.cs
+++ b/src/OpenRiaServices.Tools/Framework/DomainOperationEntryProxyGenerator.cs
@@ -49,10 +49,8 @@ namespace OpenRiaServices.Tools
                 this.GenerateEntityQueryMethod(domainOperationEntry);
 
                 Type entityType = TypeUtility.GetElementType(domainOperationEntry.ReturnType);
-                if (!visitedEntityTypes.Contains(entityType))
+                if (visitedEntityTypes.Add(entityType))
                 {
-                    visitedEntityTypes.Add(entityType);
-
                     // We don't generate entity sets for composed Types. However the special
                     // case can arise where a Type is its own parent (and no other Types 
                     // are its parent), in which case we need to generate the set.


### PR DESCRIPTION
Remove unnecessary calls to *.Contains()
* Combine .!Contains with .Add into a single Add operation
* Replace IndexOf with Contains (faster remove from EntityCollection)

Go though usages of ContainsKey
* Use TryAdd instead if followed by Add
* Use TryGet if followed by fetching value
* Switch to HashSet if value is not used

Replace unneccesary IndexOf calls
* When access EntitySet of EntityCollection using CollectioViewSource add and Contains checks are much faster O(1) instead of O(n)

This translates to roughly ~9% perf improvement for adding 50 000 entities to an EntityCollection.