### PR TITLE
Remove ProjectPath.txt from tests

### DIFF
--- a/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
@@ -118,15 +118,4 @@
     <ProjectReference Include="..\VbExpressions\VbExpressions.vbproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="ClientTestProjectPath.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <Message Text="Writing project path" />
-    <WriteLinesToFile File="ClientTestProjectPath.txt" Lines="$(MSBuildProjectDirectory)" Overwrite="true" WriteOnlyWhenDifferent="true" />
-  </Target>
-
 </Project>

--- a/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
@@ -74,14 +74,4 @@
     </ProjectReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="ClientTestProjectPath.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <Message Text="Writing project path" />
-    <WriteLinesToFile File="ClientTestProjectPath.txt" Lines="$(MSBuildProjectDirectory)" Overwrite="true" WriteOnlyWhenDifferent="true" />
-  </Target>
 </Project>

--- a/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
@@ -28,12 +28,7 @@
     <ProjectReference Include="..\..\Test\Desktop\OpenRiaServices.Common.DomainServices.Test\OpenRiaServices.Common.DomainServices.Test.csproj" />
     <ProjectReference Include="..\Framework\OpenRiaServices.Tools.TextTemplate.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\..\OpenRiaServices.Tools\Test\ProjectPath.txt">
-      <Link>ProjectPath.txt</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />

--- a/src/OpenRiaServices.Tools.TextTemplate/Test/TestHelper.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Test/TestHelper.cs
@@ -6,54 +6,13 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Reflection;
 using System.IO;
 using OpenRiaServices.Tools.TextTemplate.Test;
