### PR TITLE
EntityAssociationAttribute Step2

### DIFF
--- a/src/OpenRiaServices.Client/Framework/EntityAssociationAttribute.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityAssociationAttribute.cs
@@ -14,7 +14,7 @@ namespace System.ComponentModel.DataAnnotations
 #pragma warning restore CS3015 // Type has no accessible constructors which use only CLS-compliant types
     {
         /// <summary>
-        /// Full form of constructor
+        /// Create an instance that defines an association between two entities, using any number of key members.
         /// </summary>
         /// <param name="name">The name of the association. For bi-directional associations,
         /// the name must be the same on both sides of the association</param>
@@ -35,12 +35,12 @@ namespace System.ComponentModel.DataAnnotations
         }
 
         /// <summary>
-        /// Full form of constructor
+        /// Create an instance that defines an association using a single key member.
         /// </summary>
         /// <param name="name">The name of the association. For bi-directional associations,
         /// the name must be the same on both sides of the association</param>
-        /// <param name="thisKey">List of the property names of the key values on this side of the association</param>
-        /// <param name="otherKey">List of the property names of the key values on the other side of the association</param>
+        /// <param name="thisKey">A single property name of the key value on this side of the association</param>
+        /// <param name="otherKey">A single property name of the key value on the other side of the association</param>
         public EntityAssociationAttribute(string name, string thisKey, string otherKey)
         {
             if (string.IsNullOrEmpty(name))

--- a/src/OpenRiaServices.Client/Framework/EntityAssociationAttribute.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityAssociationAttribute.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 
+#nullable enable
 #pragma warning disable CS3015 // Type has no accessible constructors which use only CLS-compliant types
 
-namespace OpenRiaServices
+namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
-    /// Used to mark an Entity member as an association
+    /// Used to mark an Entity member as an association.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
-
     public sealed class EntityAssociationAttribute : Attribute
 #pragma warning restore CS3015 // Type has no accessible constructors which use only CLS-compliant types
     {
@@ -26,12 +26,33 @@ namespace OpenRiaServices
             ThisKeyMembers = thisKey ?? throw new ArgumentNullException(nameof(thisKey));
             OtherKeyMembers = otherKey ?? throw new ArgumentNullException(nameof(otherKey));
 
-            if (name .Length == 0)
+            if (name.Length == 0)
                 throw new ArgumentException("Name cannot be empty", nameof(name));
             if (thisKey.Length == 0)
                 throw new ArgumentException("ThisKey cannot be empty", nameof(thisKey));
             if (otherKey.Length == 0)
                 throw new ArgumentException("OtherKey cannot be empty", nameof(otherKey));
+        }
+
+        /// <summary>
+        /// Full form of constructor
+        /// </summary>
+        /// <param name="name">The name of the association. For bi-directional associations,
+        /// the name must be the same on both sides of the association</param>
+        /// <param name="thisKey">List of the property names of the key values on this side of the association</param>
+        /// <param name="otherKey">List of the property names of the key values on the other side of the association</param>
+        public EntityAssociationAttribute(string name, string thisKey, string otherKey)
+        {
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException("Name cannot be empty", nameof(name));
+            if (string.IsNullOrEmpty(thisKey))
+                throw new ArgumentException("ThisKey cannot be empty", nameof(thisKey));
+            if (string.IsNullOrEmpty(otherKey))
+                throw new ArgumentException("OtherKey cannot be empty", nameof(otherKey));
+
+            Name = name;
+            ThisKeyMembers = [thisKey];
+            OtherKeyMembers = [otherKey];
         }
 
         /// <summary>
@@ -49,12 +70,12 @@ namespace OpenRiaServices
         /// <summary>
         /// Gets the collection of individual key members specified in the ThisKey string.
         /// </summary>
-        public IReadOnlyCollection<string> ThisKeyMembers { get; }
+        public IReadOnlyList<string> ThisKeyMembers { get; }
 
         /// <summary>
         /// Gets the collection of individual key members specified in the OtherKey string.
         /// </summary>
-        public IReadOnlyCollection<string> OtherKeyMembers { get; }
+        public IReadOnlyList<string> OtherKeyMembers { get; }
 
         /// <summary>
         /// Gets or sets the key value on this side of the association

--- a/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
@@ -1,17 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NoWarn>108</NoWarn>
     <TargetFrameworks>net472;net6.0-windows;net8.0-windows</TargetFrameworks>
     <Version>1.0.0.0</Version>
     <UseWPF>true</UseWPF>
     <DefineConstants>$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net472'">
-    <!-- Disable obsolete warning (primarily AssociationAttribute) -->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />

--- a/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net472</TargetFrameworks>
     <DefineConstants>TRACE;DEBUG;VBTests</DefineConstants>
-    <NoWarn>108</NoWarn>
     <RootNamespace>OpenRiaServices.Client.Test</RootNamespace>
   </PropertyGroup>
 

--- a/src/OpenRiaServices.EntityFramework/Test/CodeFirstModel/EFCodeFirstModels.csproj
+++ b/src/OpenRiaServices.EntityFramework/Test/CodeFirstModel/EFCodeFirstModels.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NoWarn>618</NoWarn>
     <RootNamespace>CodeFirstModels</RootNamespace>
     <AssemblyName>CodeFirstModels</AssemblyName>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>

--- a/src/OpenRiaServices.LinqToSql/Framework/LinqToSqlTypeDescriptionContext.cs
+++ b/src/OpenRiaServices.LinqToSql/Framework/LinqToSqlTypeDescriptionContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Data.Linq.Mapping;
 using System.Globalization;
 using System.Linq;

--- a/src/OpenRiaServices.LinqToSql/Framework/LinqToSqlTypeDescriptionContext.cs
+++ b/src/OpenRiaServices.LinqToSql/Framework/LinqToSqlTypeDescriptionContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Data.Linq.Mapping;
 using System.Globalization;
 using System.Linq;

--- a/src/OpenRiaServices.Tools/Framework/MetadataPipeline/EntityAssociationAttributeBuilder.cs
+++ b/src/OpenRiaServices.Tools/Framework/MetadataPipeline/EntityAssociationAttributeBuilder.cs
@@ -16,36 +16,48 @@ namespace OpenRiaServices.Tools
         /// </summary>
         public AttributeDeclaration GetAttributeDeclaration(Attribute attribute)
         {
-            AttributeDeclaration attributeDeclaration = new AttributeDeclaration(typeof(EntityAssociationAttribute));
+            string name;
+            string[] thisKey, otherKey;
+            bool isForeignKey;
 
             if (attribute is EntityAssociationAttribute entityAssociation)
             {
-                attributeDeclaration.ConstructorArguments.Add(entityAssociation.Name);
-                attributeDeclaration.ConstructorArguments.Add((string[])entityAssociation.ThisKeyMembers);
-                attributeDeclaration.ConstructorArguments.Add((string[])entityAssociation.OtherKeyMembers);
-
-                if (entityAssociation.IsForeignKey)
-                {
-                    attributeDeclaration.NamedParameters.Add(nameof(EntityAssociationAttribute.IsForeignKey), true);
-                }
+                name = entityAssociation.Name;
+                thisKey = (string[])entityAssociation.ThisKeyMembers;
+                otherKey = (string[])entityAssociation.OtherKeyMembers;
+                isForeignKey = entityAssociation.IsForeignKey;
             }
             else if (attribute is AssociationAttribute associationAttribute)
             {
-                // [EntityAssociation( {true|false} )]
-                attributeDeclaration.ConstructorArguments.Add(associationAttribute.Name);
-                attributeDeclaration.ConstructorArguments.Add(associationAttribute.ThisKeyMembers.ToArray());
-                attributeDeclaration.ConstructorArguments.Add(associationAttribute.OtherKeyMembers.ToArray());
-
-                if (associationAttribute.IsForeignKey)
-                {
-                    attributeDeclaration.NamedParameters.Add(nameof(EntityAssociationAttribute.IsForeignKey), true);
-                }
+                name = associationAttribute.Name;
+                thisKey = associationAttribute.ThisKeyMembers.ToArray();
+                otherKey = associationAttribute.OtherKeyMembers.ToArray();
+                isForeignKey = associationAttribute.IsForeignKey;
             }
             else
             {
                 return null;
             }
 
+            // Generate the attribute declaration
+            // If there is only a single key member, we use string based constructor
+            AttributeDeclaration attributeDeclaration = new AttributeDeclaration(typeof(EntityAssociationAttribute));
+            attributeDeclaration.ConstructorArguments.Add(name);
+            if (thisKey.Length == 1 && otherKey.Length == 1)
+            {
+                attributeDeclaration.ConstructorArguments.Add(thisKey[0]);
+                attributeDeclaration.ConstructorArguments.Add(otherKey[0]);
+            }
+            else
+            {
+                attributeDeclaration.ConstructorArguments.Add(thisKey);
+                attributeDeclaration.ConstructorArguments.Add(otherKey);
+            }
+
+            if (isForeignKey)
+            {
+                attributeDeclaration.NamedParameters.Add(nameof(EntityAssociationAttribute.IsForeignKey), true);
+            }
             return attributeDeclaration;
         }
     }

--- a/src/OpenRiaServices.Tools/Test/CodeGenExternalAttributeTests.cs
+++ b/src/OpenRiaServices.Tools/Test/CodeGenExternalAttributeTests.cs
@@ -54,7 +54,7 @@ namespace OpenRiaServices.Tools.Test
             TestHelper.AssertGeneratedCodeContains(
                 generatedCode,
                 "private EntityRef<global::DataTests.Scenarios.EF.Northwind.PersonalDetails> _personalDetails_MarkedAsExternal;",
-                "[EntityAssociation(\"Employee_PersonalDetails\", new string[] { \"EmployeeID\"}, new string[] { \"UniqueID\"}, IsForeignKey=true)] [ExternalReference()]",
+                "[EntityAssociation(\"Employee_PersonalDetails\", \"EmployeeID\", \"UniqueID\", IsForeignKey=true)] [ExternalReference()]",
                 "public global::DataTests.Scenarios.EF.Northwind.PersonalDetails PersonalDetails_MarkedAsExternal",
                 "private bool FilterPersonalDetails_MarkedAsExternal(global::DataTests.Scenarios.EF.Northwind.PersonalDetails entity)");
         }

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.cs
@@ -1750,9 +1750,7 @@ namespace Cities
         /// <summary>
         /// Gets or sets the associated <see cref="State"/> entity.
         /// </summary>
