### PR TITLE
Update nugets and Add some trimming annotations

### DIFF
--- a/NuGet/OpenRiaServices.Client.Core.nuspec
+++ b/NuGet/OpenRiaServices.Client.Core.nuspec
@@ -24,8 +24,8 @@
         <dependency id="System.ServiceModel.Primitives" version="4.10.2" />
       </group>
       <group targetFramework="net6.0-windows7.0">
-        <dependency id="System.ServiceModel.Http" version="4.10.2" />
-        <dependency id="System.ServiceModel.Primitives" version="4.10.2" />
+        <dependency id="System.ServiceModel.Http" version="6.2.0" />
+        <dependency id="System.ServiceModel.Primitives" version="6.2.0" />
       </group>
     </dependencies>
     <frameworkReferences>

--- a/NuGet/OpenRiaServices.Hosting.Wcf/OpenRiaServices.Hosting.Wcf.nuspec
+++ b/NuGet/OpenRiaServices.Hosting.Wcf/OpenRiaServices.Hosting.Wcf.nuspec
@@ -20,7 +20,7 @@
     <tags>WCF RIA Services RIAServices Server aspnet OpenRiaServices</tags>
 	<dependencies>
 		<group targetFramework="net472">
-			<dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.0"/>
+			<dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.2"/>
 			<dependency id="OpenRiaServices.Server" version="$version$"/>
 			<dependency id="System.Collections.Immutable" version="8.0.0" />
 			<dependency id="System.Memory" version="4.5.5"/>

--- a/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
+++ b/NuGet/OpenRiaServices.Server/OpenRiaServices.Server.nuspec
@@ -28,11 +28,11 @@
 		<group targetFramework="netstandard2.0">
 			<dependency id="System.ComponentModel.Annotations" version="5.0.0"/>
 			<dependency id="System.Reflection.Emit.Lightweight" version="4.7.0"/>
-			<dependency id="System.CodeDom" version="7.0.0"/>
+			<dependency id="System.CodeDom" version="8.0.0"/>
 			<dependency id="System.Threading.Tasks.Extensions" version="4.5.4"/>
 		</group>
 		<group targetFramework="net6.0">
-			<dependency id="System.CodeDom" version="7.0.0"/>
+			<dependency id="System.CodeDom" version="8.0.0"/>
 		</group>
 	</dependencies>
   </metadata>

--- a/NuGet/OpenRiaServices.T4.nuspec
+++ b/NuGet/OpenRiaServices.T4.nuspec
@@ -17,11 +17,11 @@
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="OpenRiaServices.Server" version="$version$" />
-        <dependency id="Mono.Cecil" version="0.11.5" />
+        <dependency id="Mono.Cecil" version="0.11.6" />
       </group>
       <group targetFramework="net472">
         <dependency id="OpenRiaServices.Server" version="$version$" />