+using System.Runtime.CompilerServices;
 
 namespace OpenRiaServices.Tools.Test
 {
     public class TestHelper
     {
-        // Returns the folder under which this test is currently running.
-        public static string TestDir
-        {
-            get
-            {
-                return Path.GetDirectoryName(typeof(TestHelper).Assembly.Location);
-            }
-        }
-
-        // Returns the path of the currently executing project as well as the output path
-        // This unusual logic is necessary because MSTest has deployed this test to somewhere
-        // from which we cannot locate our test project.  We use this technique to leave
-        // breadcrumbs we can use to get back to it/
-        public static void GetProjectPaths(string relativeTestDir, out string projectPath, out string outputPath)
-        {
-            string projectPathRelativeFileName = Path.Combine(relativeTestDir, "ProjectPath.txt");
-            string projectPathFile = GetTestFileName(projectPathRelativeFileName);
-            projectPath = string.Empty;
-            outputPath = string.Empty;
-            string inputString = string.Empty;
-            using (StreamReader t1 = new StreamReader(projectPathFile))
-            {
-                inputString = t1.ReadToEnd();
-            }
-
-            string[] split = inputString.Split(',');
-            projectPath = split[0];
-            outputPath = split[1];
-        }
-
-        // Returns the full path to a deployment item file
-        public static string GetTestFileName(string baseName)
-        {
-            string testFileName = Path.Combine(TestDir, baseName);
-
-            Assert.IsTrue(File.Exists(testFileName), "Cannot locate " + testFileName +
-                " which is a necessary input file to this test.\r\n" +
-                " Be sure to add a [DeploymentItem] attribute for every new test file.");
-
-            return testFileName;
-        }
-
-        // Creates a mock code generation host that uses the given logger and shared type service
+         // Creates a mock code generation host that uses the given logger and shared type service
         internal static MockCodeGenerationHost CreateMockCodeGenerationHost(ILoggingService logger, ISharedCodeService sharedCodeService)
         {
             MockCodeGenerationHost host = new MockCodeGenerationHost(logger, sharedCodeService);

--- a/src/OpenRiaServices.Tools/Test/CodeGenDomainServices.cs
+++ b/src/OpenRiaServices.Tools/Test/CodeGenDomainServices.cs
@@ -24,7 +24,6 @@ namespace OpenRiaServices.Tools.Test
             _logger = new ConsoleLogger();
         }
         [DeploymentItem(@"Baselines\Default\Mocks", "CG_Scenarios_Complex")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_Complex")]
         [DeploymentItem(@"Shared\Test.shared.cs")]
         [TestMethod]
         public void TestClientCodegen_ComplexTypeScenarios()
@@ -52,7 +51,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Mocks", "CG_Scenarios_Complex_RootNs_FullTypeNames")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_Complex_RootNs_FullTypeNames")]
         [DeploymentItem(@"Shared\Test.shared.cs")]
         [TestMethod]
         public void TestClientCodegen_ComplexTypeScenarios_RootNs_FullTypeNames()
@@ -75,7 +73,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_Comp")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_Comp")]
         [TestMethod]
         public void TestClientCodegen_CompositionScenarios()
         {
@@ -92,7 +89,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_CI")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_CI")]
         [TestMethod]
         public void TestClientCodegen_CompositionInheritanceScenarios()
         {
@@ -119,7 +115,6 @@ namespace OpenRiaServices.Tools.Test
 
 #if HAS_LINQ2SQL
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_MP")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_MP")]
         [TestMethod]
         public void TestClientCodegen_MultipleDomainServices()
         {
@@ -132,7 +127,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Scenarios_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_FullTypes")]
         [TestMethod]
         public void TestClientCodegen_MultipleDomainServices_FullTypes()
         {
@@ -145,7 +139,6 @@ namespace OpenRiaServices.Tools.Test
 #endif
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_EFDbContext")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_EFDbContext")]
         [TestMethod]
         public void TestClientCodegen_EFDbCtxDomainServices()
         {
@@ -157,7 +150,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Scenarios_EFDbContext_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_EFDbContext_FullTypes")]
         [TestMethod]
         public void TestClientCodegen_EFDbCtxDomainServices_FullTypes()
         {
@@ -169,7 +161,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_EFContext")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_EFContext")]
         [TestMethod]
         public void TestClientCodegen_EFCoreDomainServices()
         {
@@ -181,7 +172,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Scenarios_EFDbContext_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_EFDbContext_FullTypes")]
         [TestMethod]
         public void TestClientCodegen_EFCoreEFDbCtxDomainServices_FullTypes()
         {
@@ -193,7 +183,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_EFCFDbContext")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_EFCFDbContext")]
         [TestMethod]
         public void TestClientCodegen_EFCFDomainServices()
         {
@@ -205,7 +194,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Scenarios_EFCFDbContext_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_EFCFDbContext_FullTypes")]
         [TestMethod]
         public void TestClientCodegen_EFCFDomainServices_FullTypes()
         {
@@ -218,7 +206,6 @@ namespace OpenRiaServices.Tools.Test
 
 #if HAS_LINQ2SQL
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_LTSNW")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_LTSNW")]
         [TestMethod]
         public void TestClientCodegen_LTSNorthwindScenarios()
         {
@@ -231,7 +218,6 @@ namespace OpenRiaServices.Tools.Test
 #endif
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_EF_Inheritance")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_EF_Inheritance")]
         [TestMethod]
         [Description("Validates baseline of simple inheritance model using LTS model")]
         public void TestClientCodegen_EF_Inheritance()
@@ -245,7 +231,6 @@ namespace OpenRiaServices.Tools.Test
 
 #if HAS_LINQ2SQL
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_LTS_Inheritance")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_LTS_Inheritance")]
         [TestMethod]
         [Description("Validates baseline of simple inheritance model using LTS model")]
         public void TestClientCodegen_LTS_Inheritance()