-        [EntityAssociation("State_County", new string[] {
-                "StateName"}, new string[] {
-                "Name"}, IsForeignKey=true)]
+        [EntityAssociation("State_County", "StateName", "Name", IsForeignKey=true)]
         public State State
         {
             get
@@ -1930,9 +1928,7 @@ namespace Cities
         /// </summary>
         [CustomValidation(typeof(CountiesValidator), "AreCountiesValid")]
         [Editable(false)]
-        [EntityAssociation("State_County", new string[] {
-                "Name"}, new string[] {
-                "StateName"})]
+        [EntityAssociation("State_County", "Name", "StateName")]
         [ReadOnly(true)]
         public EntityCollection<County> Counties
         {

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Cities/Cities.g.vb
@@ -1628,7 +1628,7 @@ Namespace Cities
         ''' <summary>
         ''' Gets or sets the associated <see cref="State"/> entity.
         ''' </summary>
-        <EntityAssociation("State_County", New String() {"StateName"}, New String() {"Name"}, IsForeignKey:=true)>  _
+        <EntityAssociation("State_County", "StateName", "Name", IsForeignKey:=true)>  _
         Public Property State() As State
             Get
                 If (Me._state Is Nothing) Then
@@ -1793,7 +1793,7 @@ Namespace Cities
         ''' </summary>
         <CustomValidation(GetType(CountiesValidator), "AreCountiesValid"),  _
          Editable(false),  _
-         EntityAssociation("State_County", New String() {"Name"}, New String() {"StateName"}),  _
+         EntityAssociation("State_County", "Name", "StateName"),  _
          [ReadOnly](true)>  _
         Public ReadOnly Property Counties() As EntityCollection(Of County)
             Get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EF.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EF.g.cs
@@ -295,9 +295,7 @@ namespace AdventureWorksModel
         /// <summary>
         /// Gets or sets the associated <see cref="Employee"/> entity.
         /// </summary>
-        [EntityAssociation("Employee_Employee", new string[] {
-                "ManagerID"}, new string[] {
-                "EmployeeID"}, IsForeignKey=true)]
+        [EntityAssociation("Employee_Employee", "ManagerID", "EmployeeID", IsForeignKey=true)]
         public Employee Manager
         {
             get
@@ -441,9 +439,7 @@ namespace AdventureWorksModel
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrder"/> entity instances.
         /// </summary>
-        [EntityAssociation("Employee_PurchaseOrder", new string[] {
-                "EmployeeID"}, new string[] {
-                "EmployeeID"})]
+        [EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID")]
         public EntityCollection<PurchaseOrder> PurchaseOrders
         {
             get
@@ -459,9 +455,7 @@ namespace AdventureWorksModel
         /// <summary>
         /// Gets the collection of associated <see cref="Employee"/> entity instances.
         /// </summary>
-        [EntityAssociation("Employee_Employee", new string[] {
-                "EmployeeID"}, new string[] {
-                "ManagerID"})]
+        [EntityAssociation("Employee_Employee", "EmployeeID", "ManagerID")]
         public EntityCollection<Employee> Reports
         {
             get
@@ -1265,9 +1259,7 @@ namespace AdventureWorksModel
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_PurchaseOrderDetail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID")]
         public EntityCollection<PurchaseOrderDetail> PurchaseOrderDetails
         {
             get
@@ -1637,9 +1629,7 @@ namespace AdventureWorksModel
         /// <summary>
         /// Gets or sets the associated <see cref="Employee"/> entity.
         /// </summary>
-        [EntityAssociation("Employee_PurchaseOrder", new string[] {
-                "EmployeeID"}, new string[] {
-                "EmployeeID"}, IsForeignKey=true)]
+        [EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID", IsForeignKey=true)]
         public Employee Employee
         {
             get
@@ -1779,9 +1769,7 @@ namespace AdventureWorksModel
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         /// </summary>
-        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", new string[] {
-                "PurchaseOrderID"}, new string[] {
-                "PurchaseOrderID"})]
+        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID")]
         public EntityCollection<PurchaseOrderDetail> PurchaseOrderDetails
         {
             get
@@ -2217,9 +2205,7 @@ namespace AdventureWorksModel
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_PurchaseOrderDetail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -2287,9 +2273,7 @@ namespace AdventureWorksModel
         /// <summary>
         /// Gets or sets the associated <see cref="PurchaseOrder"/> entity.
         /// </summary>
-        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", new string[] {
-                "PurchaseOrderID"}, new string[] {
-                "PurchaseOrderID"}, IsForeignKey=true)]
+        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID", IsForeignKey=true)]
         public PurchaseOrder PurchaseOrder
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EF.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EF.g.vb
@@ -311,7 +311,7 @@ Namespace AdventureWorksModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="Employee"/> entity.
         ''' </summary>
-        <EntityAssociation("Employee_Employee", New String() {"ManagerID"}, New String() {"EmployeeID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Employee_Employee", "ManagerID", "EmployeeID", IsForeignKey:=true)>  _
         Public Property Manager() As Employee
             Get
                 If (Me._manager Is Nothing) Then
@@ -430,7 +430,7 @@ Namespace AdventureWorksModel
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrder"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Employee_PurchaseOrder", New String() {"EmployeeID"}, New String() {"EmployeeID"})>  _
+        <EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID")>  _
         Public ReadOnly Property PurchaseOrders() As EntityCollection(Of PurchaseOrder)
             Get
                 If (Me._purchaseOrders Is Nothing) Then
@@ -443,7 +443,7 @@ Namespace AdventureWorksModel
         ''' <summary>
         ''' Gets the collection of associated <see cref="Employee"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Employee_Employee", New String() {"EmployeeID"}, New String() {"ManagerID"})>  _
+        <EntityAssociation("Employee_Employee", "EmployeeID", "ManagerID")>  _
         Public ReadOnly Property Reports() As EntityCollection(Of Employee)
             Get
                 If (Me._reports Is Nothing) Then
@@ -1213,7 +1213,7 @@ Namespace AdventureWorksModel
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_PurchaseOrderDetail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID")>  _
         Public ReadOnly Property PurchaseOrderDetails() As EntityCollection(Of PurchaseOrderDetail)
             Get
                 If (Me._purchaseOrderDetails Is Nothing) Then
@@ -1567,7 +1567,7 @@ Namespace AdventureWorksModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="Employee"/> entity.
         ''' </summary>
-        <EntityAssociation("Employee_PurchaseOrder", New String() {"EmployeeID"}, New String() {"EmployeeID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID", IsForeignKey:=true)>  _
         Public Property Employee() As Employee
             Get
                 If (Me._employee Is Nothing) Then
@@ -1685,7 +1685,7 @@ Namespace AdventureWorksModel
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", New String() {"PurchaseOrderID"}, New String() {"PurchaseOrderID"})>  _
+        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID")>  _
         Public ReadOnly Property PurchaseOrderDetails() As EntityCollection(Of PurchaseOrderDetail)
             Get
                 If (Me._purchaseOrderDetails Is Nothing) Then
@@ -2096,7 +2096,7 @@ Namespace AdventureWorksModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_PurchaseOrderDetail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -2151,7 +2151,7 @@ Namespace AdventureWorksModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="PurchaseOrder"/> entity.
         ''' </summary>
-        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", New String() {"PurchaseOrderID"}, New String() {"PurchaseOrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID", IsForeignKey:=true)>  _
         Public Property PurchaseOrder() As PurchaseOrder
             Get
                 If (Me._purchaseOrder Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EFCore.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EFCore.g.cs
@@ -291,9 +291,7 @@ namespace EFCoreModels.AdventureWorks
         /// <summary>
         /// Gets or sets the associated <see cref="Employee"/> entity.
         /// </summary>
-        [EntityAssociation("FK_Employee_Employee_ManagerID", new string[] {
-                "ManagerID"}, new string[] {
-                "EmployeeID"}, IsForeignKey=true)]
+        [EntityAssociation("FK_Employee_Employee_ManagerID", "ManagerID", "EmployeeID", IsForeignKey=true)]
         public Employee Manager
         {
             get
@@ -1185,9 +1183,7 @@ namespace EFCoreModels.AdventureWorks
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         /// </summary>
-        [EntityAssociation("FK_PurchaseOrderDetail_Product_ProductID", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("FK_PurchaseOrderDetail_Product_ProductID", "ProductID", "ProductID")]
         public EntityCollection<PurchaseOrderDetail> PurchaseOrderDetails
         {
             get
@@ -1649,9 +1645,7 @@ namespace EFCoreModels.AdventureWorks
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         /// </summary>
-        [EntityAssociation("FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", new string[] {
-                "PurchaseOrderID"}, new string[] {
-                "PurchaseOrderID"})]
+        [EntityAssociation("FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", "PurchaseOrderID", "PurchaseOrderID")]
         public EntityCollection<PurchaseOrderDetail> PurchaseOrderDetails
         {
             get
@@ -2080,9 +2074,7 @@ namespace EFCoreModels.AdventureWorks
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("FK_PurchaseOrderDetail_Product_ProductID", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("FK_PurchaseOrderDetail_Product_ProductID", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -2150,9 +2142,7 @@ namespace EFCoreModels.AdventureWorks
         /// <summary>
         /// Gets or sets the associated <see cref="PurchaseOrder"/> entity.
         /// </summary>
-        [EntityAssociation("FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", new string[] {
-                "PurchaseOrderID"}, new string[] {
-                "PurchaseOrderID"}, IsForeignKey=true)]
+        [EntityAssociation("FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", "PurchaseOrderID", "PurchaseOrderID", IsForeignKey=true)]
         public PurchaseOrder PurchaseOrder
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EFCore.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EFCore.g.vb
@@ -307,7 +307,7 @@ Namespace EFCoreModels.AdventureWorks
         ''' <summary>
         ''' Gets or sets the associated <see cref="Employee"/> entity.
         ''' </summary>
-        <EntityAssociation("FK_Employee_Employee_ManagerID", New String() {"ManagerID"}, New String() {"EmployeeID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("FK_Employee_Employee_ManagerID", "ManagerID", "EmployeeID", IsForeignKey:=true)>  _
         Public Property Manager() As Employee
             Get
                 If (Me._manager Is Nothing) Then
@@ -1151,7 +1151,7 @@ Namespace EFCoreModels.AdventureWorks
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("FK_PurchaseOrderDetail_Product_ProductID", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("FK_PurchaseOrderDetail_Product_ProductID", "ProductID", "ProductID")>  _
         Public ReadOnly Property PurchaseOrderDetails() As EntityCollection(Of PurchaseOrderDetail)
             Get
                 If (Me._purchaseOrderDetails Is Nothing) Then
@@ -1585,7 +1585,7 @@ Namespace EFCoreModels.AdventureWorks
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", New String() {"PurchaseOrderID"}, New String() {"PurchaseOrderID"})>  _
+        <EntityAssociation("FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", "PurchaseOrderID", "PurchaseOrderID")>  _
         Public ReadOnly Property PurchaseOrderDetails() As EntityCollection(Of PurchaseOrderDetail)
             Get
                 If (Me._purchaseOrderDetails Is Nothing) Then
@@ -1990,7 +1990,7 @@ Namespace EFCoreModels.AdventureWorks
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("FK_PurchaseOrderDetail_Product_ProductID", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("FK_PurchaseOrderDetail_Product_ProductID", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -2045,7 +2045,7 @@ Namespace EFCoreModels.AdventureWorks
         ''' <summary>
         ''' Gets or sets the associated <see cref="PurchaseOrder"/> entity.
         ''' </summary>
-        <EntityAssociation("FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", New String() {"PurchaseOrderID"}, New String() {"PurchaseOrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("FK_PurchaseOrderDetail_PurchaseOrderHeader_PurchaseOrderID", "PurchaseOrderID", "PurchaseOrderID", IsForeignKey:=true)>  _
         Public Property PurchaseOrder() As PurchaseOrder
             Get
                 If (Me._purchaseOrder Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EFDbCtx.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EFDbCtx.g.cs
@@ -295,9 +295,7 @@ namespace DbContextModels.AdventureWorks
         /// <summary>
         /// Gets or sets the associated <see cref="Employee"/> entity.
         /// </summary>
-        [EntityAssociation("Employee_Employee", new string[] {
-                "ManagerID"}, new string[] {
-                "EmployeeID"}, IsForeignKey=true)]
+        [EntityAssociation("Employee_Employee", "ManagerID", "EmployeeID", IsForeignKey=true)]
         public Employee Manager
         {
             get
@@ -441,9 +439,7 @@ namespace DbContextModels.AdventureWorks
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrder"/> entity instances.
         /// </summary>
-        [EntityAssociation("Employee_PurchaseOrder", new string[] {
-                "EmployeeID"}, new string[] {
-                "EmployeeID"})]
+        [EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID")]
         public EntityCollection<PurchaseOrder> PurchaseOrders
         {
             get
@@ -459,9 +455,7 @@ namespace DbContextModels.AdventureWorks
         /// <summary>
         /// Gets the collection of associated <see cref="Employee"/> entity instances.
         /// </summary>
-        [EntityAssociation("Employee_Employee", new string[] {
-                "EmployeeID"}, new string[] {
-                "ManagerID"})]
+        [EntityAssociation("Employee_Employee", "EmployeeID", "ManagerID")]
         public EntityCollection<Employee> Reports
         {
             get
@@ -1265,9 +1259,7 @@ namespace DbContextModels.AdventureWorks
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_PurchaseOrderDetail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID")]
         public EntityCollection<PurchaseOrderDetail> PurchaseOrderDetails
         {
             get
@@ -1637,9 +1629,7 @@ namespace DbContextModels.AdventureWorks
         /// <summary>
         /// Gets or sets the associated <see cref="Employee"/> entity.
         /// </summary>
-        [EntityAssociation("Employee_PurchaseOrder", new string[] {
-                "EmployeeID"}, new string[] {
-                "EmployeeID"}, IsForeignKey=true)]
+        [EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID", IsForeignKey=true)]
         public Employee Employee
         {
             get
@@ -1779,9 +1769,7 @@ namespace DbContextModels.AdventureWorks
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         /// </summary>
-        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", new string[] {
-                "PurchaseOrderID"}, new string[] {
-                "PurchaseOrderID"})]
+        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID")]
         public EntityCollection<PurchaseOrderDetail> PurchaseOrderDetails
         {
             get
@@ -2217,9 +2205,7 @@ namespace DbContextModels.AdventureWorks
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_PurchaseOrderDetail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -2287,9 +2273,7 @@ namespace DbContextModels.AdventureWorks
         /// <summary>
         /// Gets or sets the associated <see cref="PurchaseOrder"/> entity.
         /// </summary>
-        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", new string[] {
-                "PurchaseOrderID"}, new string[] {
-                "PurchaseOrderID"}, IsForeignKey=true)]
+        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID", IsForeignKey=true)]
         public PurchaseOrder PurchaseOrder
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EFDbCtx.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Catalog_EFDbCtx.g.vb
@@ -311,7 +311,7 @@ Namespace DbContextModels.AdventureWorks
         ''' <summary>
         ''' Gets or sets the associated <see cref="Employee"/> entity.
         ''' </summary>
-        <EntityAssociation("Employee_Employee", New String() {"ManagerID"}, New String() {"EmployeeID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Employee_Employee", "ManagerID", "EmployeeID", IsForeignKey:=true)>  _
         Public Property Manager() As Employee
             Get
                 If (Me._manager Is Nothing) Then
@@ -430,7 +430,7 @@ Namespace DbContextModels.AdventureWorks
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrder"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Employee_PurchaseOrder", New String() {"EmployeeID"}, New String() {"EmployeeID"})>  _
+        <EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID")>  _
         Public ReadOnly Property PurchaseOrders() As EntityCollection(Of PurchaseOrder)
             Get
                 If (Me._purchaseOrders Is Nothing) Then
@@ -443,7 +443,7 @@ Namespace DbContextModels.AdventureWorks
         ''' <summary>
         ''' Gets the collection of associated <see cref="Employee"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Employee_Employee", New String() {"EmployeeID"}, New String() {"ManagerID"})>  _
+        <EntityAssociation("Employee_Employee", "EmployeeID", "ManagerID")>  _
         Public ReadOnly Property Reports() As EntityCollection(Of Employee)
             Get
                 If (Me._reports Is Nothing) Then
@@ -1213,7 +1213,7 @@ Namespace DbContextModels.AdventureWorks
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_PurchaseOrderDetail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID")>  _
         Public ReadOnly Property PurchaseOrderDetails() As EntityCollection(Of PurchaseOrderDetail)
             Get
                 If (Me._purchaseOrderDetails Is Nothing) Then
@@ -1567,7 +1567,7 @@ Namespace DbContextModels.AdventureWorks
         ''' <summary>
         ''' Gets or sets the associated <see cref="Employee"/> entity.
         ''' </summary>
-        <EntityAssociation("Employee_PurchaseOrder", New String() {"EmployeeID"}, New String() {"EmployeeID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID", IsForeignKey:=true)>  _
         Public Property Employee() As Employee
             Get
                 If (Me._employee Is Nothing) Then
@@ -1685,7 +1685,7 @@ Namespace DbContextModels.AdventureWorks
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", New String() {"PurchaseOrderID"}, New String() {"PurchaseOrderID"})>  _
+        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID")>  _
         Public ReadOnly Property PurchaseOrderDetails() As EntityCollection(Of PurchaseOrderDetail)
             Get
                 If (Me._purchaseOrderDetails Is Nothing) Then
@@ -2096,7 +2096,7 @@ Namespace DbContextModels.AdventureWorks
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_PurchaseOrderDetail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -2151,7 +2151,7 @@ Namespace DbContextModels.AdventureWorks
         ''' <summary>
         ''' Gets or sets the associated <see cref="PurchaseOrder"/> entity.
         ''' </summary>
-        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", New String() {"PurchaseOrderID"}, New String() {"PurchaseOrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID", IsForeignKey:=true)>  _
         Public Property PurchaseOrder() As PurchaseOrder
             Get
                 If (Me._purchaseOrder Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EF.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EF.g.cs
@@ -169,9 +169,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID")]
         public EntityCollection<Product> Products
         {
             get
@@ -503,9 +501,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID")]
         public EntityCollection<Order> Orders
         {
             get
@@ -717,9 +713,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer Customer
         {
             get
@@ -866,9 +860,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -1283,9 +1275,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public Order Order
         {
             get
@@ -1355,9 +1345,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -1583,9 +1571,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public Category Category
         {
             get
@@ -1705,9 +1691,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -2286,9 +2270,7 @@ namespace NorthwindModel
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID")]
         public EntityCollection<Territory> Territories
         {
             get
@@ -2369,9 +2351,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EF.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EF.g.vb
@@ -169,7 +169,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As EntityCollection(Of Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -485,7 +485,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As EntityCollection(Of Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -709,7 +709,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -830,7 +830,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1202,7 +1202,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1259,7 +1259,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1492,7 +1492,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1591,7 +1591,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2109,7 +2109,7 @@ Namespace NorthwindModel
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         EntityAssociation("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As EntityCollection(Of Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2190,7 +2190,7 @@ Namespace NorthwindModel
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EFCore.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EFCore.g.cs
@@ -169,9 +169,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID")]
         public EntityCollection<Product> Products
         {
             get
@@ -503,9 +501,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID")]
         public EntityCollection<Order> Orders
         {
             get
@@ -717,9 +713,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer Customer
         {
             get
@@ -866,9 +860,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -1283,9 +1275,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public Order Order
         {
             get
@@ -1355,9 +1345,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -1583,9 +1571,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public Category Category
         {
             get
@@ -1705,9 +1691,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -2286,9 +2270,7 @@ namespace EFCoreModels.Northwind
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID")]
         public EntityCollection<Territory> Territories
         {
             get
@@ -2369,9 +2351,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EFCore.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EFCore.g.vb
@@ -169,7 +169,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As EntityCollection(Of Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -485,7 +485,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As EntityCollection(Of Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -709,7 +709,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -830,7 +830,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1202,7 +1202,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1259,7 +1259,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1492,7 +1492,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1591,7 +1591,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2109,7 +2109,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         EntityAssociation("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As EntityCollection(Of Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2190,7 +2190,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/LTS/Catalog_LTS.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/LTS/Catalog_LTS.g.cs
@@ -308,9 +308,7 @@ namespace DataTests.AdventureWorks.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Employee"/> entity.
         /// </summary>
-        [EntityAssociation("Employee_Employee", new string[] {
-                "ManagerID"}, new string[] {
-                "EmployeeID"}, IsForeignKey=true)]
+        [EntityAssociation("Employee_Employee", "ManagerID", "EmployeeID", IsForeignKey=true)]
         public Employee Manager
         {
             get
@@ -461,9 +459,7 @@ namespace DataTests.AdventureWorks.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrder"/> entity instances.
         /// </summary>
-        [EntityAssociation("Employee_PurchaseOrder", new string[] {
-                "EmployeeID"}, new string[] {
-                "EmployeeID"})]
+        [EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID")]
         public EntityCollection<PurchaseOrder> PurchaseOrders
         {
             get
@@ -479,9 +475,7 @@ namespace DataTests.AdventureWorks.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Employee"/> entity instances.
         /// </summary>
-        [EntityAssociation("Employee_Employee", new string[] {
-                "EmployeeID"}, new string[] {
-                "ManagerID"})]
+        [EntityAssociation("Employee_Employee", "EmployeeID", "ManagerID")]
         public EntityCollection<Employee> Reports
         {
             get
@@ -1170,9 +1164,7 @@ namespace DataTests.AdventureWorks.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_PurchaseOrderDetail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID")]
         public EntityCollection<PurchaseOrderDetail> PurchaseOrderDetails
         {
             get
@@ -1559,9 +1551,7 @@ namespace DataTests.AdventureWorks.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Employee"/> entity.
         /// </summary>
-        [EntityAssociation("Employee_PurchaseOrder", new string[] {
-                "EmployeeID"}, new string[] {
-                "EmployeeID"}, IsForeignKey=true)]
+        [EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID", IsForeignKey=true)]
         public Employee Employee
         {
             get
@@ -1708,9 +1698,7 @@ namespace DataTests.AdventureWorks.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         /// </summary>
-        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", new string[] {
-                "PurchaseOrderID"}, new string[] {
-                "PurchaseOrderID"})]
+        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID")]
         public EntityCollection<PurchaseOrderDetail> PurchaseOrderDetails
         {
             get
@@ -2167,9 +2155,7 @@ namespace DataTests.AdventureWorks.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_PurchaseOrderDetail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -2238,9 +2224,7 @@ namespace DataTests.AdventureWorks.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="PurchaseOrder"/> entity.
         /// </summary>
-        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", new string[] {
-                "PurchaseOrderID"}, new string[] {
-                "PurchaseOrderID"}, IsForeignKey=true)]
+        [EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID", IsForeignKey=true)]
         public PurchaseOrder PurchaseOrder
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/LTS/Catalog_LTS.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/LTS/Catalog_LTS.g.vb
@@ -324,7 +324,7 @@ Namespace DataTests.AdventureWorks.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="Employee"/> entity.
         ''' </summary>
-        <EntityAssociation("Employee_Employee", New String() {"ManagerID"}, New String() {"EmployeeID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Employee_Employee", "ManagerID", "EmployeeID", IsForeignKey:=true)>  _
         Public Property Manager() As Employee
             Get
                 If (Me._manager Is Nothing) Then
@@ -450,7 +450,7 @@ Namespace DataTests.AdventureWorks.LTS
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrder"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Employee_PurchaseOrder", New String() {"EmployeeID"}, New String() {"EmployeeID"})>  _
+        <EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID")>  _
         Public ReadOnly Property PurchaseOrders() As EntityCollection(Of PurchaseOrder)
             Get
                 If (Me._purchaseOrders Is Nothing) Then
@@ -463,7 +463,7 @@ Namespace DataTests.AdventureWorks.LTS
         ''' <summary>
         ''' Gets the collection of associated <see cref="Employee"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Employee_Employee", New String() {"EmployeeID"}, New String() {"ManagerID"})>  _
+        <EntityAssociation("Employee_Employee", "EmployeeID", "ManagerID")>  _
         Public ReadOnly Property Reports() As EntityCollection(Of Employee)
             Get
                 If (Me._reports Is Nothing) Then
@@ -1124,7 +1124,7 @@ Namespace DataTests.AdventureWorks.LTS
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_PurchaseOrderDetail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID")>  _
         Public ReadOnly Property PurchaseOrderDetails() As EntityCollection(Of PurchaseOrderDetail)
             Get
                 If (Me._purchaseOrderDetails Is Nothing) Then
@@ -1495,7 +1495,7 @@ Namespace DataTests.AdventureWorks.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="Employee"/> entity.
         ''' </summary>
-        <EntityAssociation("Employee_PurchaseOrder", New String() {"EmployeeID"}, New String() {"EmployeeID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Employee_PurchaseOrder", "EmployeeID", "EmployeeID", IsForeignKey:=true)>  _
         Public Property Employee() As Employee
             Get
                 If (Me._employee Is Nothing) Then
@@ -1620,7 +1620,7 @@ Namespace DataTests.AdventureWorks.LTS
         ''' <summary>
         ''' Gets the collection of associated <see cref="PurchaseOrderDetail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", New String() {"PurchaseOrderID"}, New String() {"PurchaseOrderID"})>  _
+        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID")>  _
         Public ReadOnly Property PurchaseOrderDetails() As EntityCollection(Of PurchaseOrderDetail)
             Get
                 If (Me._purchaseOrderDetails Is Nothing) Then
@@ -2052,7 +2052,7 @@ Namespace DataTests.AdventureWorks.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_PurchaseOrderDetail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_PurchaseOrderDetail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -2108,7 +2108,7 @@ Namespace DataTests.AdventureWorks.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="PurchaseOrder"/> entity.
         ''' </summary>
-        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", New String() {"PurchaseOrderID"}, New String() {"PurchaseOrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("PurchaseOrder_PurchaseOrderDetail", "PurchaseOrderID", "PurchaseOrderID", IsForeignKey:=true)>  _
         Public Property PurchaseOrder() As PurchaseOrder
             Get
                 If (Me._purchaseOrder Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/LTS/Northwind_LTS.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/LTS/Northwind_LTS.g.cs
@@ -173,9 +173,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID")]
         public EntityCollection<Product> Products
         {
             get
@@ -507,9 +505,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID")]
         public EntityCollection<Order> Orders
         {
             get
@@ -721,9 +717,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer Customer
         {
             get
@@ -871,9 +865,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -1288,9 +1280,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public Order Order
         {
             get
@@ -1360,9 +1350,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -1588,9 +1576,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public Category Category
         {
             get
@@ -1710,9 +1696,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -2295,9 +2279,7 @@ namespace DataTests.Northwind.LTS
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID")]
         public EntityCollection<Territory> Territories
         {
             get
@@ -2378,9 +2360,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/LTS/Northwind_LTS.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/LTS/Northwind_LTS.g.vb
@@ -173,7 +173,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As EntityCollection(Of Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -489,7 +489,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As EntityCollection(Of Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -713,7 +713,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -835,7 +835,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1207,7 +1207,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1264,7 +1264,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1497,7 +1497,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1596,7 +1596,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2118,7 +2118,7 @@ Namespace DataTests.Northwind.LTS
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         EntityAssociation("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As EntityCollection(Of Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2199,7 +2199,7 @@ Namespace DataTests.Northwind.LTS
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.cs
@@ -159,9 +159,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="City"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_PreviousResidences", new string[] {
-                "StateName"}, new string[] {
-                "StateName"})]
+        [EntityAssociation("Customer_PreviousResidences", "StateName", "StateName")]
         [ExternalReference()]
         public EntityCollection<global::Cities.City> PreviousResidences
         {
@@ -501,9 +499,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="MockCustomer"/> entity.
         /// </summary>
-        [EntityAssociation("R_C", new string[] {
-                "CustomerId"}, new string[] {
-                "CustomerId"})]
+        [EntityAssociation("R_C", "CustomerId", "CustomerId")]
         public MockCustomer Customer
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.vb
@@ -153,7 +153,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="City"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_PreviousResidences", New String() {"StateName"}, New String() {"StateName"}),  _
+        <EntityAssociation("Customer_PreviousResidences", "StateName", "StateName"),  _
          ExternalReference()>  _
         Public ReadOnly Property PreviousResidences() As EntityCollection(Of Global.Cities.City)
             Get
@@ -480,7 +480,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="MockCustomer"/> entity.
         ''' </summary>
-        <EntityAssociation("R_C", New String() {"CustomerId"}, New String() {"CustomerId"})>  _
+        <EntityAssociation("R_C", "CustomerId", "CustomerId")>  _
         Public Property Customer() As MockCustomer
             Get
                 If (Me._customer Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/AttributeThrowing.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/AttributeThrowing.g.cs
@@ -336,9 +336,7 @@ namespace TestDomainServices
         // 
         // - An exception occurred generating the 'ThrowingEntityAssociationAttributeProperty' property on attribute of type 'TestDomainServices.ThrowingEntityAssociationAttribute'.
         // 
-        [EntityAssociation("Association", new string[] {
-                "ThrowingProperty"}, new string[] {
-                "NonThrowingProperty"}, IsForeignKey=true)]
+        [EntityAssociation("Association", "ThrowingProperty", "NonThrowingProperty", IsForeignKey=true)]
         public AttributeThrowingEntity ThrowingAssociation
         {
             get
@@ -376,9 +374,7 @@ namespace TestDomainServices
         // 
         // - An exception occurred generating the 'ThrowingEntityAssociationCollectionAttributeProperty' property on attribute of type 'TestDomainServices.ThrowingEntityAssociationCollectionAttribute'.
         // 
-        [EntityAssociation("AssociationCollection", new string[] {
-                "NonThrowingProperty"}, new string[] {
-                "ThrowingProperty"})]
+        [EntityAssociation("AssociationCollection", "NonThrowingProperty", "ThrowingProperty")]
         public EntityCollection<AttributeThrowingEntity> ThrowingAssociationCollection
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/AttributeThrowing.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/AttributeThrowing.g.vb
@@ -332,7 +332,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="AttributeThrowingEntity"/> entity.
         ''' </summary>
-        <EntityAssociation("Association", New String() {"ThrowingProperty"}, New String() {"NonThrowingProperty"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Association", "ThrowingProperty", "NonThrowingProperty", IsForeignKey:=true)>  _
         Public Property ThrowingAssociation() As AttributeThrowingEntity
             Get
                 If (Me._throwingAssociation Is Nothing) Then
@@ -362,7 +362,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="AttributeThrowingEntity"/> entity instances.
         ''' </summary>
-        <EntityAssociation("AssociationCollection", New String() {"NonThrowingProperty"}, New String() {"ThrowingProperty"})>  _
+        <EntityAssociation("AssociationCollection", "NonThrowingProperty", "ThrowingProperty")>  _
         Public ReadOnly Property ThrowingAssociationCollection() As EntityCollection(Of AttributeThrowingEntity)
             Get
                 If (Me._throwingAssociationCollection Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/CompositionInheritanceScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/CompositionInheritanceScenarios.g.cs
@@ -151,9 +151,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="AI_MasterDerived"/> entity.
         /// </summary>
-        [EntityAssociation("Master_to_Derived1_Many", new string[] {
-                "MasterID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Master_to_Derived1_Many", "MasterID", "ID", IsForeignKey=true)]
         public AI_MasterDerived Master
         {
             get
@@ -230,9 +228,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="AI_MasterDerived"/> entity.
         /// </summary>
-        [EntityAssociation("Master_to_Derived2_Many", new string[] {
-                "MasterID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Master_to_Derived2_Many", "MasterID", "ID", IsForeignKey=true)]
         public AI_MasterDerived Master
         {
             get
@@ -309,9 +305,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="AI_MasterDerived"/> entity.
         /// </summary>
-        [EntityAssociation("Master_to_Derived3_One", new string[] {
-                "MasterID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Master_to_Derived3_One", "MasterID", "ID", IsForeignKey=true)]
         public AI_MasterDerived Master
         {
             get
@@ -388,9 +382,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="AI_MasterDerived"/> entity.
         /// </summary>
-        [EntityAssociation("Master_to_Derived4_One", new string[] {
-                "MasterID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Master_to_Derived4_One", "MasterID", "ID", IsForeignKey=true)]
         public AI_MasterDerived Master
         {
             get
@@ -540,9 +532,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="AI_DetailDerived1"/> entity instances.
         /// </summary>
-        [EntityAssociation("Master_to_Derived1_Many", new string[] {
-                "ID"}, new string[] {
-                "MasterID"})]
+        [EntityAssociation("Master_to_Derived1_Many", "ID", "MasterID")]
         public EntityCollection<AI_DetailDerived1> DetailDerived1s
         {
             get
@@ -558,9 +548,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="AI_DetailDerived2"/> entity instances.
         /// </summary>
-        [EntityAssociation("Master_to_Derived2_Many", new string[] {
-                "ID"}, new string[] {
-                "MasterID"})]
+        [EntityAssociation("Master_to_Derived2_Many", "ID", "MasterID")]
         public EntityCollection<AI_DetailDerived2> DetailDerived2s
         {
             get
@@ -576,9 +564,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="AI_DetailDerived3"/> entity.
         /// </summary>
-        [EntityAssociation("Master_to_Derived3_One", new string[] {
-                "ID"}, new string[] {
-                "MasterID"})]
+        [EntityAssociation("Master_to_Derived3_One", "ID", "MasterID")]
         public AI_DetailDerived3 DetailDerived3
         {
             get
@@ -613,9 +599,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="AI_DetailDerived4"/> entity.
         /// </summary>
-        [EntityAssociation("Master_to_Derived4_One", new string[] {
-                "ID"}, new string[] {
-                "MasterID"})]
+        [EntityAssociation("Master_to_Derived4_One", "ID", "MasterID")]
         public AI_DetailDerived4 DetailDerived4
         {
             get
@@ -1045,9 +1029,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="CI_Parent"/> entity.
         /// </summary>
-        [EntityAssociation("Child_Parent", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Child_Parent", "ParentID", "ID", IsForeignKey=true)]
         public CI_Parent Parent
         {
             get
@@ -1233,9 +1215,7 @@ namespace TestDomainServices
         /// Gets the collection of associated <see cref="CI_Child"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Child_Parent", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [EntityAssociation("Child_Parent", "ID", "ParentID")]
         public EntityCollection<CI_Child> Children
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/CompositionInheritanceScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/CompositionInheritanceScenarios.g.vb
@@ -154,7 +154,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="AI_MasterDerived"/> entity.
         ''' </summary>
-        <EntityAssociation("Master_to_Derived1_Many", New String() {"MasterID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Master_to_Derived1_Many", "MasterID", "ID", IsForeignKey:=true)>  _
         Public Property Master() As AI_MasterDerived
             Get
                 If (Me._master Is Nothing) Then
@@ -221,7 +221,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="AI_MasterDerived"/> entity.
         ''' </summary>
-        <EntityAssociation("Master_to_Derived2_Many", New String() {"MasterID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Master_to_Derived2_Many", "MasterID", "ID", IsForeignKey:=true)>  _
         Public Property Master() As AI_MasterDerived
             Get
                 If (Me._master Is Nothing) Then
@@ -288,7 +288,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="AI_MasterDerived"/> entity.
         ''' </summary>
-        <EntityAssociation("Master_to_Derived3_One", New String() {"MasterID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Master_to_Derived3_One", "MasterID", "ID", IsForeignKey:=true)>  _
         Public Property Master() As AI_MasterDerived
             Get
                 If (Me._master Is Nothing) Then
@@ -355,7 +355,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="AI_MasterDerived"/> entity.
         ''' </summary>
-        <EntityAssociation("Master_to_Derived4_One", New String() {"MasterID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Master_to_Derived4_One", "MasterID", "ID", IsForeignKey:=true)>  _
         Public Property Master() As AI_MasterDerived
             Get
                 If (Me._master Is Nothing) Then
@@ -494,7 +494,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="AI_DetailDerived1"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Master_to_Derived1_Many", New String() {"ID"}, New String() {"MasterID"})>  _
+        <EntityAssociation("Master_to_Derived1_Many", "ID", "MasterID")>  _
         Public ReadOnly Property DetailDerived1s() As EntityCollection(Of AI_DetailDerived1)
             Get
                 If (Me._detailDerived1s Is Nothing) Then
@@ -507,7 +507,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="AI_DetailDerived2"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Master_to_Derived2_Many", New String() {"ID"}, New String() {"MasterID"})>  _
+        <EntityAssociation("Master_to_Derived2_Many", "ID", "MasterID")>  _
         Public ReadOnly Property DetailDerived2s() As EntityCollection(Of AI_DetailDerived2)
             Get
                 If (Me._detailDerived2s Is Nothing) Then
@@ -520,7 +520,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="AI_DetailDerived3"/> entity.
         ''' </summary>
-        <EntityAssociation("Master_to_Derived3_One", New String() {"ID"}, New String() {"MasterID"})>  _
+        <EntityAssociation("Master_to_Derived3_One", "ID", "MasterID")>  _
         Public Property DetailDerived3() As AI_DetailDerived3
             Get
                 If (Me._detailDerived3 Is Nothing) Then
@@ -548,7 +548,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="AI_DetailDerived4"/> entity.
         ''' </summary>
-        <EntityAssociation("Master_to_Derived4_One", New String() {"ID"}, New String() {"MasterID"})>  _
+        <EntityAssociation("Master_to_Derived4_One", "ID", "MasterID")>  _
         Public Property DetailDerived4() As AI_DetailDerived4
             Get
                 If (Me._detailDerived4 Is Nothing) Then
@@ -954,7 +954,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="CI_Parent"/> entity.
         ''' </summary>
-        <EntityAssociation("Child_Parent", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Child_Parent", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As CI_Parent
             Get
                 If (Me._parent Is Nothing) Then
@@ -1125,7 +1125,7 @@ Namespace TestDomainServices
         ''' Gets the collection of associated <see cref="CI_Child"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Child_Parent", New String() {"ID"}, New String() {"ParentID"})>  _
+         EntityAssociation("Child_Parent", "ID", "ParentID")>  _
         Public ReadOnly Property Children() As EntityCollection(Of CI_Child)
             Get
                 If (Me._children Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/CompositionScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/CompositionScenarios.g.cs
@@ -74,9 +74,7 @@ namespace TestDomainServices
         /// Gets the collection of associated <see cref="GrandChild"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("GrandChild_Child", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [EntityAssociation("GrandChild_Child", "ID", "ParentID")]
         public EntityCollection<GrandChild> Children
         {
             get
@@ -142,9 +140,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="Parent"/> entity.
         /// </summary>
-        [EntityAssociation("Child_Parent", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Child_Parent", "ParentID", "ID", IsForeignKey=true)]
         public Parent Parent
         {
             get
@@ -391,9 +387,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="CompositionScenarios_Parent"/> entity.
         /// </summary>
-        [EntityAssociation("Parent_Child", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Parent_Child", "ParentID", "ID", IsForeignKey=true)]
         public CompositionScenarios_Parent Parent
         {
             get
@@ -702,9 +696,7 @@ namespace TestDomainServices
         /// Gets the collection of associated <see cref="CompositionScenarios_Child"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Parent_Child", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [EntityAssociation("Parent_Child", "ID", "ParentID")]
         public EntityCollection<CompositionScenarios_Child> Children
         {
             get
@@ -1059,9 +1051,7 @@ namespace TestDomainServices
         /// Gets or sets the associated <see cref="GreatGrandChild"/> entity.
         /// </summary>
         [Composition()]
-        [EntityAssociation("GreatGrandChild_GrandChild", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [EntityAssociation("GreatGrandChild_GrandChild", "ID", "ParentID")]
         public GreatGrandChild Child
         {
             get
@@ -1146,9 +1136,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="Child"/> entity.
         /// </summary>
-        [EntityAssociation("GrandChild_Child", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("GrandChild_Child", "ParentID", "ID", IsForeignKey=true)]
         public Child Parent
         {
             get
@@ -1391,9 +1379,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="GrandChild"/> entity.
         /// </summary>
-        [EntityAssociation("GreatGrandChild_GrandChild", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("GreatGrandChild_GrandChild", "ParentID", "ID", IsForeignKey=true)]
         public GrandChild Parent
         {
             get
@@ -1578,9 +1564,7 @@ namespace TestDomainServices
         /// Gets the collection of associated <see cref="Child"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Child_Parent", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [EntityAssociation("Child_Parent", "ID", "ParentID")]
         public EntityCollection<Child> Children
         {
             get
@@ -1773,9 +1757,7 @@ namespace TestDomainServices
         /// Gets or sets the associated <see cref="SelfReferencingComposition"/> entity.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Ref_Assoc", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [EntityAssociation("Ref_Assoc", "ID", "ParentID")]
         public SelfReferencingComposition Child
         {
             get
@@ -1836,9 +1818,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="SelfReferencingComposition"/> entity.
         /// </summary>
-        [EntityAssociation("Ref_Assoc", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Ref_Assoc", "ParentID", "ID", IsForeignKey=true)]
         public SelfReferencingComposition Parent
         {
             get
@@ -1993,9 +1973,7 @@ namespace TestDomainServices
         /// Gets the collection of associated <see cref="SelfReferencingComposition_OneToMany"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("SelfReferencingComposition_OneToMany", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [EntityAssociation("SelfReferencingComposition_OneToMany", "ID", "ParentID")]
         public EntityCollection<SelfReferencingComposition_OneToMany> Children
         {
             get
@@ -2037,9 +2015,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="SelfReferencingComposition_OneToMany"/> entity.
         /// </summary>
-        [EntityAssociation("SelfReferencingComposition_OneToMany", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("SelfReferencingComposition_OneToMany", "ParentID", "ID", IsForeignKey=true)]
         public SelfReferencingComposition_OneToMany Parent
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/CompositionScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/CompositionScenarios.g.vb
@@ -89,7 +89,7 @@ Namespace TestDomainServices
         ''' Gets the collection of associated <see cref="GrandChild"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("GrandChild_Child", New String() {"ID"}, New String() {"ParentID"})>  _
+         EntityAssociation("GrandChild_Child", "ID", "ParentID")>  _
         Public ReadOnly Property Children() As EntityCollection(Of GrandChild)
             Get
                 If (Me._children Is Nothing) Then
@@ -145,7 +145,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="Parent"/> entity.
         ''' </summary>
-        <EntityAssociation("Child_Parent", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Child_Parent", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As Parent
             Get
                 If (Me._parent Is Nothing) Then
@@ -365,7 +365,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="CompositionScenarios_Parent"/> entity.
         ''' </summary>
-        <EntityAssociation("Parent_Child", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Parent_Child", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As CompositionScenarios_Parent
             Get
                 If (Me._parent Is Nothing) Then
@@ -649,7 +649,7 @@ Namespace TestDomainServices
         ''' Gets the collection of associated <see cref="CompositionScenarios_Child"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Parent_Child", New String() {"ID"}, New String() {"ParentID"})>  _
+         EntityAssociation("Parent_Child", "ID", "ParentID")>  _
         Public ReadOnly Property Children() As EntityCollection(Of CompositionScenarios_Child)
             Get
                 If (Me._children Is Nothing) Then
@@ -991,7 +991,7 @@ Namespace TestDomainServices
         ''' Gets or sets the associated <see cref="GreatGrandChild"/> entity.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("GreatGrandChild_GrandChild", New String() {"ID"}, New String() {"ParentID"})>  _
+         EntityAssociation("GreatGrandChild_GrandChild", "ID", "ParentID")>  _
         Public Property Child() As GreatGrandChild
             Get
                 If (Me._child Is Nothing) Then
@@ -1062,7 +1062,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="Child"/> entity.
         ''' </summary>
-        <EntityAssociation("GrandChild_Child", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("GrandChild_Child", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As Child
             Get
                 If (Me._parent Is Nothing) Then
@@ -1284,7 +1284,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="GrandChild"/> entity.
         ''' </summary>
-        <EntityAssociation("GreatGrandChild_GrandChild", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("GreatGrandChild_GrandChild", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As GrandChild
             Get
                 If (Me._parent Is Nothing) Then
@@ -1454,7 +1454,7 @@ Namespace TestDomainServices
         ''' Gets the collection of associated <see cref="Child"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Child_Parent", New String() {"ID"}, New String() {"ParentID"})>  _
+         EntityAssociation("Child_Parent", "ID", "ParentID")>  _
         Public ReadOnly Property Children() As EntityCollection(Of Child)
             Get
                 If (Me._children Is Nothing) Then
@@ -1631,7 +1631,7 @@ Namespace TestDomainServices
         ''' Gets or sets the associated <see cref="SelfReferencingComposition"/> entity.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Ref_Assoc", New String() {"ID"}, New String() {"ParentID"})>  _
+         EntityAssociation("Ref_Assoc", "ID", "ParentID")>  _
         Public Property Child() As SelfReferencingComposition
             Get
                 If (Me._child Is Nothing) Then
@@ -1682,7 +1682,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="SelfReferencingComposition"/> entity.
         ''' </summary>
-        <EntityAssociation("Ref_Assoc", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Ref_Assoc", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As SelfReferencingComposition
             Get
                 If (Me._parent Is Nothing) Then
@@ -1824,7 +1824,7 @@ Namespace TestDomainServices
         ''' Gets the collection of associated <see cref="SelfReferencingComposition_OneToMany"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("SelfReferencingComposition_OneToMany", New String() {"ID"}, New String() {"ParentID"})>  _
+         EntityAssociation("SelfReferencingComposition_OneToMany", "ID", "ParentID")>  _
         Public ReadOnly Property Children() As EntityCollection(Of SelfReferencingComposition_OneToMany)
             Get
                 If (Me._children Is Nothing) Then
@@ -1860,7 +1860,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="SelfReferencingComposition_OneToMany"/> entity.
         ''' </summary>
-        <EntityAssociation("SelfReferencingComposition_OneToMany", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("SelfReferencingComposition_OneToMany", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As SelfReferencingComposition_OneToMany
             Get
                 If (Me._parent Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCFDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCFDbContextScenarios.g.cs
@@ -169,9 +169,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID")]
         public EntityCollection<Product> Products
         {
             get
@@ -502,9 +500,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID")]
         public EntityCollection<Order> Orders
         {
             get
@@ -716,9 +712,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer Customer
         {
             get
@@ -865,9 +859,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -1282,9 +1274,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public Order Order
         {
             get
@@ -1354,9 +1344,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -1582,9 +1570,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public Category Category
         {
             get
@@ -1704,9 +1690,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -2284,9 +2268,7 @@ namespace CodeFirstModels
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID")]
         public EntityCollection<Territory> Territories
         {
             get
@@ -2367,9 +2349,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCFDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCFDbContextScenarios.g.vb
@@ -169,7 +169,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As EntityCollection(Of Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -484,7 +484,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As EntityCollection(Of Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -708,7 +708,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -829,7 +829,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1201,7 +1201,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1258,7 +1258,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1491,7 +1491,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1590,7 +1590,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2107,7 +2107,7 @@ Namespace CodeFirstModels
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         EntityAssociation("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As EntityCollection(Of Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2188,7 +2188,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCoreContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCoreContextScenarios.g.cs
@@ -169,9 +169,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID")]
         public EntityCollection<Product> Products
         {
             get
@@ -503,9 +501,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID")]
         public EntityCollection<Order> Orders
         {
             get
@@ -717,9 +713,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer Customer
         {
             get
@@ -866,9 +860,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -1283,9 +1275,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public Order Order
         {
             get
@@ -1355,9 +1345,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -1583,9 +1571,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public Category Category
         {
             get
@@ -1705,9 +1691,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -2286,9 +2270,7 @@ namespace EFCoreModels.Northwind
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID")]
         public EntityCollection<Territory> Territories
         {
             get
@@ -2369,9 +2351,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCoreContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCoreContextScenarios.g.vb
@@ -169,7 +169,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As EntityCollection(Of Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -485,7 +485,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As EntityCollection(Of Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -709,7 +709,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -830,7 +830,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1202,7 +1202,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1259,7 +1259,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1492,7 +1492,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1591,7 +1591,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2109,7 +2109,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         EntityAssociation("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As EntityCollection(Of Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2190,7 +2190,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCore_ComplexObject.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCore_ComplexObject.g.cs
@@ -316,9 +316,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// Gets or sets the associated <see cref="OwnedEntityWithExplicitId"/> entity.
         /// </summary>
         [Composition()]
-        [EntityAssociation("FK_Employees_Employees_EmployeeId|owns:OwnedEntityWithExplicitId", new string[] {
-                "EmployeeId"}, new string[] {
-                "EmployeeId"})]
+        [EntityAssociation("FK_Employees_Employees_EmployeeId|owns:OwnedEntityWithExplicitId", "EmployeeId", "EmployeeId")]
         public OwnedEntityWithExplicitId OwnedEntityWithExplicitId
         {
             get
@@ -346,9 +344,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// </summary>
         [Composition()]
         [EntityAssociation("FK_Employees_Employees_EmployeeId|owns:OwnedEntityWithExplicitIdAndBackNavigation" +
-            "", new string[] {
-                "EmployeeId"}, new string[] {
-                "EmployeeId"})]
+            "", "EmployeeId", "EmployeeId")]
         public OwnedEntityWithExplicitIdAndBackNavigation OwnedEntityWithExplicitIdAndBackNavigation
         {
             get
@@ -606,9 +602,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// <summary>
         /// Gets or sets the associated <see cref="Employee"/> entity.
         /// </summary>
-        [EntityAssociation("FK_Employees_Employees_EmployeeId", new string[] {
-                "EmployeeId"}, new string[] {
-                "EmployeeId"}, IsForeignKey=true)]
+        [EntityAssociation("FK_Employees_Employees_EmployeeId", "EmployeeId", "EmployeeId", IsForeignKey=true)]
         public Employee Employee
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCore_ComplexObject.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCore_ComplexObject.g.vb
@@ -312,7 +312,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' Gets or sets the associated <see cref="OwnedEntityWithExplicitId"/> entity.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("FK_Employees_Employees_EmployeeId|owns:OwnedEntityWithExplicitId", New String() {"EmployeeId"}, New String() {"EmployeeId"})>  _
+         EntityAssociation("FK_Employees_Employees_EmployeeId|owns:OwnedEntityWithExplicitId", "EmployeeId", "EmployeeId")>  _
         Public Property OwnedEntityWithExplicitId() As OwnedEntityWithExplicitId
             Get
                 If (Me._ownedEntityWithExplicitId Is Nothing) Then
@@ -335,7 +335,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' </summary>
         <Composition(),  _
          EntityAssociation("FK_Employees_Employees_EmployeeId|owns:OwnedEntityWithExplicitIdAndBackNavigation"& _ 
-            "", New String() {"EmployeeId"}, New String() {"EmployeeId"})>  _
+            "", "EmployeeId", "EmployeeId")>  _
         Public Property OwnedEntityWithExplicitIdAndBackNavigation() As OwnedEntityWithExplicitIdAndBackNavigation
             Get
                 If (Me._ownedEntityWithExplicitIdAndBackNavigation Is Nothing) Then
@@ -582,7 +582,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' <summary>
         ''' Gets or sets the associated <see cref="Employee"/> entity.
         ''' </summary>
-        <EntityAssociation("FK_Employees_Employees_EmployeeId", New String() {"EmployeeId"}, New String() {"EmployeeId"}, IsForeignKey:=true)>  _
+        <EntityAssociation("FK_Employees_Employees_EmployeeId", "EmployeeId", "EmployeeId", IsForeignKey:=true)>  _
         Public Property Employee() As Employee
             Get
                 If (Me._employee Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFDbContextScenarios.g.cs
@@ -169,9 +169,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID")]
         public EntityCollection<Product> Products
         {
             get
@@ -503,9 +501,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID")]
         public EntityCollection<Order> Orders
         {
             get
@@ -717,9 +713,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer Customer
         {
             get
@@ -866,9 +860,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -1283,9 +1275,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public Order Order
         {
             get
@@ -1355,9 +1345,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -1583,9 +1571,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public Category Category
         {
             get
@@ -1705,9 +1691,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -2286,9 +2270,7 @@ namespace DbContextModels.Northwind
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID")]
         public EntityCollection<Territory> Territories
         {
             get
@@ -2369,9 +2351,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFDbContextScenarios.g.vb
@@ -169,7 +169,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As EntityCollection(Of Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -485,7 +485,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As EntityCollection(Of Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -709,7 +709,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -830,7 +830,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1202,7 +1202,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <EntityAssociation("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1259,7 +1259,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1492,7 +1492,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <EntityAssociation("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1591,7 +1591,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As EntityCollection(Of Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2109,7 +2109,7 @@ Namespace DbContextModels.Northwind
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Composition(),  _
-         EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         EntityAssociation("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As EntityCollection(Of Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2190,7 +2190,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <EntityAssociation("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/InheritanceScenarios1.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/InheritanceScenarios1.g.cs
@@ -174,9 +174,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="InheritanceT1"/> entity.
         /// </summary>
-        [EntityAssociation("InheritanceBase_InheritanceT1", new string[] {
-                "T1_ID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("InheritanceBase_InheritanceT1", "T1_ID", "ID", IsForeignKey=true)]
         public InheritanceT1 T1
         {
             get
@@ -235,9 +233,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="InheritanceT1"/> entity instances.
         /// </summary>
-        [EntityAssociation("InheritanceT1_InheritanceBase", new string[] {
-                "ID"}, new string[] {
-                "InheritanceBase_ID"})]
+        [EntityAssociation("InheritanceT1_InheritanceBase", "ID", "InheritanceBase_ID")]
         public EntityCollection<InheritanceT1> T1s
         {
             get
@@ -422,9 +418,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="InheritanceT1"/> entity.
         /// </summary>
-        [EntityAssociation("InheritanceBase_InheritanceT1", new string[] {
-                "T1_ID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("InheritanceBase_InheritanceT1", "T1_ID", "ID", IsForeignKey=true)]
         public InheritanceT1 T1
         {
             get
@@ -483,9 +477,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="InheritanceT1"/> entity instances.
         /// </summary>
-        [EntityAssociation("InheritanceT1_InheritanceBase", new string[] {
-                "ID"}, new string[] {
-                "InheritanceBase_ID"})]
+        [EntityAssociation("InheritanceT1_InheritanceBase", "ID", "InheritanceBase_ID")]
         public EntityCollection<InheritanceT1> T1s
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/LTSNorthwindScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/LTSNorthwindScenarios.g.cs
@@ -674,9 +674,7 @@ namespace DataTests.Scenarios.LTS.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Customer_Bug479436"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Bug479436_Order_Bug479436", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Bug479436_Order_Bug479436", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer_Bug479436 Customer
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/LTSNorthwindScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/LTSNorthwindScenarios.g.vb
@@ -670,7 +670,7 @@ Namespace DataTests.Scenarios.LTS.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer_Bug479436"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_Bug479436_Order_Bug479436", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Customer_Bug479436_Order_Bug479436", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Customer_Bug479436
             Get
                 If (Me._customer Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/MultipleProviderScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/MultipleProviderScenarios.g.cs
@@ -173,9 +173,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID")]
         public EntityCollection<Product> Products
         {
             get
@@ -507,9 +505,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID")]
         public EntityCollection<Order> Orders
         {
             get
@@ -721,9 +717,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer Customer
         {
             get
@@ -871,9 +865,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -1288,9 +1280,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public Order Order
         {
             get
@@ -1360,9 +1350,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -1588,9 +1576,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public Category Category
         {
             get
@@ -1710,9 +1696,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -2295,9 +2279,7 @@ namespace DataTests.Northwind.LTS
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID")]
         public EntityCollection<Territory> Territories
         {
             get
@@ -2378,9 +2360,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public Region Region
         {
             get
@@ -2680,9 +2660,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID")]
         public EntityCollection<Product> Products
         {
             get
@@ -3014,9 +2992,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID")]
         public EntityCollection<Order> Orders
         {
             get
@@ -3228,9 +3204,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [EntityAssociation("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [EntityAssociation("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public Customer Customer
         {
             get
@@ -3377,9 +3351,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -3794,9 +3766,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [EntityAssociation("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [EntityAssociation("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public Order Order
         {
             get
@@ -3866,9 +3836,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public Product Product
         {
             get
@@ -4094,9 +4062,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [EntityAssociation("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [EntityAssociation("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public Category Category
         {
             get
@@ -4216,9 +4182,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [EntityAssociation("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [EntityAssociation("Product_Order_Detail", "ProductID", "ProductID")]
         public EntityCollection<Order_Detail> Order_Details
         {
             get
@@ -4797,9 +4761,7 @@ namespace NorthwindModel
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [Composition()]
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID")]
         public EntityCollection<Territory> Territories
         {
             get
@@ -4880,9 +4842,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [EntityAssociation("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [EntityAssociation("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/SharedEntities.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/SharedEntities.g.cs
@@ -74,9 +74,7 @@ namespace SharedEntities
         /// <summary>
         /// Gets or sets the associated <see cref="EntityB"/> entity.
         /// </summary>
-        [EntityAssociation("A_B", new string[] {
-                "IdB"}, new string[] {
-                "Id"})]
+        [EntityAssociation("A_B", "IdB", "Id")]
         public EntityB EntityB
         {
             get
@@ -102,9 +100,7 @@ namespace SharedEntities
         /// <summary>
         /// Gets or sets the associated <see cref="EntityC"/> entity.
         /// </summary>
-        [EntityAssociation("A_C", new string[] {
-                "IdC"}, new string[] {
-                "Id"})]
+        [EntityAssociation("A_C", "IdC", "Id")]
         public EntityC EntityC
         {
             get
@@ -565,9 +561,7 @@ namespace SharedEntities
         /// <summary>
         /// Gets or sets the associated <see cref="EntityZ"/> entity.
         /// </summary>
-        [EntityAssociation("Y_Z", new string[] {
-                "IdZ"}, new string[] {
-                "Id"})]
+        [EntityAssociation("Y_Z", "IdZ", "Id")]
         public EntityZ EntityZ
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/SharedEntities.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/SharedEntities.g.vb
@@ -89,7 +89,7 @@ Namespace SharedEntities
         ''' <summary>
         ''' Gets or sets the associated <see cref="EntityB"/> entity.
         ''' </summary>
-        <EntityAssociation("A_B", New String() {"IdB"}, New String() {"Id"})>  _
+        <EntityAssociation("A_B", "IdB", "Id")>  _
         Public Property EntityB() As EntityB
             Get
                 If (Me._entityB Is Nothing) Then
@@ -110,7 +110,7 @@ Namespace SharedEntities
         ''' <summary>
         ''' Gets or sets the associated <see cref="EntityC"/> entity.
         ''' </summary>
-        <EntityAssociation("A_C", New String() {"IdC"}, New String() {"Id"})>  _
+        <EntityAssociation("A_C", "IdC", "Id")>  _
         Public Property EntityC() As EntityC
             Get
                 If (Me._entityC Is Nothing) Then
@@ -543,7 +543,7 @@ Namespace SharedEntities
         ''' <summary>
         ''' Gets or sets the associated <see cref="EntityZ"/> entity.
         ''' </summary>
-        <EntityAssociation("Y_Z", New String() {"IdZ"}, New String() {"Id"})>  _
+        <EntityAssociation("Y_Z", "IdZ", "Id")>  _
         Public Property EntityZ() As EntityZ
             Get
                 If (Me._entityZ Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios.g.cs
@@ -557,9 +557,7 @@ namespace TestDomainServices
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
         [Display(Description="D_Ref1")]
-        [EntityAssociation("C_D_Ref1", new string[] {
-                "DID_Ref1"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey=true)]
         public D D_Ref1
         {
             get
@@ -602,9 +600,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [EntityAssociation("C_D_Ref2", new string[] {
-                "DID_Ref2"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey=true)]
         public D D_Ref2
         {
             get
@@ -793,9 +789,7 @@ namespace TestDomainServices
         /// Gets the collection of associated <see cref="CartItem"/> entity instances.
         /// </summary>
         [Editable(false)]
-        [EntityAssociation("CartItem_Cart", new string[] {
-                "CartId"}, new string[] {
-                "CartItemId"})]
+        [EntityAssociation("CartItem_Cart", "CartId", "CartItemId")]
         [ReadOnly(true)]
         public EntityCollection<CartItem> Items
         {
@@ -877,9 +871,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="Cart"/> entity.
         /// </summary>
-        [EntityAssociation("CartItem_Cart", new string[] {
-                "CartItemId"}, new string[] {
-                "CartId"}, IsForeignKey=true)]
+        [EntityAssociation("CartItem_Cart", "CartItemId", "CartId", IsForeignKey=true)]
         public Cart Cart
         {
             get
@@ -1224,9 +1216,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="C"/> entity.
         /// </summary>
-        [EntityAssociation("C_D_Ref1", new string[] {
-                "ID"}, new string[] {
-                "DID_Ref1"})]
+        [EntityAssociation("C_D_Ref1", "ID", "DID_Ref1")]
         public C C
         {
             get
@@ -1261,9 +1251,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [EntityAssociation("D_D", new string[] {
-                "DSelfRef_ID1"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("D_D", "DSelfRef_ID1", "ID", IsForeignKey=true)]
         public D D1
         {
             get
@@ -1306,9 +1294,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [EntityAssociation("D_D2", new string[] {
-                "DSelfRef_ID2"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("D_D2", "DSelfRef_ID2", "ID", IsForeignKey=true)]
         public D D2
         {
             get
@@ -1351,9 +1337,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [EntityAssociation("D_D2", new string[] {
-                "ID"}, new string[] {
-                "DSelfRef_ID2"})]
+        [EntityAssociation("D_D2", "ID", "DSelfRef_ID2")]
         public D D2_BackRef
         {
             get
@@ -1388,9 +1372,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="D"/> entity instances.
         /// </summary>
-        [EntityAssociation("D_D", new string[] {
-                "ID"}, new string[] {
-                "DSelfRef_ID1"})]
+        [EntityAssociation("D_D", "ID", "DSelfRef_ID1")]
         public EntityCollection<D> Ds
         {
             get
@@ -5517,9 +5499,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKParent"/> entity.
         /// </summary>
-        [EntityAssociation("Parent_Child", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Parent_Child", "ParentID", "ID", IsForeignKey=true)]
         public NullableFKParent Parent
         {
             get
@@ -5562,9 +5542,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKParent"/> entity.
         /// </summary>
-        [EntityAssociation("Parent_Child_Singleton", new string[] {
-                "ParentID_Singleton"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("Parent_Child_Singleton", "ParentID_Singleton", "ID", IsForeignKey=true)]
         public NullableFKParent Parent2
         {
             get
@@ -5715,9 +5693,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKChild"/> entity.
         /// </summary>
-        [EntityAssociation("Parent_Child_Singleton", new string[] {
-                "ID"}, new string[] {
-                "ParentID_Singleton"})]
+        [EntityAssociation("Parent_Child_Singleton", "ID", "ParentID_Singleton")]
         public NullableFKChild Child
         {
             get
@@ -5752,9 +5728,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="NullableFKChild"/> entity instances.
         /// </summary>
-        [EntityAssociation("Parent_Child", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [EntityAssociation("Parent_Child", "ID", "ParentID")]
         public EntityCollection<NullableFKChild> Children
         {
             get
@@ -6220,9 +6194,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="RoundtripOriginal_TestEntity"/> entity.
         /// </summary>
-        [EntityAssociation("RTO_RTO2", new string[] {
-                "ID"}, new string[] {
-                "ID"})]
+        [EntityAssociation("RTO_RTO2", "ID", "ID")]
         public RoundtripOriginal_TestEntity AssocProp
         {
             get
@@ -6607,9 +6579,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="TestCycles"/> entity.
         /// </summary>
-        [EntityAssociation("TestCycle_Parent", new string[] {
-                "ParentName"}, new string[] {
-                "Name"}, IsForeignKey=true)]
+        [EntityAssociation("TestCycle_Parent", "ParentName", "Name", IsForeignKey=true)]
         public TestCycles IncludedT
         {
             get
@@ -6652,9 +6622,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="TestCycles"/> entity instances.
         /// </summary>
-        [EntityAssociation("TestCycle_Parent", new string[] {
-                "Name"}, new string[] {
-                "ParentName"})]
+        [EntityAssociation("TestCycle_Parent", "Name", "ParentName")]
         public EntityCollection<TestCycles> IncludedTs
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios.g.vb
@@ -531,7 +531,7 @@ Namespace TestDomainServices
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
         <Display(Description:="D_Ref1"),  _
-         EntityAssociation("C_D_Ref1", New String() {"DID_Ref1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+         EntityAssociation("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref1() As D
             Get
                 If (Me._d_Ref1 Is Nothing) Then
@@ -564,7 +564,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("C_D_Ref2", New String() {"DID_Ref2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref2() As D
             Get
                 If (Me._d_Ref2 Is Nothing) Then
@@ -733,7 +733,7 @@ Namespace TestDomainServices
         ''' Gets the collection of associated <see cref="CartItem"/> entity instances.
         ''' </summary>
         <Editable(false),  _
-         EntityAssociation("CartItem_Cart", New String() {"CartId"}, New String() {"CartItemId"}),  _
+         EntityAssociation("CartItem_Cart", "CartId", "CartItemId"),  _
          [ReadOnly](true)>  _
         Public ReadOnly Property Items() As EntityCollection(Of CartItem)
             Get
@@ -815,7 +815,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="Cart"/> entity.
         ''' </summary>
-        <EntityAssociation("CartItem_Cart", New String() {"CartItemId"}, New String() {"CartId"}, IsForeignKey:=true)>  _
+        <EntityAssociation("CartItem_Cart", "CartItemId", "CartId", IsForeignKey:=true)>  _
         Public Property Cart() As Cart
             Get
                 If (Me._cart Is Nothing) Then
@@ -1140,7 +1140,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="C"/> entity.
         ''' </summary>
-        <EntityAssociation("C_D_Ref1", New String() {"ID"}, New String() {"DID_Ref1"})>  _
+        <EntityAssociation("C_D_Ref1", "ID", "DID_Ref1")>  _
         Public Property C() As C
             Get
                 If (Me._c Is Nothing) Then
@@ -1168,7 +1168,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D", New String() {"DSelfRef_ID1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("D_D", "DSelfRef_ID1", "ID", IsForeignKey:=true)>  _
         Public Property D1() As D
             Get
                 If (Me._d1 Is Nothing) Then
@@ -1201,7 +1201,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D2", New String() {"DSelfRef_ID2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("D_D2", "DSelfRef_ID2", "ID", IsForeignKey:=true)>  _
         Public Property D2() As D
             Get
                 If (Me._d2 Is Nothing) Then
@@ -1234,7 +1234,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D2", New String() {"ID"}, New String() {"DSelfRef_ID2"})>  _
+        <EntityAssociation("D_D2", "ID", "DSelfRef_ID2")>  _
         Public Property D2_BackRef() As D
             Get
                 If (Me._d2_BackRef Is Nothing) Then
@@ -1262,7 +1262,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="D"/> entity instances.
         ''' </summary>
-        <EntityAssociation("D_D", New String() {"ID"}, New String() {"DSelfRef_ID1"})>  _
+        <EntityAssociation("D_D", "ID", "DSelfRef_ID1")>  _
         Public ReadOnly Property Ds() As EntityCollection(Of D)
             Get
                 If (Me._ds Is Nothing) Then
@@ -5177,7 +5177,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKParent"/> entity.
         ''' </summary>
-        <EntityAssociation("Parent_Child", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Parent_Child", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As NullableFKParent
             Get
                 If (Me._parent Is Nothing) Then
@@ -5210,7 +5210,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKParent"/> entity.
         ''' </summary>
-        <EntityAssociation("Parent_Child_Singleton", New String() {"ParentID_Singleton"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("Parent_Child_Singleton", "ParentID_Singleton", "ID", IsForeignKey:=true)>  _
         Public Property Parent2() As NullableFKParent
             Get
                 If (Me._parent2 Is Nothing) Then
@@ -5345,7 +5345,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKChild"/> entity.
         ''' </summary>
-        <EntityAssociation("Parent_Child_Singleton", New String() {"ID"}, New String() {"ParentID_Singleton"})>  _
+        <EntityAssociation("Parent_Child_Singleton", "ID", "ParentID_Singleton")>  _
         Public Property Child() As NullableFKChild
             Get
                 If (Me._child Is Nothing) Then
@@ -5373,7 +5373,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="NullableFKChild"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Parent_Child", New String() {"ID"}, New String() {"ParentID"})>  _
+        <EntityAssociation("Parent_Child", "ID", "ParentID")>  _
         Public ReadOnly Property Children() As EntityCollection(Of NullableFKChild)
             Get
                 If (Me._children Is Nothing) Then
@@ -5817,7 +5817,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="RoundtripOriginal_TestEntity"/> entity.
         ''' </summary>
-        <EntityAssociation("RTO_RTO2", New String() {"ID"}, New String() {"ID"})>  _
+        <EntityAssociation("RTO_RTO2", "ID", "ID")>  _
         Public Property AssocProp() As RoundtripOriginal_TestEntity
             Get
                 If (Me._assocProp Is Nothing) Then
@@ -6182,7 +6182,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="TestCycles"/> entity.
         ''' </summary>
-        <EntityAssociation("TestCycle_Parent", New String() {"ParentName"}, New String() {"Name"}, IsForeignKey:=true)>  _
+        <EntityAssociation("TestCycle_Parent", "ParentName", "Name", IsForeignKey:=true)>  _
         Public Property IncludedT() As TestCycles
             Get
                 If (Me._includedT Is Nothing) Then
@@ -6215,7 +6215,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="TestCycles"/> entity instances.
         ''' </summary>
-        <EntityAssociation("TestCycle_Parent", New String() {"Name"}, New String() {"ParentName"})>  _
+        <EntityAssociation("TestCycle_Parent", "Name", "ParentName")>  _
         Public ReadOnly Property IncludedTs() As EntityCollection(Of TestCycles)
             Get
                 If (Me._includedTs Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
@@ -555,9 +555,7 @@ namespace TestDomainServices
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
         [Display(Description="D_Ref1")]
-        [EntityAssociation("C_D_Ref1", new string[] {
-                "DID_Ref1"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey=true)]
         public D D_Ref1
         {
             get
@@ -600,9 +598,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [EntityAssociation("C_D_Ref2", new string[] {
-                "DID_Ref2"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey=true)]
         public D D_Ref2
         {
             get
@@ -816,9 +812,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="C"/> entity.
         /// </summary>
-        [EntityAssociation("C_D_Ref1", new string[] {
-                "ID"}, new string[] {
-                "DID_Ref1"})]
+        [EntityAssociation("C_D_Ref1", "ID", "DID_Ref1")]
         public C C
         {
             get
@@ -853,9 +847,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [EntityAssociation("D_D", new string[] {
-                "DSelfRef_ID1"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("D_D", "DSelfRef_ID1", "ID", IsForeignKey=true)]
         public D D1
         {
             get
@@ -898,9 +890,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [EntityAssociation("D_D2", new string[] {
-                "DSelfRef_ID2"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [EntityAssociation("D_D2", "DSelfRef_ID2", "ID", IsForeignKey=true)]
         public D D2
         {
             get
@@ -943,9 +933,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [EntityAssociation("D_D2", new string[] {
-                "ID"}, new string[] {
-                "DSelfRef_ID2"})]
+        [EntityAssociation("D_D2", "ID", "DSelfRef_ID2")]
         public D D2_BackRef
         {
             get
@@ -980,9 +968,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="D"/> entity instances.
         /// </summary>
-        [EntityAssociation("D_D", new string[] {
-                "ID"}, new string[] {
-                "DSelfRef_ID1"})]
+        [EntityAssociation("D_D", "ID", "DSelfRef_ID1")]
         public EntityCollection<D> Ds
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
@@ -528,7 +528,7 @@ Namespace TestDomainServices
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
         <Display(Description:="D_Ref1"),  _
-         EntityAssociation("C_D_Ref1", New String() {"DID_Ref1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+         EntityAssociation("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref1() As D
             Get
                 If (Me._d_Ref1 Is Nothing) Then
@@ -561,7 +561,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("C_D_Ref2", New String() {"DID_Ref2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref2() As D
             Get
                 If (Me._d_Ref2 Is Nothing) Then
@@ -764,7 +764,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="C"/> entity.
         ''' </summary>
-        <EntityAssociation("C_D_Ref1", New String() {"ID"}, New String() {"DID_Ref1"})>  _
+        <EntityAssociation("C_D_Ref1", "ID", "DID_Ref1")>  _
         Public Property C() As C
             Get
                 If (Me._c Is Nothing) Then
@@ -792,7 +792,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D", New String() {"DSelfRef_ID1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("D_D", "DSelfRef_ID1", "ID", IsForeignKey:=true)>  _
         Public Property D1() As D
             Get
                 If (Me._d1 Is Nothing) Then
@@ -825,7 +825,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D2", New String() {"DSelfRef_ID2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <EntityAssociation("D_D2", "DSelfRef_ID2", "ID", IsForeignKey:=true)>  _
         Public Property D2() As D
             Get
                 If (Me._d2 Is Nothing) Then
@@ -858,7 +858,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D2", New String() {"ID"}, New String() {"DSelfRef_ID2"})>  _
+        <EntityAssociation("D_D2", "ID", "DSelfRef_ID2")>  _
         Public Property D2_BackRef() As D
             Get
                 If (Me._d2_BackRef Is Nothing) Then
@@ -886,7 +886,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="D"/> entity instances.
         ''' </summary>
-        <EntityAssociation("D_D", New String() {"ID"}, New String() {"DSelfRef_ID1"})>  _
+        <EntityAssociation("D_D", "ID", "DSelfRef_ID1")>  _
         Public ReadOnly Property Ds() As EntityCollection(Of D)
             Get
                 If (Me._ds Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCFDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCFDbContextScenarios.g.cs
@@ -159,9 +159,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID")]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Product> Products
         {
             get
@@ -492,9 +490,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID")]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Order> Orders
         {
             get
@@ -706,9 +702,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public global::CodeFirstModels.Customer Customer
         {
             get
@@ -855,9 +849,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID")]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Order_Detail> Order_Details
         {
             get
@@ -1272,9 +1264,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public global::CodeFirstModels.Order Order
         {
             get
@@ -1344,9 +1334,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public global::CodeFirstModels.Product Product
         {
             get
@@ -1572,9 +1560,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public global::CodeFirstModels.Category Category
         {
             get
@@ -1694,9 +1680,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID")]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Order_Detail> Order_Details
         {
             get
@@ -2274,9 +2258,7 @@ namespace CodeFirstModels
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID")]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Territory> Territories
         {
             get
@@ -2357,9 +2339,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public global::CodeFirstModels.Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCFDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCFDbContextScenarios.g.cs
@@ -159,7 +159,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
                 "CategoryID"}, new string[] {
                 "CategoryID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Product> Products
@@ -492,7 +492,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
                 "CustomerID"}, new string[] {
                 "CustomerID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Order> Orders
@@ -706,7 +706,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
                 "CustomerID"}, new string[] {
                 "CustomerID"}, IsForeignKey=true)]
         public global::CodeFirstModels.Customer Customer
@@ -855,7 +855,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
                 "OrderID"}, new string[] {
                 "OrderID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Order_Detail> Order_Details
@@ -1272,7 +1272,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
                 "OrderID"}, new string[] {
                 "OrderID"}, IsForeignKey=true)]
         public global::CodeFirstModels.Order Order
@@ -1344,7 +1344,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
                 "ProductID"}, new string[] {
                 "ProductID"}, IsForeignKey=true)]
         public global::CodeFirstModels.Product Product
@@ -1572,7 +1572,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
                 "CategoryID"}, new string[] {
                 "CategoryID"}, IsForeignKey=true)]
         public global::CodeFirstModels.Category Category
@@ -1694,7 +1694,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
                 "ProductID"}, new string[] {
                 "ProductID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Order_Detail> Order_Details
@@ -2273,10 +2273,10 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
+        [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
                 "RegionID"}, new string[] {
                 "RegionID"})]
-        [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
         public global::OpenRiaServices.Client.EntityCollection<global::CodeFirstModels.Territory> Territories
         {
             get
@@ -2357,7 +2357,7 @@ namespace CodeFirstModels
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
                 "RegionID"}, new string[] {
                 "RegionID"}, IsForeignKey=true)]
         public global::CodeFirstModels.Region Region

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCFDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCFDbContextScenarios.g.vb
@@ -157,7 +157,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
         Public ReadOnly Property Products() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -472,7 +472,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
         Public ReadOnly Property Orders() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -696,7 +696,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
         Public Property Customer() As Global.CodeFirstModels.Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -817,7 +817,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1189,7 +1189,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
         Public Property Order() As Global.CodeFirstModels.Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1246,7 +1246,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
         Public Property Product() As Global.CodeFirstModels.Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1479,7 +1479,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
         Public Property Category() As Global.CodeFirstModels.Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1578,7 +1578,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2094,8 +2094,8 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}),  _
-         Global.System.ComponentModel.DataAnnotations.CompositionAttribute()>  _
+        <Global.System.ComponentModel.DataAnnotations.CompositionAttribute(),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
         Public ReadOnly Property Territories() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2176,7 +2176,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
         Public Property Region() As Global.CodeFirstModels.Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCFDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCFDbContextScenarios.g.vb
@@ -157,7 +157,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -472,7 +472,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -696,7 +696,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Global.CodeFirstModels.Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -817,7 +817,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1189,7 +1189,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Global.CodeFirstModels.Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1246,7 +1246,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Global.CodeFirstModels.Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1479,7 +1479,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Global.CodeFirstModels.Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1578,7 +1578,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2095,7 +2095,7 @@ Namespace CodeFirstModels
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.CompositionAttribute(),  _
-         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As Global.OpenRiaServices.Client.EntityCollection(Of Global.CodeFirstModels.Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2176,7 +2176,7 @@ Namespace CodeFirstModels
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Global.CodeFirstModels.Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.cs
@@ -159,9 +159,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID")]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Product> Products
         {
             get
@@ -493,9 +491,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID")]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Order> Orders
         {
             get
@@ -707,9 +703,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Customer Customer
         {
             get
@@ -856,9 +850,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID")]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Order_Detail> Order_Details
         {
             get
@@ -1273,9 +1265,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Order Order
         {
             get
@@ -1345,9 +1335,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Product Product
         {
             get
@@ -1573,9 +1561,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Category Category
         {
             get
@@ -1695,9 +1681,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID")]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Order_Detail> Order_Details
         {
             get
@@ -2276,9 +2260,7 @@ namespace EFCoreModels.Northwind
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID")]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Territory> Territories
         {
             get
@@ -2359,9 +2341,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.cs
@@ -159,7 +159,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
                 "CategoryID"}, new string[] {
                 "CategoryID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Product> Products
@@ -493,7 +493,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
                 "CustomerID"}, new string[] {
                 "CustomerID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Order> Orders
@@ -707,7 +707,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
                 "CustomerID"}, new string[] {
                 "CustomerID"}, IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Customer Customer
@@ -856,7 +856,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
                 "OrderID"}, new string[] {
                 "OrderID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Order_Detail> Order_Details
@@ -1273,7 +1273,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
                 "OrderID"}, new string[] {
                 "OrderID"}, IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Order Order
@@ -1345,7 +1345,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
                 "ProductID"}, new string[] {
                 "ProductID"}, IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Product Product
@@ -1573,7 +1573,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
                 "CategoryID"}, new string[] {
                 "CategoryID"}, IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Category Category
@@ -1695,7 +1695,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
                 "ProductID"}, new string[] {
                 "ProductID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Order_Detail> Order_Details
@@ -2275,10 +2275,10 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
+        [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
                 "RegionID"}, new string[] {
                 "RegionID"})]
-        [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
         public global::OpenRiaServices.Client.EntityCollection<global::EFCoreModels.Northwind.Territory> Territories
         {
             get
@@ -2359,7 +2359,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
                 "RegionID"}, new string[] {
                 "RegionID"}, IsForeignKey=true)]
         public global::EFCoreModels.Northwind.Region Region

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.vb
@@ -157,7 +157,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
         Public ReadOnly Property Products() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -473,7 +473,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
         Public ReadOnly Property Orders() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -697,7 +697,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
         Public Property Customer() As Global.EFCoreModels.Northwind.Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -818,7 +818,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1190,7 +1190,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
         Public Property Order() As Global.EFCoreModels.Northwind.Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1247,7 +1247,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
         Public Property Product() As Global.EFCoreModels.Northwind.Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1480,7 +1480,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
         Public Property Category() As Global.EFCoreModels.Northwind.Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1579,7 +1579,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2096,8 +2096,8 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}),  _
-         Global.System.ComponentModel.DataAnnotations.CompositionAttribute()>  _
+        <Global.System.ComponentModel.DataAnnotations.CompositionAttribute(),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
         Public ReadOnly Property Territories() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2178,7 +2178,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
         Public Property Region() As Global.EFCoreModels.Northwind.Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.vb
@@ -157,7 +157,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -473,7 +473,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -697,7 +697,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Global.EFCoreModels.Northwind.Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -818,7 +818,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1190,7 +1190,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Global.EFCoreModels.Northwind.Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1247,7 +1247,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Global.EFCoreModels.Northwind.Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1480,7 +1480,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Global.EFCoreModels.Northwind.Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1579,7 +1579,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2097,7 +2097,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.CompositionAttribute(),  _
-         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As Global.OpenRiaServices.Client.EntityCollection(Of Global.EFCoreModels.Northwind.Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2178,7 +2178,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Global.EFCoreModels.Northwind.Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFDbContextScenarios.g.cs
@@ -159,7 +159,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
                 "CategoryID"}, new string[] {
                 "CategoryID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Product> Products
@@ -493,7 +493,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
                 "CustomerID"}, new string[] {
                 "CustomerID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Order> Orders
@@ -707,7 +707,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
                 "CustomerID"}, new string[] {
                 "CustomerID"}, IsForeignKey=true)]
         public global::DbContextModels.Northwind.Customer Customer
@@ -856,7 +856,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
                 "OrderID"}, new string[] {
                 "OrderID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Order_Detail> Order_Details
@@ -1273,7 +1273,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
                 "OrderID"}, new string[] {
                 "OrderID"}, IsForeignKey=true)]
         public global::DbContextModels.Northwind.Order Order
@@ -1345,7 +1345,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
                 "ProductID"}, new string[] {
                 "ProductID"}, IsForeignKey=true)]
         public global::DbContextModels.Northwind.Product Product
@@ -1573,7 +1573,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
                 "CategoryID"}, new string[] {
                 "CategoryID"}, IsForeignKey=true)]
         public global::DbContextModels.Northwind.Category Category
@@ -1695,7 +1695,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
                 "ProductID"}, new string[] {
                 "ProductID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Order_Detail> Order_Details
@@ -2275,10 +2275,10 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
+        [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
                 "RegionID"}, new string[] {
                 "RegionID"})]
-        [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Territory> Territories
         {
             get
@@ -2359,7 +2359,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
                 "RegionID"}, new string[] {
                 "RegionID"}, IsForeignKey=true)]
         public global::DbContextModels.Northwind.Region Region

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFDbContextScenarios.g.cs
@@ -159,9 +159,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Product> Products
         {
             get
@@ -493,9 +491,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Order> Orders
         {
             get
@@ -707,9 +703,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public global::DbContextModels.Northwind.Customer Customer
         {
             get
@@ -856,9 +850,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Order_Detail> Order_Details
         {
             get
@@ -1273,9 +1265,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public global::DbContextModels.Northwind.Order Order
         {
             get
@@ -1345,9 +1335,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public global::DbContextModels.Northwind.Product Product
         {
             get
@@ -1573,9 +1561,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public global::DbContextModels.Northwind.Category Category
         {
             get
@@ -1695,9 +1681,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Order_Detail> Order_Details
         {
             get
@@ -2276,9 +2260,7 @@ namespace DbContextModels.Northwind
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DbContextModels.Northwind.Territory> Territories
         {
             get
@@ -2359,9 +2341,7 @@ namespace DbContextModels.Northwind
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public global::DbContextModels.Northwind.Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFDbContextScenarios.g.vb
@@ -157,7 +157,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
         Public ReadOnly Property Products() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -473,7 +473,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
         Public ReadOnly Property Orders() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -697,7 +697,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
         Public Property Customer() As Global.DbContextModels.Northwind.Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -818,7 +818,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1190,7 +1190,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
         Public Property Order() As Global.DbContextModels.Northwind.Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1247,7 +1247,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
         Public Property Product() As Global.DbContextModels.Northwind.Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1480,7 +1480,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
         Public Property Category() As Global.DbContextModels.Northwind.Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1579,7 +1579,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2096,8 +2096,8 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}),  _
-         Global.System.ComponentModel.DataAnnotations.CompositionAttribute()>  _
+        <Global.System.ComponentModel.DataAnnotations.CompositionAttribute(),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
         Public ReadOnly Property Territories() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2178,7 +2178,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
         Public Property Region() As Global.DbContextModels.Northwind.Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFDbContextScenarios.g.vb
@@ -157,7 +157,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Product"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID")>  _
         Public ReadOnly Property Products() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Product)
             Get
                 If (Me._products Is Nothing) Then
@@ -473,7 +473,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID")>  _
         Public ReadOnly Property Orders() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Order)
             Get
                 If (Me._orders Is Nothing) Then
@@ -697,7 +697,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Customer"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", New String() {"CustomerID"}, New String() {"CustomerID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID", IsForeignKey:=true)>  _
         Public Property Customer() As Global.DbContextModels.Northwind.Customer
             Get
                 If (Me._customer Is Nothing) Then
@@ -818,7 +818,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID")>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -1190,7 +1190,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Order"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", New String() {"OrderID"}, New String() {"OrderID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey:=true)>  _
         Public Property Order() As Global.DbContextModels.Northwind.Order
             Get
                 If (Me._order Is Nothing) Then
@@ -1247,7 +1247,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Product"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey:=true)>  _
         Public Property Product() As Global.DbContextModels.Northwind.Product
             Get
                 If (Me._product Is Nothing) Then
@@ -1480,7 +1480,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Category"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", New String() {"CategoryID"}, New String() {"CategoryID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID", IsForeignKey:=true)>  _
         Public Property Category() As Global.DbContextModels.Northwind.Category
             Get
                 If (Me._category Is Nothing) Then
@@ -1579,7 +1579,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", New String() {"ProductID"}, New String() {"ProductID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID")>  _
         Public ReadOnly Property Order_Details() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Order_Detail)
             Get
                 If (Me._order_Details Is Nothing) Then
@@ -2097,7 +2097,7 @@ Namespace DbContextModels.Northwind
         ''' Gets the collection of associated <see cref="Territory"/> entity instances.
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.CompositionAttribute(),  _
-         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"})>  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID")>  _
         Public ReadOnly Property Territories() As Global.OpenRiaServices.Client.EntityCollection(Of Global.DbContextModels.Northwind.Territory)
             Get
                 If (Me._territories Is Nothing) Then
@@ -2178,7 +2178,7 @@ Namespace DbContextModels.Northwind
         ''' <summary>
         ''' Gets or sets the associated <see cref="Region"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", New String() {"RegionID"}, New String() {"RegionID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID", IsForeignKey:=true)>  _
         Public Property Region() As Global.DbContextModels.Northwind.Region
             Get
                 If (Me._region Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/InheritanceScenarios1.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/InheritanceScenarios1.g.cs
@@ -163,9 +163,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="InheritanceT1"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceBase_InheritanceT1", new string[] {
-                "T1_ID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceBase_InheritanceT1", "T1_ID", "ID", IsForeignKey=true)]
         public global::TestDomainServices.InheritanceT1 T1
         {
             get
@@ -224,9 +222,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="InheritanceT1"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceT1_InheritanceBase", new string[] {
-                "ID"}, new string[] {
-                "InheritanceBase_ID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceT1_InheritanceBase", "ID", "InheritanceBase_ID")]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.InheritanceT1> T1s
         {
             get
@@ -411,9 +407,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="InheritanceT1"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceBase_InheritanceT1", new string[] {
-                "T1_ID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceBase_InheritanceT1", "T1_ID", "ID", IsForeignKey=true)]
         public global::TestDomainServices.InheritanceT1 T1
         {
             get
@@ -472,9 +466,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="InheritanceT1"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceT1_InheritanceBase", new string[] {
-                "ID"}, new string[] {
-                "InheritanceBase_ID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceT1_InheritanceBase", "ID", "InheritanceBase_ID")]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.InheritanceT1> T1s
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/InheritanceScenarios1.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/InheritanceScenarios1.g.cs
@@ -163,7 +163,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="InheritanceT1"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("InheritanceBase_InheritanceT1", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceBase_InheritanceT1", new string[] {
                 "T1_ID"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.InheritanceT1 T1
@@ -224,7 +224,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="InheritanceT1"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("InheritanceT1_InheritanceBase", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceT1_InheritanceBase", new string[] {
                 "ID"}, new string[] {
                 "InheritanceBase_ID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.InheritanceT1> T1s
@@ -411,7 +411,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="InheritanceT1"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("InheritanceBase_InheritanceT1", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceBase_InheritanceT1", new string[] {
                 "T1_ID"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.InheritanceT1 T1
@@ -472,7 +472,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="InheritanceT1"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("InheritanceT1_InheritanceBase", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("InheritanceT1_InheritanceBase", new string[] {
                 "ID"}, new string[] {
                 "InheritanceBase_ID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.InheritanceT1> T1s

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/MultipleProviderScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/MultipleProviderScenarios.g.cs
@@ -163,9 +163,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DataTests.Northwind.LTS.Product> Products
         {
             get
@@ -497,9 +495,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DataTests.Northwind.LTS.Order> Orders
         {
             get
@@ -711,9 +707,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public global::DataTests.Northwind.LTS.Customer Customer
         {
             get
@@ -861,9 +855,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DataTests.Northwind.LTS.Order_Detail> Order_Details
         {
             get
@@ -1278,9 +1270,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public global::DataTests.Northwind.LTS.Order Order
         {
             get
@@ -1350,9 +1340,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public global::DataTests.Northwind.LTS.Product Product
         {
             get
@@ -1578,9 +1566,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public global::DataTests.Northwind.LTS.Category Category
         {
             get
@@ -1700,9 +1686,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DataTests.Northwind.LTS.Order_Detail> Order_Details
         {
             get
@@ -2284,10 +2268,8 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
         [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID")]
         public global::OpenRiaServices.Client.EntityCollection<global::DataTests.Northwind.LTS.Territory> Territories
         {
             get
@@ -2368,9 +2350,7 @@ namespace DataTests.Northwind.LTS
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public global::DataTests.Northwind.LTS.Region Region
         {
             get
@@ -2660,9 +2640,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Product"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID")]
         public global::OpenRiaServices.Client.EntityCollection<global::NorthwindModel.Product> Products
         {
             get
@@ -2994,9 +2972,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID")]
         public global::OpenRiaServices.Client.EntityCollection<global::NorthwindModel.Order> Orders
         {
             get
@@ -3208,9 +3184,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Customer"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Customer_Order", new string[] {
-                "CustomerID"}, new string[] {
-                "CustomerID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Customer_Order", "CustomerID", "CustomerID", IsForeignKey=true)]
         public global::NorthwindModel.Customer Customer
         {
             get
@@ -3357,9 +3331,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID")]
         public global::OpenRiaServices.Client.EntityCollection<global::NorthwindModel.Order_Detail> Order_Details
         {
             get
@@ -3774,9 +3746,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Order"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Order_Order_Detail", new string[] {
-                "OrderID"}, new string[] {
-                "OrderID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Order_Order_Detail", "OrderID", "OrderID", IsForeignKey=true)]
         public global::NorthwindModel.Order Order
         {
             get
@@ -3846,9 +3816,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Product"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID", IsForeignKey=true)]
         public global::NorthwindModel.Product Product
         {
             get
@@ -4074,9 +4042,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Category"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Category_Product", new string[] {
-                "CategoryID"}, new string[] {
-                "CategoryID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Category_Product", "CategoryID", "CategoryID", IsForeignKey=true)]
         public global::NorthwindModel.Category Category
         {
             get
@@ -4196,9 +4162,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Order_Detail"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Product_Order_Detail", new string[] {
-                "ProductID"}, new string[] {
-                "ProductID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Product_Order_Detail", "ProductID", "ProductID")]
         public global::OpenRiaServices.Client.EntityCollection<global::NorthwindModel.Order_Detail> Order_Details
         {
             get
@@ -4776,10 +4740,8 @@ namespace NorthwindModel
         /// <summary>
         /// Gets the collection of associated <see cref="Territory"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"})]
         [global::System.ComponentModel.DataAnnotations.CompositionAttribute()]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID")]
         public global::OpenRiaServices.Client.EntityCollection<global::NorthwindModel.Territory> Territories
         {
             get
@@ -4860,9 +4822,7 @@ namespace NorthwindModel
         /// <summary>
         /// Gets or sets the associated <see cref="Region"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Region_Territory", new string[] {
-                "RegionID"}, new string[] {
-                "RegionID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Region_Territory", "RegionID", "RegionID", IsForeignKey=true)]
         public global::NorthwindModel.Region Region
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios.g.cs
@@ -542,9 +542,7 @@ namespace TestDomainServices
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="D_Ref1")]
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", new string[] {
-                "DID_Ref1"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey=true)]
         public global::TestDomainServices.D D_Ref1
         {
             get
@@ -587,9 +585,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", new string[] {
-                "DID_Ref2"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey=true)]
         public global::TestDomainServices.D D_Ref2
         {
             get
@@ -778,9 +774,7 @@ namespace TestDomainServices
         /// Gets the collection of associated <see cref="CartItem"/> entity instances.
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.EditableAttribute(false)]
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", new string[] {
-                "CartId"}, new string[] {
-                "CartItemId"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", "CartId", "CartItemId")]
         [global::System.ComponentModel.ReadOnlyAttribute(true)]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.CartItem> Items
         {
@@ -862,9 +856,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="Cart"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", new string[] {
-                "CartItemId"}, new string[] {
-                "CartId"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", "CartItemId", "CartId", IsForeignKey=true)]
         public global::TestDomainServices.Cart Cart
         {
             get
@@ -1209,9 +1201,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="C"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", new string[] {
-                "ID"}, new string[] {
-                "DID_Ref1"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", "ID", "DID_Ref1")]
         public global::TestDomainServices.C C
         {
             get
@@ -1246,9 +1236,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", new string[] {
-                "DSelfRef_ID1"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", "DSelfRef_ID1", "ID", IsForeignKey=true)]
         public global::TestDomainServices.D D1
         {
             get
@@ -1291,9 +1279,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", new string[] {
-                "DSelfRef_ID2"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", "DSelfRef_ID2", "ID", IsForeignKey=true)]
         public global::TestDomainServices.D D2
         {
             get
@@ -1336,9 +1322,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", new string[] {
-                "ID"}, new string[] {
-                "DSelfRef_ID2"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", "ID", "DSelfRef_ID2")]
         public global::TestDomainServices.D D2_BackRef
         {
             get
@@ -1373,9 +1357,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="D"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", new string[] {
-                "ID"}, new string[] {
-                "DSelfRef_ID1"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", "ID", "DSelfRef_ID1")]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.D> Ds
         {
             get
@@ -5502,9 +5484,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKParent"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", new string[] {
-                "ParentID"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", "ParentID", "ID", IsForeignKey=true)]
         public global::TestDomainServices.NullableFKParent Parent
         {
             get
@@ -5547,9 +5527,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKParent"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", new string[] {
-                "ParentID_Singleton"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", "ParentID_Singleton", "ID", IsForeignKey=true)]
         public global::TestDomainServices.NullableFKParent Parent2
         {
             get
@@ -5700,9 +5678,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKChild"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", new string[] {
-                "ID"}, new string[] {
-                "ParentID_Singleton"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", "ID", "ParentID_Singleton")]
         public global::TestDomainServices.NullableFKChild Child
         {
             get
@@ -5737,9 +5713,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="NullableFKChild"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", new string[] {
-                "ID"}, new string[] {
-                "ParentID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", "ID", "ParentID")]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.NullableFKChild> Children
         {
             get
@@ -6205,9 +6179,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="RoundtripOriginal_TestEntity"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("RTO_RTO2", new string[] {
-                "ID"}, new string[] {
-                "ID"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("RTO_RTO2", "ID", "ID")]
         public global::TestDomainServices.RoundtripOriginal_TestEntity AssocProp
         {
             get
@@ -6592,9 +6564,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="TestCycles"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", new string[] {
-                "ParentName"}, new string[] {
-                "Name"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", "ParentName", "Name", IsForeignKey=true)]
         public global::TestDomainServices.TestCycles IncludedT
         {
             get
@@ -6637,9 +6607,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="TestCycles"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", new string[] {
-                "Name"}, new string[] {
-                "ParentName"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", "Name", "ParentName")]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.TestCycles> IncludedTs
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios.g.cs
@@ -76,7 +76,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="B"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("A_B", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("A_B", new string[] {
                 "BID1",
                 "BID2"}, new string[] {
                 "ID1",
@@ -354,12 +354,12 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="C"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("B_C", new string[] {
+        [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="Cs")]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("B_C", new string[] {
                 "ID1",
                 "ID2"}, new string[] {
                 "BID1",
                 "BID2"})]
-        [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="Cs")]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.C> Cs
         {
             get
@@ -541,10 +541,10 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("C_D_Ref1", new string[] {
+        [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="D_Ref1")]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", new string[] {
                 "DID_Ref1"}, new string[] {
                 "ID"}, IsForeignKey=true)]
-        [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="D_Ref1")]
         public global::TestDomainServices.D D_Ref1
         {
             get
@@ -587,7 +587,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("C_D_Ref2", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", new string[] {
                 "DID_Ref2"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.D D_Ref2
@@ -777,10 +777,10 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="CartItem"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("CartItem_Cart", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EditableAttribute(false)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", new string[] {
                 "CartId"}, new string[] {
                 "CartItemId"})]
-        [global::System.ComponentModel.DataAnnotations.EditableAttribute(false)]
         [global::System.ComponentModel.ReadOnlyAttribute(true)]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.CartItem> Items
         {
@@ -862,7 +862,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="Cart"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("CartItem_Cart", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", new string[] {
                 "CartItemId"}, new string[] {
                 "CartId"}, IsForeignKey=true)]
         public global::TestDomainServices.Cart Cart
@@ -1209,7 +1209,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="C"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("C_D_Ref1", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", new string[] {
                 "ID"}, new string[] {
                 "DID_Ref1"})]
         public global::TestDomainServices.C C
@@ -1246,7 +1246,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("D_D", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", new string[] {
                 "DSelfRef_ID1"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.D D1
@@ -1291,7 +1291,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("D_D2", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", new string[] {
                 "DSelfRef_ID2"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.D D2
@@ -1336,7 +1336,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("D_D2", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", new string[] {
                 "ID"}, new string[] {
                 "DSelfRef_ID2"})]
         public global::TestDomainServices.D D2_BackRef
@@ -1373,7 +1373,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="D"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("D_D", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", new string[] {
                 "ID"}, new string[] {
                 "DSelfRef_ID1"})]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.D> Ds
@@ -5502,7 +5502,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKParent"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Parent_Child", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", new string[] {
                 "ParentID"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.NullableFKParent Parent
@@ -5547,7 +5547,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKParent"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Parent_Child_Singleton", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", new string[] {
                 "ParentID_Singleton"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.NullableFKParent Parent2
@@ -5700,7 +5700,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="NullableFKChild"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Parent_Child_Singleton", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", new string[] {
                 "ID"}, new string[] {
                 "ParentID_Singleton"})]
         public global::TestDomainServices.NullableFKChild Child
@@ -5737,7 +5737,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="NullableFKChild"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("Parent_Child", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", new string[] {
                 "ID"}, new string[] {
                 "ParentID"})]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.NullableFKChild> Children
@@ -6205,7 +6205,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="RoundtripOriginal_TestEntity"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("RTO_RTO2", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("RTO_RTO2", new string[] {
                 "ID"}, new string[] {
                 "ID"})]
         public global::TestDomainServices.RoundtripOriginal_TestEntity AssocProp
@@ -6592,7 +6592,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="TestCycles"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("TestCycle_Parent", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", new string[] {
                 "ParentName"}, new string[] {
                 "Name"}, IsForeignKey=true)]
         public global::TestDomainServices.TestCycles IncludedT
@@ -6637,7 +6637,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="TestCycles"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("TestCycle_Parent", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", new string[] {
                 "Name"}, new string[] {
                 "ParentName"})]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.TestCycles> IncludedTs

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios.g.vb
@@ -515,7 +515,7 @@ Namespace TestDomainServices
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="D_Ref1"),  _
-         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", New String() {"DID_Ref1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref1() As Global.TestDomainServices.D
             Get
                 If (Me._d_Ref1 Is Nothing) Then
@@ -548,7 +548,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", New String() {"DID_Ref2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref2() As Global.TestDomainServices.D
             Get
                 If (Me._d_Ref2 Is Nothing) Then
@@ -717,7 +717,7 @@ Namespace TestDomainServices
         ''' Gets the collection of associated <see cref="CartItem"/> entity instances.
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.EditableAttribute(false),  _
-         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", New String() {"CartId"}, New String() {"CartItemId"}),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", "CartId", "CartItemId"),  _
          Global.System.ComponentModel.ReadOnlyAttribute(true)>  _
         Public ReadOnly Property Items() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.CartItem)
             Get
@@ -799,7 +799,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="Cart"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", New String() {"CartItemId"}, New String() {"CartId"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", "CartItemId", "CartId", IsForeignKey:=true)>  _
         Public Property Cart() As Global.TestDomainServices.Cart
             Get
                 If (Me._cart Is Nothing) Then
@@ -1124,7 +1124,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="C"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", New String() {"ID"}, New String() {"DID_Ref1"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", "ID", "DID_Ref1")>  _
         Public Property C() As Global.TestDomainServices.C
             Get
                 If (Me._c Is Nothing) Then
@@ -1152,7 +1152,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", New String() {"DSelfRef_ID1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", "DSelfRef_ID1", "ID", IsForeignKey:=true)>  _
         Public Property D1() As Global.TestDomainServices.D
             Get
                 If (Me._d1 Is Nothing) Then
@@ -1185,7 +1185,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", New String() {"DSelfRef_ID2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", "DSelfRef_ID2", "ID", IsForeignKey:=true)>  _
         Public Property D2() As Global.TestDomainServices.D
             Get
                 If (Me._d2 Is Nothing) Then
@@ -1218,7 +1218,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", New String() {"ID"}, New String() {"DSelfRef_ID2"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", "ID", "DSelfRef_ID2")>  _
         Public Property D2_BackRef() As Global.TestDomainServices.D
             Get
                 If (Me._d2_BackRef Is Nothing) Then
@@ -1246,7 +1246,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="D"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", New String() {"ID"}, New String() {"DSelfRef_ID1"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", "ID", "DSelfRef_ID1")>  _
         Public ReadOnly Property Ds() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.D)
             Get
                 If (Me._ds Is Nothing) Then
@@ -5161,7 +5161,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKParent"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", "ParentID", "ID", IsForeignKey:=true)>  _
         Public Property Parent() As Global.TestDomainServices.NullableFKParent
             Get
                 If (Me._parent Is Nothing) Then
@@ -5194,7 +5194,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKParent"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", New String() {"ParentID_Singleton"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", "ParentID_Singleton", "ID", IsForeignKey:=true)>  _
         Public Property Parent2() As Global.TestDomainServices.NullableFKParent
             Get
                 If (Me._parent2 Is Nothing) Then
@@ -5329,7 +5329,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKChild"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", New String() {"ID"}, New String() {"ParentID_Singleton"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", "ID", "ParentID_Singleton")>  _
         Public Property Child() As Global.TestDomainServices.NullableFKChild
             Get
                 If (Me._child Is Nothing) Then
@@ -5357,7 +5357,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="NullableFKChild"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", New String() {"ID"}, New String() {"ParentID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", "ID", "ParentID")>  _
         Public ReadOnly Property Children() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.NullableFKChild)
             Get
                 If (Me._children Is Nothing) Then
@@ -5801,7 +5801,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="RoundtripOriginal_TestEntity"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("RTO_RTO2", New String() {"ID"}, New String() {"ID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("RTO_RTO2", "ID", "ID")>  _
         Public Property AssocProp() As Global.TestDomainServices.RoundtripOriginal_TestEntity
             Get
                 If (Me._assocProp Is Nothing) Then
@@ -6166,7 +6166,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="TestCycles"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", New String() {"ParentName"}, New String() {"Name"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", "ParentName", "Name", IsForeignKey:=true)>  _
         Public Property IncludedT() As Global.TestDomainServices.TestCycles
             Get
                 If (Me._includedT Is Nothing) Then
@@ -6199,7 +6199,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="TestCycles"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", New String() {"Name"}, New String() {"ParentName"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", "Name", "ParentName")>  _
         Public ReadOnly Property IncludedTs() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.TestCycles)
             Get
                 If (Me._includedTs Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios.g.vb
@@ -95,7 +95,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="B"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("A_B", New String() {"BID1", "BID2"}, New String() {"ID1", "ID2"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("A_B", New String() {"BID1", "BID2"}, New String() {"ID1", "ID2"}, IsForeignKey:=true)>  _
         Public Property B() As Global.TestDomainServices.B
             Get
                 If (Me._b Is Nothing) Then
@@ -338,8 +338,8 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="C"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("B_C", New String() {"ID1", "ID2"}, New String() {"BID1", "BID2"}),  _
-         Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="Cs")>  _
+        <Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="Cs"),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("B_C", New String() {"ID1", "ID2"}, New String() {"BID1", "BID2"})>  _
         Public ReadOnly Property Cs() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.C)
             Get
                 If (Me._cs Is Nothing) Then
@@ -514,8 +514,8 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("C_D_Ref1", New String() {"DID_Ref1"}, New String() {"ID"}, IsForeignKey:=true),  _
-         Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="D_Ref1")>  _
+        <Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="D_Ref1"),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", New String() {"DID_Ref1"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property D_Ref1() As Global.TestDomainServices.D
             Get
                 If (Me._d_Ref1 Is Nothing) Then
@@ -548,7 +548,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("C_D_Ref2", New String() {"DID_Ref2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", New String() {"DID_Ref2"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property D_Ref2() As Global.TestDomainServices.D
             Get
                 If (Me._d_Ref2 Is Nothing) Then
@@ -716,8 +716,8 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="CartItem"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("CartItem_Cart", New String() {"CartId"}, New String() {"CartItemId"}),  _
-         Global.System.ComponentModel.DataAnnotations.EditableAttribute(false),  _
+        <Global.System.ComponentModel.DataAnnotations.EditableAttribute(false),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", New String() {"CartId"}, New String() {"CartItemId"}),  _
          Global.System.ComponentModel.ReadOnlyAttribute(true)>  _
         Public ReadOnly Property Items() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.CartItem)
             Get
@@ -799,7 +799,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="Cart"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("CartItem_Cart", New String() {"CartItemId"}, New String() {"CartId"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("CartItem_Cart", New String() {"CartItemId"}, New String() {"CartId"}, IsForeignKey:=true)>  _
         Public Property Cart() As Global.TestDomainServices.Cart
             Get
                 If (Me._cart Is Nothing) Then
@@ -1124,7 +1124,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="C"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("C_D_Ref1", New String() {"ID"}, New String() {"DID_Ref1"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", New String() {"ID"}, New String() {"DID_Ref1"})>  _
         Public Property C() As Global.TestDomainServices.C
             Get
                 If (Me._c Is Nothing) Then
@@ -1152,7 +1152,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("D_D", New String() {"DSelfRef_ID1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", New String() {"DSelfRef_ID1"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property D1() As Global.TestDomainServices.D
             Get
                 If (Me._d1 Is Nothing) Then
@@ -1185,7 +1185,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("D_D2", New String() {"DSelfRef_ID2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", New String() {"DSelfRef_ID2"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property D2() As Global.TestDomainServices.D
             Get
                 If (Me._d2 Is Nothing) Then
@@ -1218,7 +1218,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("D_D2", New String() {"ID"}, New String() {"DSelfRef_ID2"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", New String() {"ID"}, New String() {"DSelfRef_ID2"})>  _
         Public Property D2_BackRef() As Global.TestDomainServices.D
             Get
                 If (Me._d2_BackRef Is Nothing) Then
@@ -1246,7 +1246,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="D"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("D_D", New String() {"ID"}, New String() {"DSelfRef_ID1"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", New String() {"ID"}, New String() {"DSelfRef_ID1"})>  _
         Public ReadOnly Property Ds() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.D)
             Get
                 If (Me._ds Is Nothing) Then
@@ -5161,7 +5161,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKParent"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Parent_Child", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", New String() {"ParentID"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property Parent() As Global.TestDomainServices.NullableFKParent
             Get
                 If (Me._parent Is Nothing) Then
@@ -5194,7 +5194,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKParent"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Parent_Child_Singleton", New String() {"ParentID_Singleton"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", New String() {"ParentID_Singleton"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property Parent2() As Global.TestDomainServices.NullableFKParent
             Get
                 If (Me._parent2 Is Nothing) Then
@@ -5329,7 +5329,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="NullableFKChild"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Parent_Child_Singleton", New String() {"ID"}, New String() {"ParentID_Singleton"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child_Singleton", New String() {"ID"}, New String() {"ParentID_Singleton"})>  _
         Public Property Child() As Global.TestDomainServices.NullableFKChild
             Get
                 If (Me._child Is Nothing) Then
@@ -5357,7 +5357,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="NullableFKChild"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("Parent_Child", New String() {"ID"}, New String() {"ParentID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("Parent_Child", New String() {"ID"}, New String() {"ParentID"})>  _
         Public ReadOnly Property Children() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.NullableFKChild)
             Get
                 If (Me._children Is Nothing) Then
@@ -5801,7 +5801,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="RoundtripOriginal_TestEntity"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("RTO_RTO2", New String() {"ID"}, New String() {"ID"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("RTO_RTO2", New String() {"ID"}, New String() {"ID"})>  _
         Public Property AssocProp() As Global.TestDomainServices.RoundtripOriginal_TestEntity
             Get
                 If (Me._assocProp Is Nothing) Then
@@ -6166,7 +6166,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="TestCycles"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("TestCycle_Parent", New String() {"ParentName"}, New String() {"Name"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", New String() {"ParentName"}, New String() {"Name"}, IsForeignKey:=true)>  _
         Public Property IncludedT() As Global.TestDomainServices.TestCycles
             Get
                 If (Me._includedT Is Nothing) Then
@@ -6199,7 +6199,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="TestCycles"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("TestCycle_Parent", New String() {"Name"}, New String() {"ParentName"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("TestCycle_Parent", New String() {"Name"}, New String() {"ParentName"})>  _
         Public ReadOnly Property IncludedTs() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.TestCycles)
             Get
                 If (Me._includedTs Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
@@ -76,7 +76,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="B"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("A_B", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("A_B", new string[] {
                 "BID1",
                 "BID2"}, new string[] {
                 "ID1",
@@ -354,12 +354,12 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="C"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("B_C", new string[] {
+        [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="Cs")]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("B_C", new string[] {
                 "ID1",
                 "ID2"}, new string[] {
                 "BID1",
                 "BID2"})]
-        [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="Cs")]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.C> Cs
         {
             get
@@ -541,10 +541,10 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("C_D_Ref1", new string[] {
+        [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="D_Ref1")]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", new string[] {
                 "DID_Ref1"}, new string[] {
                 "ID"}, IsForeignKey=true)]
-        [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="D_Ref1")]
         public global::TestDomainServices.D D_Ref1
         {
             get
@@ -587,7 +587,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("C_D_Ref2", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", new string[] {
                 "DID_Ref2"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.D D_Ref2
@@ -803,7 +803,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="C"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("C_D_Ref1", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", new string[] {
                 "ID"}, new string[] {
                 "DID_Ref1"})]
         public global::TestDomainServices.C C
@@ -840,7 +840,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("D_D", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", new string[] {
                 "DSelfRef_ID1"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.D D1
@@ -885,7 +885,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("D_D2", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", new string[] {
                 "DSelfRef_ID2"}, new string[] {
                 "ID"}, IsForeignKey=true)]
         public global::TestDomainServices.D D2
@@ -930,7 +930,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("D_D2", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", new string[] {
                 "ID"}, new string[] {
                 "DSelfRef_ID2"})]
         public global::TestDomainServices.D D2_BackRef
@@ -967,7 +967,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="D"/> entity instances.
         /// </summary>
-        [global::OpenRiaServices.EntityAssociationAttribute("D_D", new string[] {
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", new string[] {
                 "ID"}, new string[] {
                 "DSelfRef_ID1"})]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.D> Ds

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
@@ -542,9 +542,7 @@ namespace TestDomainServices
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.DisplayAttribute(Description="D_Ref1")]
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", new string[] {
-                "DID_Ref1"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey=true)]
         public global::TestDomainServices.D D_Ref1
         {
             get
@@ -587,9 +585,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", new string[] {
-                "DID_Ref2"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey=true)]
         public global::TestDomainServices.D D_Ref2
         {
             get
@@ -803,9 +799,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="C"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", new string[] {
-                "ID"}, new string[] {
-                "DID_Ref1"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", "ID", "DID_Ref1")]
         public global::TestDomainServices.C C
         {
             get
@@ -840,9 +834,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", new string[] {
-                "DSelfRef_ID1"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", "DSelfRef_ID1", "ID", IsForeignKey=true)]
         public global::TestDomainServices.D D1
         {
             get
@@ -885,9 +877,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", new string[] {
-                "DSelfRef_ID2"}, new string[] {
-                "ID"}, IsForeignKey=true)]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", "DSelfRef_ID2", "ID", IsForeignKey=true)]
         public global::TestDomainServices.D D2
         {
             get
@@ -930,9 +920,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets or sets the associated <see cref="D"/> entity.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", new string[] {
-                "ID"}, new string[] {
-                "DSelfRef_ID2"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", "ID", "DSelfRef_ID2")]
         public global::TestDomainServices.D D2_BackRef
         {
             get
@@ -967,9 +955,7 @@ namespace TestDomainServices
         /// <summary>
         /// Gets the collection of associated <see cref="D"/> entity instances.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", new string[] {
-                "ID"}, new string[] {
-                "DSelfRef_ID1"})]
+        [global::System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", "ID", "DSelfRef_ID1")]
         public global::OpenRiaServices.Client.EntityCollection<global::TestDomainServices.D> Ds
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
@@ -95,7 +95,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="B"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("A_B", New String() {"BID1", "BID2"}, New String() {"ID1", "ID2"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("A_B", New String() {"BID1", "BID2"}, New String() {"ID1", "ID2"}, IsForeignKey:=true)>  _
         Public Property B() As Global.TestDomainServices.B
             Get
                 If (Me._b Is Nothing) Then
@@ -338,8 +338,8 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="C"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("B_C", New String() {"ID1", "ID2"}, New String() {"BID1", "BID2"}),  _
-         Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="Cs")>  _
+        <Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="Cs"),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("B_C", New String() {"ID1", "ID2"}, New String() {"BID1", "BID2"})>  _
         Public ReadOnly Property Cs() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.C)
             Get
                 If (Me._cs Is Nothing) Then
@@ -514,8 +514,8 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("C_D_Ref1", New String() {"DID_Ref1"}, New String() {"ID"}, IsForeignKey:=true),  _
-         Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="D_Ref1")>  _
+        <Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="D_Ref1"),  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", New String() {"DID_Ref1"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property D_Ref1() As Global.TestDomainServices.D
             Get
                 If (Me._d_Ref1 Is Nothing) Then
@@ -548,7 +548,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("C_D_Ref2", New String() {"DID_Ref2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", New String() {"DID_Ref2"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property D_Ref2() As Global.TestDomainServices.D
             Get
                 If (Me._d_Ref2 Is Nothing) Then
@@ -751,7 +751,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="C"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("C_D_Ref1", New String() {"ID"}, New String() {"DID_Ref1"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", New String() {"ID"}, New String() {"DID_Ref1"})>  _
         Public Property C() As Global.TestDomainServices.C
             Get
                 If (Me._c Is Nothing) Then
@@ -779,7 +779,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("D_D", New String() {"DSelfRef_ID1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", New String() {"DSelfRef_ID1"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property D1() As Global.TestDomainServices.D
             Get
                 If (Me._d1 Is Nothing) Then
@@ -812,7 +812,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("D_D2", New String() {"DSelfRef_ID2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", New String() {"DSelfRef_ID2"}, New String() {"ID"}, IsForeignKey:=true)>  _
         Public Property D2() As Global.TestDomainServices.D
             Get
                 If (Me._d2 Is Nothing) Then
@@ -845,7 +845,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("D_D2", New String() {"ID"}, New String() {"DSelfRef_ID2"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", New String() {"ID"}, New String() {"DSelfRef_ID2"})>  _
         Public Property D2_BackRef() As Global.TestDomainServices.D
             Get
                 If (Me._d2_BackRef Is Nothing) Then
@@ -873,7 +873,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="D"/> entity instances.
         ''' </summary>
-        <Global.OpenRiaServices.EntityAssociationAttribute("D_D", New String() {"ID"}, New String() {"DSelfRef_ID1"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", New String() {"ID"}, New String() {"DSelfRef_ID1"})>  _
         Public ReadOnly Property Ds() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.D)
             Get
                 If (Me._ds Is Nothing) Then

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
@@ -515,7 +515,7 @@ Namespace TestDomainServices
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.DisplayAttribute(Description:="D_Ref1"),  _
-         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", New String() {"DID_Ref1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+         Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref1() As Global.TestDomainServices.D
             Get
                 If (Me._d_Ref1 Is Nothing) Then
@@ -548,7 +548,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", New String() {"DID_Ref2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref2() As Global.TestDomainServices.D
             Get
                 If (Me._d_Ref2 Is Nothing) Then
@@ -751,7 +751,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="C"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", New String() {"ID"}, New String() {"DID_Ref1"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("C_D_Ref1", "ID", "DID_Ref1")>  _
         Public Property C() As Global.TestDomainServices.C
             Get
                 If (Me._c Is Nothing) Then
@@ -779,7 +779,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", New String() {"DSelfRef_ID1"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", "DSelfRef_ID1", "ID", IsForeignKey:=true)>  _
         Public Property D1() As Global.TestDomainServices.D
             Get
                 If (Me._d1 Is Nothing) Then
@@ -812,7 +812,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", New String() {"DSelfRef_ID2"}, New String() {"ID"}, IsForeignKey:=true)>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", "DSelfRef_ID2", "ID", IsForeignKey:=true)>  _
         Public Property D2() As Global.TestDomainServices.D
             Get
                 If (Me._d2 Is Nothing) Then
@@ -845,7 +845,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", New String() {"ID"}, New String() {"DSelfRef_ID2"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D2", "ID", "DSelfRef_ID2")>  _
         Public Property D2_BackRef() As Global.TestDomainServices.D
             Get
                 If (Me._d2_BackRef Is Nothing) Then
@@ -873,7 +873,7 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets the collection of associated <see cref="D"/> entity instances.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", New String() {"ID"}, New String() {"DSelfRef_ID1"})>  _
+        <Global.System.ComponentModel.DataAnnotations.EntityAssociationAttribute("D_D", "ID", "DSelfRef_ID1")>  _
         Public ReadOnly Property Ds() As Global.OpenRiaServices.Client.EntityCollection(Of Global.TestDomainServices.D)
             Get
                 If (Me._ds Is Nothing) Then


### PR DESCRIPTION
1. Change `EntityAssociationAttribute` namespace to `System.ComponentModel.DataAnnotations`
    * This will match other attributes such as `[Composition]` as well as the `AssociationAttribute` is should replace
2. Add  a constructor taking 2 strings for the case where the key is a single member
3. Update code generation to use new constructor when possible (`EntityAssociationAttributeBuilder`)
4. Update baselines