-        <dependency id="Mono.Cecil" version="0.11.5" />
+        <dependency id="Mono.Cecil" version="0.11.6" />
       </group>
     </dependencies>
   </metadata>

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.10.2" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="6.2.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.Client.Web/Framework/OpenRiaServices.Client.Web.csproj
+++ b/src/OpenRiaServices.Client.Web/Framework/OpenRiaServices.Client.Web.csproj
@@ -6,8 +6,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net472'  ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'  ">
     <PackageReference Include="System.ServiceModel.Http" Version="4.10.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net472' and '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="System.ServiceModel.Http" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/OpenRiaServices.Client/Framework/DomainClientFactory.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenRiaServices.Client
 {
@@ -60,7 +61,7 @@ namespace OpenRiaServices.Client
         /// <exception cref="ArgumentNullException"><paramref name="serviceContract"/> or <paramref name="serviceUri"/> is null</exception>
         /// <exception cref="ArgumentException"><paramref name="serviceContract"/>  is not an interface</exception>
         /// <returns>A <see cref="DomainClient"/> to use when communicating with the service</returns>
-        public DomainClient CreateDomainClient(Type serviceContract, Uri serviceUri, bool requiresSecureEndpoint)
+        public DomainClient CreateDomainClient([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type serviceContract, Uri serviceUri, bool requiresSecureEndpoint)
         {
             if (serviceContract == null)
                 throw new ArgumentNullException(nameof(serviceContract));

--- a/src/OpenRiaServices.Client/Framework/DomainContext.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainContext.cs
@@ -4,13 +4,13 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenRiaServices.Client.Data;
 
 namespace OpenRiaServices.Client
 {
@@ -68,7 +68,7 @@ namespace OpenRiaServices.Client
         ///  fall back to a "DefaultDomainClientFactory" with the same behaviour as in this function.
         /// </remarks>
         /// <returns>A domain client which can be used to access the service which the serviceContract reference</returns>
-        protected static DomainClient CreateDomainClient(Type serviceContract, Uri serviceUri, bool usesHttps)
+        protected static DomainClient CreateDomainClient([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type serviceContract, Uri serviceUri, bool usesHttps)
         {
             return DomainClientFactory.CreateDomainClient(serviceContract, serviceUri, usesHttps);
         }

--- a/src/OpenRiaServices.Client/Framework/EntityContainer.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityContainer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 
@@ -129,7 +130,7 @@ namespace OpenRiaServices.Client
         /// </summary>
         /// <typeparam name="TEntity">The Entity type</typeparam>
         /// <param name="supportedOperations">The operations supported for the Entity type</param>
-        protected void CreateEntitySet<TEntity>(EntitySetOperations supportedOperations) where TEntity : Entity
+        protected void CreateEntitySet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TEntity>(EntitySetOperations supportedOperations) where TEntity : Entity
         {
             EntitySet set = new EntitySet<TEntity>();
             this.AddEntitySet(set, supportedOperations);

--- a/src/OpenRiaServices.Client/Framework/IDomainClientFactory.cs
+++ b/src/OpenRiaServices.Client/Framework/IDomainClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace OpenRiaServices.Client
 {
@@ -15,6 +16,6 @@ namespace OpenRiaServices.Client
         /// <param name="serviceUri">The service URI (not null).</param>
         /// <param name="requiresSecureEndpoint"><c>true</c> if DomainService has the RequiresSecureEndpoint attribute and encryption should be enabled.</param>
         /// <returns>A <see cref="DomainClient"/> to use when communicating with the service</returns>
-        DomainClient CreateDomainClient(Type serviceContract, Uri serviceUri, bool requiresSecureEndpoint);
+        DomainClient CreateDomainClient([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type serviceContract, Uri serviceUri, bool requiresSecureEndpoint);
     }
 }

--- a/src/OpenRiaServices.Client/Framework/Polyfills.cs
+++ b/src/OpenRiaServices.Client/Framework/Polyfills.cs
@@ -25,4 +25,105 @@ namespace System.Collections.Generic
         }
     }
 }
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    //
+    // Summary:
+    //     Specifies the types of members that are dynamically accessed. This enumeration
+    //     has a System.FlagsAttribute attribute that allows a bitwise combination of its
+    //     member values.
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        //
+        // Summary:
+        //     Specifies all members.
+        All = -1,
+        //
+        // Summary:
+        //     Specifies no members.
+        None = 0,
+        //
+        // Summary:
+        //     Specifies the default, parameterless public constructor.
+        PublicParameterlessConstructor = 1,
+        //
+        // Summary:
+        //     Specifies all public constructors.
+        PublicConstructors = 3,
+        //
+        // Summary:
+        //     Specifies all non-public constructors.
+        NonPublicConstructors = 4,
+        //
+        // Summary:
+        //     Specifies all public methods.
+        PublicMethods = 8,
+        //
+        // Summary:
+        //     Specifies all non-public methods.
+        NonPublicMethods = 16,
+        //
+        // Summary:
+        //     Specifies all public fields.
+        PublicFields = 32,
+        //
+        // Summary:
+        //     Specifies all non-public fields.
+        NonPublicFields = 64,
+        //
+        // Summary:
+        //     Specifies all public nested types.
+        PublicNestedTypes = 128,
+        //
+        // Summary:
+        //     Specifies all non-public nested types.
+        NonPublicNestedTypes = 256,
+        //
+        // Summary:
+        //     Specifies all public properties.
+        PublicProperties = 512,
+        //
+        // Summary:
+        //     Specifies all non-public properties.
+        NonPublicProperties = 1024,
+        //
+        // Summary:
+        //     Specifies all public events.
+        PublicEvents = 2048,
+        //
+        // Summary:
+        //     Specifies all non-public events.
+        NonPublicEvents = 4096,
+        //
+        // Summary:
+        //     Specifies all interfaces implemented by the type.
+        Interfaces = 8192
+    }
+
+    //
+    // Summary:
+    //     Indicates that certain members on a specified System.Type are accessed dynamically,
+    //     for example, through System.Reflection.
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Interface | AttributeTargets.Parameter | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter, Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        //
+        // Summary:
+        //     Initializes a new instance of the System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute
+        //     class with the specified member types.
+        //
+        // Parameters:
+        //   memberTypes:
+        //     The types of the dynamically accessed members.
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes) { }
+
+        //
+        // Summary:
+        //     Gets the System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes that
+        //     specifies the type of dynamically accessed members.
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+}
 #endif

