### PR TITLE
Move DomainServiceEndpointRoutePatternAttribute to Hosting

### DIFF
--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/DomainServiceEndpointRoutePatternAttribute.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/DomainServiceEndpointRoutePatternAttribute.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 
-namespace OpenRiaServices.Server
+namespace OpenRiaServices.Hosting.AspNetCore
 {
-#if NET
     /// <summary>
     /// Determine how endpoints routes (Uris to access DomainServices) are generated
     /// </summary>
@@ -28,7 +27,7 @@ namespace OpenRiaServices.Server
     }
 
     /// <summary>
-    /// Attribute to configure the pattern used for endpoint, see <see cref="Server.EndpointRoutePattern"/>
+    /// Attribute to configure the pattern used for endpoint, see <see cref="AspNetCore.EndpointRoutePattern"/>
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = true)]
     public sealed class DomainServiceEndpointRoutePatternAttribute : Attribute
@@ -36,7 +35,7 @@ namespace OpenRiaServices.Server
         /// <summary>
         /// Initializes a new instance of the <see cref="DomainServiceEndpointRoutePatternAttribute"/> class.
         /// </summary>
-        /// <param name="endpointRoutePattern"><see cref="Server.EndpointRoutePattern"/> to use</param>
+        /// <param name="endpointRoutePattern"><see cref="AspNetCore.EndpointRoutePattern"/> to use</param>
         public DomainServiceEndpointRoutePatternAttribute(EndpointRoutePattern endpointRoutePattern)
             => EndpointRoutePattern = endpointRoutePattern;
 
@@ -45,5 +44,4 @@ namespace OpenRiaServices.Server
         /// </summary>
         public EndpointRoutePattern EndpointRoutePattern { get; }
     }
-#endif
 }

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpDomainContextGenerator.partial.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpDomainContextGenerator.partial.cs
@@ -150,13 +150,11 @@ namespace OpenRiaServices.Tools.TextTemplate.CSharpGenerators
         private string GetDomainServiceUri()
         {
             Type type = this.DomainServiceDescription.DomainServiceType;
-#if NET
+
             // Lookup DomainServiceEndpointRoutePatternAttribute first in same assembly as DomainService
-            // Then in the entry point assembly
-            // - Fallback
-            EndpointRoutePattern routePattern = type.Assembly.GetCustomAttribute<DomainServiceEndpointRoutePatternAttribute>()?.EndpointRoutePattern is { } endpointRoutePattern
-                ? (EndpointRoutePattern)(int)(endpointRoutePattern)
-                : (EndpointRoutePattern)(int)this.ClientCodeGenerator.Options.DefaultEndpointRoutePattern;
+            // Otherwise fallback to default
+            EndpointRoutePattern routePattern = SharedCodeGenUtilities.TryGetRoutePatternFromAssembly(type.Assembly)
+                ?? this.ClientCodeGenerator.Options.DefaultEndpointRoutePattern;
 
             return routePattern switch
             {
@@ -165,9 +163,6 @@ namespace OpenRiaServices.Tools.TextTemplate.CSharpGenerators
                 EndpointRoutePattern.FullName => type.FullName.Replace('.', '-'),
                 _ => throw new NotImplementedException(),
             };
-#else
-            return type.FullName.Replace('.', '-') + ".svc";
-#endif
         }
     }
 }

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/OpenRiaServices.Tools.TextTemplate.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/OpenRiaServices.Tools.TextTemplate.csproj
@@ -10,6 +10,7 @@
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Tools\Framework\SharedCodeGenUtilities.cs" Link="Utilities\SharedCodeGenUtilities.cs" />
     <Compile Include="..\..\OpenRiaServices.Tools\Framework\MetadataPipeline\AttributeBuilderException.cs" Link="CSharpGenerators\AttributeGenerationHelpers\AttributeBuilderException.cs" />
     <Compile Include="..\..\OpenRiaServices.Tools\Framework\MetadataPipeline\AttributeDeclaration.cs" Link="CSharpGenerators\AttributeGenerationHelpers\AttributeDeclaration.cs" />
     <Compile Include="..\..\OpenRiaServices.Tools\Framework\MetadataPipeline\CustomValidationCustomAttributeBuilder.cs" Link="CSharpGenerators\AttributeGenerationHelpers\CustomValidationCustomAttributeBuilder.cs" />