@@ -259,7 +244,6 @@ namespace OpenRiaServices.Tools.Test
 #endif
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_Include")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_Include")]
         [TestMethod]
         public void TestClientCodegen_IncludeScenarios()
         {
@@ -271,7 +255,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_Inherit")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_Inherit")]
         [TestMethod]
         public void TestClientCodegen_InheritanceScenarios()
         {
@@ -288,7 +271,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Scenarios_Inherit_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_Inherit_FullTypes")]
         [TestMethod]
         public void TestClientCodegen_InheritanceScenarios_FullTypes()
         {
@@ -307,7 +289,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_INTF")]
         [DeploymentItem(@"Shared\Mock.shared.cs")]
         [DeploymentItem(@"Shared\Mock.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_INTF")]
         [TestMethod]
         public void TestClientCodegen_InterfaceInheritanceScenarios()
         {
@@ -325,7 +306,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_Secure")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_Secure")]
         [TestMethod]
         public void TestClientCodegen_RequiresSecureEndpointScenarios()
         {
@@ -337,7 +317,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios")]
         [DeploymentItem(@"Shared\Mock.shared.cs")]
         [DeploymentItem(@"Shared\Mock.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios")]
         [TestMethod]
         public void TestClientCodegen_Scenarios_CodeGen()
         {
@@ -359,7 +338,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Scenarios_FullTypes_1")]
         [DeploymentItem(@"Shared\Mock.shared.cs")]
         [DeploymentItem(@"Shared\Mock.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_FullTypes_1")]
         [TestMethod]
         public void TestClientCodegen_Scenarios_CodeGen_FullTypes()
         {
@@ -383,7 +361,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Shared\Mock.shared.vb")]
         [DeploymentItem(@"Shared\Test.shared.cs")]
         [DeploymentItem(@"Shared\Test.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_1")]
         [TestMethod]
         public void TestClientCodegen_Scenarios()
         {
@@ -419,7 +396,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Shared\Mock.shared.vb")]
         [DeploymentItem(@"Shared\Test.shared.cs")]
         [DeploymentItem(@"Shared\Test.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_FullTypes_2")]
         [TestMethod]
         public void TestClientCodegen_Scenarios_FullTypes()
         {
@@ -451,7 +427,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_3")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_3")]
         [TestMethod]
         [Description("Generated code should include error messages from attributes that throw exceptions")]
         public void TestClientCodeGen_AttributeThrowing()
@@ -461,7 +436,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_4")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_4")]
         [TestMethod]
         [Description("Generated code in VB should correctly handle root namespace inside VB project")]
         public void VBRootNamespaceTest()
@@ -472,7 +446,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Scenarios_FullTypes_5")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_FullTypes_5")]
         [TestMethod]
         [Description("Generated code in VB should correctly handle root namespace inside VB project")]
         public void VBRootNamespaceTest_FullTypes()
@@ -486,7 +459,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\Default\Cities", "CG_Cities")]
         [DeploymentItem(@"Cities\Cities.shared.cs")]
         [DeploymentItem(@"Cities\Cities.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Cities")]
         [TestMethod]
         [Description("Create client proxies for City domain service and compare to known good copy")]
         public void TestCityClientProxies()
@@ -507,7 +479,7 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\Default\Cities")]
         [DeploymentItem(@"Cities\Cities.shared.cs")]
         [DeploymentItem(@"Cities\Cities.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Mocks")]
+
         [TestMethod]
         [Description("Create client proxies for MockCustomer domain service and compare to known good copy")]
         public void TestMockCustomerProviderClientProxies()
@@ -525,7 +497,6 @@ namespace OpenRiaServices.Tools.Test
 
 #if HAS_LINQ2SQL
         [DeploymentItem(@"Baselines\Default\LTS", "CG_CATLTS")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_CATLTS")]
         [TestMethod]
         [Description("Create client proxies for Linq to Sql domain service and compare to known good copy")]
         public void TestCatalogLTSClientProxies()
@@ -535,7 +506,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\LTS", "CG_NWLTS")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_NWLTS")]
         [TestMethod]
         public void TestNorthwindLTSClientProxies()
         {
@@ -545,7 +515,6 @@ namespace OpenRiaServices.Tools.Test
 #endif
 
         [DeploymentItem(@"Baselines\Default\EF", "CG_NWEF")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_NWEF")]
         [TestMethod]
         public void TestNorthwindEFClientProxies()
         {
@@ -554,7 +523,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\EF", "CG_NWEF")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_NWEF")]
         [TestMethod]
         public void TestNorthwindEFCoreClientProxies()
         {
@@ -563,7 +531,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\EF", "CG_CATEF")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_CATEF")]
         [TestMethod]
         [Description("Create client proxies for Linq to Entities domain service and compare to known good copy")]
         public void TestCatalogEFClientProxies()