--- a/src/OpenRiaServices.Client/Test/Client.External.Test/OpenRiaServices.Client.External.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.External.Test/OpenRiaServices.Client.External.Test.csproj
@@ -4,9 +4,9 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
@@ -6,10 +6,10 @@
     <DefineConstants>$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
-    <PackageReference Include="MSTest.Analyzers" Version="3.3.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="MSTest.Analyzers" Version="3.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.VisualBasic" />

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesConfigurationBuilder.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesConfigurationBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesConfigurationBuilder.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/OpenRiaServicesConfigurationBuilder.cs
@@ -20,12 +20,12 @@ namespace OpenRiaServices.Hosting.AspNetCore
             _typeIsService = typeIsService;
         }
 
-        public IEndpointConventionBuilder AddDomainService<T>() where T : DomainService
+        public IEndpointConventionBuilder AddDomainService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>() where T : DomainService
         {
             return AddDomainService(typeof(T));
         }
 
-        public IEndpointConventionBuilder AddDomainService(Type type)
+        public IEndpointConventionBuilder AddDomainService([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type)
         {
             ArgumentNullException.ThrowIfNull(nameof(type));
 
@@ -35,7 +35,7 @@ namespace OpenRiaServices.Hosting.AspNetCore
             return _dataSource.AddDomainService(GetDomainServiceRoute(type), type);
         }
 
-        public IEndpointConventionBuilder AddDomainService(Type type, string path)
+        public IEndpointConventionBuilder AddDomainService([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string path)
         {
             ArgumentNullException.ThrowIfNull(nameof(type));
 #if NET7_0_OR_GREATER
@@ -50,7 +50,7 @@ namespace OpenRiaServices.Hosting.AspNetCore
             return _dataSource.AddDomainService(path, type);
         }
 
-        public IEndpointConventionBuilder AddDomainService<T>(string path) where T : DomainService
+        public IEndpointConventionBuilder AddDomainService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T>(string path) where T : DomainService
         {
             return AddDomainService(typeof(T), path);
         }

--- a/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/OpenRiaServices.Hosting.AspNetCore.Test.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/OpenRiaServices.Hosting.AspNetCore.Test.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Test\Desktop\OpenRiaServices.Common.DomainServices.Test\OpenRiaServices.Common.DomainServices.Test.csproj" />

--- a/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
@@ -3,9 +3,9 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.Hosting.Wcf.Endpoint/Test/OpenRiaServices.Hosting.Wcf.Endpoint.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf.Endpoint/Test/OpenRiaServices.Hosting.Wcf.Endpoint.Test.csproj
@@ -5,9 +5,9 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/OpenRiaServices.Hosting.Wcf.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/OpenRiaServices.Hosting.Wcf.csproj
@@ -18,7 +18,7 @@
     <Reference Include="system" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.Wcf/Test/OpenRiaServices.Hosting.Wcf.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf/Test/OpenRiaServices.Hosting.Wcf.Test.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj
+++ b/src/OpenRiaServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj
@@ -10,9 +10,9 @@
     <Compile Include="..\..\OpenRiaServices.Server\Test\MockDataService.cs" Link="Shared\MockDataService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Test/OpenRiaServices.Server.EntityFrameworkCore.Test/OpenRiaServices.Server.EntityFrameworkCore.Test.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Test/OpenRiaServices.Server.EntityFrameworkCore.Test/OpenRiaServices.Server.EntityFrameworkCore.Test.csproj
@@ -14,9 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
@@ -5,10 +5,10 @@
     <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Test\Desktop\OpenRiaServices.Common.DomainServices.Test\OpenRiaServices.Common.DomainServices.Test.csproj" />

--- a/src/OpenRiaServices.Server/Framework/OpenRiaServices.Server.csproj
+++ b/src/OpenRiaServices.Server/Framework/OpenRiaServices.Server.csproj
@@ -14,12 +14,12 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Include="System.CodeDom" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
+++ b/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
@@ -36,12 +36,12 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/OpenRiaServices.Tools/Framework/OpenRiaServices.Tools.csproj
+++ b/src/OpenRiaServices.Tools/Framework/OpenRiaServices.Tools.csproj
@@ -54,13 +54,13 @@
     <!-- Required for validation attributes -->
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <!-- MEF Attribute: TODO consider removing MEF support for .NET (non framework) -->
-    <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
-    <PackageReference Include="System.CodeDom" Version="7.0.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />
+    <PackageReference Include="System.CodeDom" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Use PrivateAssets="all" to prevent nuget packages to become nuget dependencies -->
     <!-- IMPORTANT: Also use ExcludeAssets="Runtime" if referencing msbuild packages https://learn.microsoft.com/en-us/visualstudio/msbuild/tutorial-custom-task-code-generation?view=vs-2022#dont-bundle-the-microsoftbuildutilitiescore-assembly -->
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" PrivateAssets="all" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\OpenRiaServices.Server\Framework\OpenRiaServices.Server.csproj" ExcludeAssets="Runtime" PrivateAssets="all">

--- a/src/OpenRiaServices.Tools/Test/ClientClassLib/ClientClassLib.csproj
+++ b/src/OpenRiaServices.Tools/Test/ClientClassLib/ClientClassLib.csproj
@@ -9,7 +9,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'!='net472'">
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.2" />
+    <PackageReference Include="System.ServiceModel.Http" Version="6.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ServerClassLib\CodelessType.linked.cs">

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -20,18 +20,18 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.11.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/OpenRiaServices.Common.Test.csproj
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/OpenRiaServices.Common.Test.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/OpenRiaservices.EndToEnd.AspNetCore.Test.csproj
+++ b/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/OpenRiaservices.EndToEnd.AspNetCore.Test.csproj
@@ -11,9 +11,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OpenRiaservices.EndToEnd.Wcf.Test.csproj
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OpenRiaservices.EndToEnd.Wcf.Test.csproj
@@ -10,9 +10,9 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">

--- a/src/Test/WebsiteFullTrust/Web.config
+++ b/src/Test/WebsiteFullTrust/Web.config
@@ -106,11 +106,11 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.0.0.2" newVersion="8.0.0.2"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>

--- a/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
+++ b/src/Test/WebsiteFullTrust/WebsiteFullTrust.csproj
@@ -149,7 +149,7 @@
       <Version>3.1.32</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>8.0.0</Version>
+      <Version>8.0.1</Version>
     </PackageReference>
     <PackageReference Include="System.Collections.Immutable">
       <Version>8.0.0</Version>

--- a/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
+++ b/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
@@ -14,10 +14,10 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.ComponentModel.DataAnnotations" />


### PR DESCRIPTION
### Dependency Updates:
* Updated `System.ServiceModel.Http` and `System.ServiceModel.Primitives` to version `6.2.0` in `OpenRiaServices.Client.Core` 
* Updated `Microsoft.Extensions.DependencyInjection.Abstractions` to version `8.0.2` in `OpenRiaServices.Hosting.Wcf/OpenRiaServices.Hosting.Wcf`.
* Updated `System.CodeDom` to version `8.0.0` in `OpenRiaServices.Server`.
* Updated `Mono.Cecil` to version `0.11.6` in `OpenRiaServices.T4`.

### Reflection Handling:
* This is **NOT** full support for trimming and is not tested

* Added `DynamicallyAccessedMembers` attributes to methods in `DomainClientFactory`, `DomainContext`, `EntityContainer`, and `IDomainClientFactory` to specify dynamically accessed members. [[1]](diffhunk://#diff-83bbcadd1120c524acff76ead6ae75315559a22244fa8111796afe3f946834a6L63-R64) [[2]](diffhunk://#diff-acea6ea9a292040a0e418aa888db1cbb1421be2af367146ba784031fe2041efeL71-R71) [[3]](diffhunk://#diff-3445fd8157383e814aca8974b5ed27051050d730ca6a79811f82ba9eb645b9b4L132-R133) [[4]](diffhunk://#diff-e1917eecc6b79e60f5b5835fb1a376365d0688eef8b05f6bb3c9db112915db03L18-R19)
* Added `DynamicallyAccessedMembers` attributes to methods in `OpenRiaServicesConfigurationBuilder` for improved reflection handling. [[1]](diffhunk://#diff-e6ad0e777924f3f9c6a7aa5cda0fa0de4f8987b9c3eebbaf570a8d1cde41b1afL23-R29) [[2]](diffhunk://#diff-e6ad0e777924f3f9c6a7aa5cda0fa0de4f8987b9c3eebbaf570a8d1cde41b1afL38-R39) [[3]](diffhunk://#diff-e6ad0e777924f3f9c6a7aa5cda0fa0de4f8987b9c3eebbaf570a8d1cde41b1afL53-R54)