--- a/src/OpenRiaServices.Tools/Framework/ClientCodeGenerationDispatcher.cs
+++ b/src/OpenRiaServices.Tools/Framework/ClientCodeGenerationDispatcher.cs
@@ -82,15 +82,12 @@ namespace OpenRiaServices.Tools
                 {
                     CodeGenerationHost host = new CodeGenerationHost(loggingService, sharedCodeService);
 
-#if NET
                     // If the server assembly has a DomainServiceEndpointRoutePatternAttribute, we use it to set the default EndpointRoutePattern
                     Assembly linkedServerAssembly = AssemblyUtilities.LoadAssembly(parameters.ServerAssemblies.First() + ".dll", loggingService);
-                    if (linkedServerAssembly?.GetCustomAttribute<DomainServiceEndpointRoutePatternAttribute>() is { } routeAttribute)
+                    if (SharedCodeGenUtilities.TryGetRoutePatternFromAssembly(linkedServerAssembly) is { } pattern)
                     {
-                        options.DefaultEndpointRoutePattern = (EndpointRoutePattern)(int)routeAttribute.EndpointRoutePattern;
+                        options.DefaultEndpointRoutePattern = pattern;
                     }
-#endif
-
                     return this.GenerateCode(host, options, parameters.ServerAssemblies, codeGeneratorName);
                 }
             }

--- a/src/OpenRiaServices.Tools/Framework/ClientCodeGenerationDispatcher.cs
+++ b/src/OpenRiaServices.Tools/Framework/ClientCodeGenerationDispatcher.cs
@@ -83,7 +83,7 @@ namespace OpenRiaServices.Tools
                     CodeGenerationHost host = new CodeGenerationHost(loggingService, sharedCodeService);
 
                     // If the server assembly has a DomainServiceEndpointRoutePatternAttribute, we use it to set the default EndpointRoutePattern
-                    Assembly linkedServerAssembly = AssemblyUtilities.LoadAssembly(parameters.ServerAssemblies.First() + ".dll", loggingService);
+                    Assembly linkedServerAssembly = AssemblyUtilities.LoadAssembly(parameters.ServerAssemblies.First(), loggingService);
                     if (SharedCodeGenUtilities.TryGetRoutePatternFromAssembly(linkedServerAssembly) is { } pattern)
                     {
                         options.DefaultEndpointRoutePattern = pattern;

--- a/src/OpenRiaServices.Tools/Framework/SharedCodeGenUtilities.cs
+++ b/src/OpenRiaServices.Tools/Framework/SharedCodeGenUtilities.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace OpenRiaServices.Tools
+{
+    /// <summary>
+    /// A collection of code generation utilities.
+    /// </summary>
+    internal static partial class SharedCodeGenUtilities
+    {
+        public static EndpointRoutePattern? TryGetRoutePatternFromAssembly(Assembly assembly)
+        {
+#if NET
+            if(assembly?.CustomAttributes.FirstOrDefault(cad => cad.AttributeType.FullName ==  "OpenRiaServices.Hosting.AspNetCore.DomainServiceEndpointRoutePatternAttribute")
+                        is { ConstructorArguments: [var constructorArgument] } )
+            {
+                return (EndpointRoutePattern)Convert.ToInt32(constructorArgument.Value, CultureInfo.InvariantCulture);
+            }
+            return null;
+#else
+            return EndpointRoutePattern.WCF;
+#endif
+        }
+    }
+}


### PR DESCRIPTION
1. Move DomainServiceEndpointRoutePatternAttribute to Hosting
2. Fix code which looks for the DomainServiceEndpointRoutePatternAttribute in the LinkedServer projekt