@@ -572,7 +539,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\EF", "CG_CATEFDbCtx")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_CATEFDbCtx")]
         [TestMethod]
         [Description("Create client proxies for Linq to Entities domain service and compare to known good copy")]
         public void TestCatalogEFDbCtxClientProxies()
@@ -582,7 +548,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\EF", "CG_CATEFDbCtx")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_CATEFDbCtx")]
         [TestMethod]
         [Description("Create client proxies for Linq to Entities domain service and compare to known good copy")]
         public void TestCatalogEFCoreClientProxies()
@@ -592,7 +557,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_CONFLICT_RESOLUTION")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_CONFLICT_RESOLUTION")]
         [TestMethod]
         [Description("Create client proxies and verifies that entity type conflicts are resolved correctly.")]
         public void TestClientCodeGen_ConflictResolution()
@@ -609,7 +573,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_CONFLICT_RESOLUTION_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_CONFLICT_RESOLUTION_FullTypes")]
         [TestMethod]
         [Description("Create client proxies and verifies that entity type conflicts are resolved correctly.")]
         public void TestClientCodeGen_ConflictResolution_FullTypes()
@@ -734,9 +697,7 @@ namespace OpenRiaServices.Tools.Test
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Global")]
         [DeploymentItem(@"Shared\Global.shared.cs")]
-        [DeploymentItem(@"Shared\Global.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Global")]
-        [TestMethod]
+        [DeploymentItem(@"Shared\Global.shared.vb")]        [TestMethod]
         [WorkItem(851335)]
         [Description("Verifies that codegen succeeds when global types are exposed to all areas of the generator.")]
         public void TestClientCodeGen_GlobalNamespace()
@@ -767,7 +728,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Global_Full")]
         [DeploymentItem(@"Shared\Global.shared.cs")]
         [DeploymentItem(@"Shared\Global.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Global_Full")]
         [TestMethod]
         [WorkItem(851335)]
         [Description("Verifies that codegen succeeds when global types are exposed to all areas of the generator using full type names.")]
@@ -800,7 +760,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Global")]
         [DeploymentItem(@"Shared\Global.shared.cs")]
         [DeploymentItem(@"Shared\Global.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Global")]
         [TestMethod]
         [WorkItem(851335)]
         [Description("Verifies that codegen succeeds when global types are exposed to all areas of the generator when the RootNamespace is empty.")]
@@ -834,7 +793,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_Global_Full")]
         [DeploymentItem(@"Shared\Global.shared.cs")]
         [DeploymentItem(@"Shared\Global.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Global_Full")]
         [TestMethod]
         [WorkItem(851335)]
         [Description("Verifies that codegen succeeds when global types are exposed to all areas of the generator using full type names when the RootNamespace is empty.")]
@@ -868,7 +826,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_SystemNamespace")]
         [DeploymentItem(@"Shared\SystemNamespace.shared.cs")]
         [DeploymentItem(@"Shared\SystemNamespace.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_SystemNamespace")]
         [TestMethod]
         [WorkItem(810123)]
         [Description("Verifies that codegen succeeds when System namespaces are included in user domain services")]
@@ -903,7 +860,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\FullTypeNames\Scenarios", "CG_SystemNamespace_Full")]
         [DeploymentItem(@"Shared\SystemNamespace.shared.cs")]
         [DeploymentItem(@"Shared\SystemNamespace.shared.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_SystemNamespace_Full")]
         [TestMethod]
         [WorkItem(810123)]
         [Description("Verifies that codegen succeeds when System namespaces are included in user domain services using full names")]
@@ -936,7 +892,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\Scenarios", "CG_Scenarios_SharedEntities")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_Scenarios_SharedEntities")]
         [TestMethod]
         [Description("Test that entities shared across two domain services can be generated.")]
         public void TestClientCodegen_SharedEntities()

--- a/src/OpenRiaServices.Tools/Test/CodeGenHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/CodeGenHelper.cs
@@ -348,9 +348,7 @@ namespace OpenRiaServices.Tools.Test
         public static CreateOpenRiaClientFilesTask CreateOpenRiaClientFilesTaskInstance(string relativeTestDir, bool includeClientOutputAssembly)
         {
             string deploymentDir = Path.GetDirectoryName(typeof(CodeGenHelper).Assembly.Location);
-            string projectPath = null;
-            string outputPath = null;
-            TestHelper.GetProjectPaths(relativeTestDir, out projectPath, out outputPath);
+            string projectPath = TestHelper.GetToolsTestProjectPath();           
 
             Assert.IsTrue(File.Exists(projectPath), "Could not locate " + projectPath + " necessary for test.");
             string serverProjectPath = CodeGenHelper.ServerClassLibProjectPath(projectPath);

--- a/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
@@ -228,17 +228,13 @@ namespace OpenRiaServices.Tools.Test
         /// <returns></returns>
         public static List<string> GetClientAssemblies(string relativeTestDir)
         {
-            string projectPath = string.Empty;  // path to current project
-            string outputPath = string.Empty;   // output path for current project, used to infer output path of test project
-            TestHelper.GetProjectPaths(relativeTestDir, out projectPath, out outputPath);
-
             // Our current project's folder
-            string projectDir = Path.GetDirectoryName(projectPath);
+            string projectDir = GetCurrentProjectFolder();
 
             // Folder of project we want to build
             string testProjectDir = Path.GetFullPath(Path.Combine(projectDir, @"..\..\OpenRiaServices.Client.Web\Framework"));
 
-            string projectOutputDir = Path.Combine(testProjectDir, outputPath);
+            string projectOutputDir = Path.Combine(testProjectDir, "Generated_Code");
             string testProjectFile = Path.Combine(testProjectDir, @"OpenRiaServices.Client.Web.csproj");
             Assert.IsTrue(File.Exists(testProjectFile), "This test could not find its required project at " + testProjectFile);
 
@@ -253,5 +249,9 @@ namespace OpenRiaServices.Tools.Test
             return assemblies;
 
         }
+
+        // This file lies in the root of the project so we can get the projects directory easily
+        private static string GetCurrentProjectFolder([System.Runtime.CompilerServices.CallerFilePath]string callerFilePath = null)
+            => Path.GetDirectoryName(callerFilePath);
     }
 }

--- a/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
@@ -228,13 +228,9 @@ namespace OpenRiaServices.Tools.Test
         /// <returns></returns>
         public static List<string> GetClientAssemblies(string relativeTestDir)
         {
-            // Our current project's folder
+            // Get full path of OpenRiaServices.Client.Web.csproj
             string projectDir = GetCurrentProjectFolder();
-
-            // Folder of project we want to build
             string testProjectDir = Path.GetFullPath(Path.Combine(projectDir, @"..\..\OpenRiaServices.Client.Web\Framework"));
-
-            string projectOutputDir = Path.Combine(testProjectDir, "Generated_Code");
             string testProjectFile = Path.Combine(testProjectDir, @"OpenRiaServices.Client.Web.csproj");
             Assert.IsTrue(File.Exists(testProjectFile), "This test could not find its required project at " + testProjectFile);
 

--- a/src/OpenRiaServices.Tools/Test/EnumCodeGenTests.cs
+++ b/src/OpenRiaServices.Tools/Test/EnumCodeGenTests.cs
@@ -229,7 +229,6 @@ namespace OpenRiaServices.Tools.Test
 
         [TestMethod]
         [Description("Entity exposing property with enum in System namespace emits warning if it is not shared")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_ENUM")]
         public void Enum_Gen_Warn_System_Property()
         {
             foreach (bool isCSharp in new bool[] { true, false })
@@ -252,7 +251,6 @@ namespace OpenRiaServices.Tools.Test
 
         [TestMethod]
         [Description("Entity exposing property with nested enum type is illegal")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_ENUM")]
         public void Enum_Gen_Warn_Nested_Property()
         {
             foreach (bool isCSharp in new bool[] { true, false })
@@ -273,7 +271,6 @@ namespace OpenRiaServices.Tools.Test
 
         [TestMethod]
         [Description("DomainService exposing query with enum in System namespace emits warning if it is not shared")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_ENUM")]
         public void Enum_Gen_Err_System_Query()
         {
             foreach (bool isCSharp in new bool[] { true, false })
@@ -296,7 +293,6 @@ namespace OpenRiaServices.Tools.Test
 
         [TestMethod]
         [Description("DomainService exposing invoke with enum in System namespace emits warning if it is not shared")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_ENUM")]
         public void Enum_Gen_Err_System_Invoke()
         {
             foreach (bool isCSharp in new bool[] { true, false })
@@ -319,7 +315,6 @@ namespace OpenRiaServices.Tools.Test
 
         [TestMethod]
         [Description("DomainService exposing named update with enum in System namespace emits warning if it is not shared")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_ENUM")]
         public void Enum_Gen_Err_System_Named()
         {
             foreach (bool isCSharp in new bool[] { true, false })
@@ -342,7 +337,6 @@ namespace OpenRiaServices.Tools.Test
 
         [TestMethod]
         [Description("DomainService exposing query with enum containing custom attributes that throw logs a warning")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_ENUM_THROW")]
         public void Enum_Gen_Warning_Throwing_CustomAttribute_Query()
         {
             foreach (bool isCSharp in new bool[] { true, false })

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -70,9 +70,6 @@
     <Content Include="NotificationMethodGeneratorTests.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="ProjectPath.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="ClientClassLib2\**" />
@@ -94,10 +91,5 @@
     <None Remove="T4DomainServiceCodeGenerator\**" />
     <None Remove="TestWap\**" />
   </ItemGroup>
-
-  <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <Message Text="Writing project path" />
-    <WriteLinesToFile File="ProjectPath.txt" Lines="$(MSBuildProjectFullPath),Generated_Code," Overwrite="true" />
-  </Target>
-
+  
 </Project>

--- a/src/OpenRiaServices.Tools/Test/PdbReaderTests.cs
+++ b/src/OpenRiaServices.Tools/Test/PdbReaderTests.cs
@@ -20,7 +20,6 @@ namespace OpenRiaServices.Tools.Test
         {
         }
 
-        [DeploymentItem("ProjectPath.txt")]
         [Description("PdbReader finds files defining properties in server assembly")]
         [TestMethod]
         public void PdbReader_Finds_Method_Files()
@@ -59,7 +58,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem("ProjectPath.txt")]
         [Description("PdbReader finds all files for a type")]
         [TestMethod]
         public void PdbReader_Finds_Types_Files()

--- a/src/OpenRiaServices.Tools/Test/ProjectSourceFileCacheTests.cs
+++ b/src/OpenRiaServices.Tools/Test/ProjectSourceFileCacheTests.cs
@@ -280,7 +280,6 @@ namespace OpenRiaServices.Tools.Test
 
         [TestMethod]
         [Description("Tests ProjectSourceFileCache loads files for project")]
-        [DeploymentItem(@"ProjectPath.txt")]
         public void ProjectSourceFileCache_Loads_Real_Project()
         {
             string projectPath = null;

--- a/src/OpenRiaServices.Tools/Test/SharedCodeServiceTests.cs
+++ b/src/OpenRiaServices.Tools/Test/SharedCodeServiceTests.cs
@@ -102,7 +102,6 @@ namespace OpenRiaServices.Tools.Test
             }
         }
 
-        [DeploymentItem("ProjectPath.txt")]
         [Description("SharedCodeService locates shared properties between projects")]
         [TestMethod]
         public void SharedCodeService_Properties()

--- a/src/OpenRiaServices.Tools/Test/TestHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/TestHelper.cs
@@ -42,14 +42,18 @@ namespace OpenRiaServices.Tools.Test
         // breadcrumbs we can use to get back to it/
         public static void GetProjectPaths(string relativeTestDir, out string projectPath, out string outputPath)
         {
-            // Read file from output folder
-            string inputString = File.ReadAllText("ProjectPath.txt");
-
-
-            string[] split = inputString.Split(',');
-            projectPath = split[0];
-            outputPath = split[1];
+            projectPath = GetToolsTestProjectPath();
+            outputPath = "Generated_Code";
         }
+
+        public static string GetToolsTestProjectPath()
+            => Path.Combine(GetCurrentProjectDirectorImpl(), "OpenRiaServices.Tools.Test.csproj");
+
+        public static string GetToolsTestProjectDirectory()
+            => GetCurrentProjectDirectorImpl();
+
+        private static string GetCurrentProjectDirectorImpl([System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = null)
+            => Path.GetDirectoryName(callerFilePath);
 
         // Validates that a generated file matches a reference file.
         // Strips off code-gen boilerplate that may cause comparison problems

--- a/src/OpenRiaServices.Tools/Test/WebContextGeneratorTest.cs
+++ b/src/OpenRiaServices.Tools/Test/WebContextGeneratorTest.cs
@@ -15,7 +15,6 @@ namespace OpenRiaServices.Tools.Test
         [DeploymentItem(@"Baselines\Default\WebContext", @"CG_WebContext")]
         [DeploymentItem(@"Baselines\Default\WebContext\WebContext0.g.cs")]
         [DeploymentItem(@"Baselines\Default\WebContext\WebContext0.g.vb")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_WebContext")]
         [TestMethod]
         [Description("Tests that the code is generated correctly when no services are present.")]
         public void NoAuthenticationServices()
@@ -25,7 +24,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\WebContext", @"CG_WebContext_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_WebContext_FullTypes")]
         [TestMethod]
         [Description("Tests that the code is generated correctly when no services are present.")]
         public void NoAuthenticationServices_FullTypes()
@@ -35,7 +33,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\WebContext", @"CG_WebContext_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_WebContext_FullTypes")]
         [TestMethod]
         [Description("Tests that the code is generated correctly when no services are present.")]
         public void NoAuthenticationServices_FullTypes_NoRootNamespace()
@@ -47,7 +44,6 @@ namespace OpenRiaServices.Tools.Test
 #if NETFRAMEWORK
 
         [DeploymentItem(@"Baselines\Default\WebContext", @"CG_WebContext")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_WebContext")]
         [TestMethod]
         [Description("Tests that the code is generated correctly when a single service is present.")]
         public void OneAuthenticationService()
@@ -57,7 +53,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\WebContext", @"CG_WebContext_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_WebContext_FullTypes")]
         [TestMethod]
         [Description("Tests that the code is generated correctly when a single service is present.")]
         public void OneAuthenticationService_FullTypes()
@@ -67,7 +62,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\Default\WebContext", @"CG_WebContext")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_WebContext")]
         [TestMethod]
         [Description("Tests that the code is generated correctly when two services are present.")]
         public void TwoAuthenticationServices()
@@ -83,7 +77,6 @@ namespace OpenRiaServices.Tools.Test
         }
 
         [DeploymentItem(@"Baselines\FullTypeNames\WebContext", @"CG_WebContext_FullTypes")]
-        [DeploymentItem(@"ProjectPath.txt", "CG_WebContext_FullTypes")]
         [TestMethod]
         [Description("Tests that the code is generated correctly when two services are present.")]
         public void TwoAuthenticationServices_FullTypes()

--- a/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/Main.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/Main.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Threading;
 using httpDomainClient::OpenRiaServices.Client.DomainClients;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace OpenRiaServices.Client.Test
 {
@@ -48,10 +49,10 @@ namespace OpenRiaServices.Client.Test
             s_aspNetCoreSite?.Kill();
         }
 
-        private static void StartWebServer()
+        private static void StartWebServer([CallerFilePath]string filePaht = null)
         {
             const string ProcessName = "AspNetCoreWebsite";
-            string projectPath = File.ReadAllLines("ClientTestProjectPath.txt")[0];
+            string projectPath = Path.GetDirectoryName(filePaht);
 #if DEBUG
             string configuration = "Debug";
 #else

--- a/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/OpenRiaservices.EndToEnd.AspNetCore.Test.csproj
+++ b/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/OpenRiaservices.EndToEnd.AspNetCore.Test.csproj
@@ -114,15 +114,4 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="ClientTestProjectPath.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <Message Text="Writing project path" />
-    <WriteLinesToFile File="ClientTestProjectPath.txt" Lines="$(MSBuildProjectDirectory)" Overwrite="true" WriteOnlyWhenDifferent="true" />
-  </Target>
-
 </Project>

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Main.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Main.cs
@@ -64,7 +64,7 @@ namespace OpenRiaServices.Client.Test
 
         private static void StartWebServer([CallerFilePathAttribute] string filepath = null)
         {
-            string projectPath = Path.GetDirectoryName(filepath); ;
+            string projectPath = Path.GetDirectoryName(filepath);
 #if VBTests
             string webSitePath = Path.GetFullPath(Path.Combine(projectPath, @"..\..\..\Test\WebsiteFullTrust"));
 #else

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Main.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Main.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using httpDomainClient::OpenRiaServices.Client.DomainClients;
 using OpenRiaServices.Common.Test;
+using System.Runtime.CompilerServices;
 
 namespace OpenRiaServices.Client.Test
 {
@@ -61,9 +62,9 @@ namespace OpenRiaServices.Client.Test
             s_webServer?.Stop();
         }
 
-        private static void StartWebServer()
+        private static void StartWebServer([CallerFilePathAttribute] string filepath = null)
         {
-            string projectPath = File.ReadAllLines("ClientTestProjectPath.txt")[0];
+            string projectPath = Path.GetDirectoryName(filepath); ;
 #if VBTests
             string webSitePath = Path.GetFullPath(Path.Combine(projectPath, @"..\..\..\Test\WebsiteFullTrust"));
 #else

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Main.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Main.cs
@@ -65,11 +65,7 @@ namespace OpenRiaServices.Client.Test
         private static void StartWebServer([CallerFilePathAttribute] string filepath = null)
         {
             string projectPath = Path.GetDirectoryName(filepath);
-#if VBTests
-            string webSitePath = Path.GetFullPath(Path.Combine(projectPath, @"..\..\..\Test\WebsiteFullTrust"));
-#else
             string webSitePath = Path.GetFullPath(Path.Combine(projectPath, @"..\WebsiteFullTrust"));
-#endif
 
             if (!Directory.Exists(webSitePath))
                 throw new FileNotFoundException($"Website not found at {webSitePath}");

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OpenRiaservices.EndToEnd.Wcf.Test.csproj
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OpenRiaservices.EndToEnd.Wcf.Test.csproj
@@ -115,15 +115,4 @@
     </ProjectReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="ClientTestProjectPath.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <Target Name="WriteProjectPath" BeforeTargets="GetCopyToOutputDirectoryItems">
-    <Message Text="Writing project path" />
-    <WriteLinesToFile File="ClientTestProjectPath.txt" Lines="$(MSBuildProjectDirectory)" Overwrite="true" WriteOnlyWhenDifferent="true" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
Remove generation of ProjectPath.txt from test projects and use [CallerFilePath] attribute instead.

This should give 
* simpler test projects 
* (and avoids unneeded rebuils)
* Removes more usages of DeploymentItem (to make it easier to choose other test frameworks)
