### PR TITLE
Breaking changes for v6 release

### DIFF
--- a/src/OpenRiaServices.Client/Framework/DomainClient.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainClient.cs
@@ -15,7 +15,7 @@ namespace OpenRiaServices.Client
     /// </summary>
     public abstract class DomainClient
     {
-        private ReadOnlyCollection<Type> _entityTypes;
+        private Type[] _entityTypes;
 
         /// <summary>
         /// Gets or sets the collection of Entity Types this <see cref="DomainClient"/> will operate on.
@@ -32,7 +32,7 @@ namespace OpenRiaServices.Client
                 {
                     throw new InvalidOperationException(OpenRiaServices.Client.Resource.DomainClient_EntityTypesAlreadyInitialized);
                 }
-                this._entityTypes = new ReadOnlyCollection<Type>(value.ToList());
+                this._entityTypes = value.ToArray();
             }
         }
 

--- a/src/OpenRiaServices.Client/Framework/Entity.cs
+++ b/src/OpenRiaServices.Client/Framework/Entity.cs
@@ -1610,20 +1610,8 @@ namespace OpenRiaServices.Client
         /// </remarks>
         /// <returns>Collection of custom method invocations pending for this entity</returns>
         [Display(AutoGenerateField = false)]
-        public IEnumerable<EntityAction> EntityActions
-        {
-            get
-            {
-                if (this._customMethodInvocations != null)
-                {
-                    return new ReadOnlyCollection<EntityAction>(this._customMethodInvocations);
-                }
-                else
-                {
-                    return Enumerable.Empty<EntityAction>();
-                }
-            }
-        }
+        public IReadOnlyCollection<EntityAction> EntityActions
+            => this._customMethodInvocations != null ? this._customMethodInvocations : Array.Empty<EntityAction>();
 
         /// <summary>
         /// Return the entity identity, suitable for hashing. If the entity

--- a/src/OpenRiaServices.Client/Framework/EntityChangeSet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityChangeSet.cs
@@ -14,7 +14,7 @@ namespace OpenRiaServices.Client
         private ReadOnlyCollection<Entity> _addedEntities;
         private ReadOnlyCollection<Entity> _removedEntities;
         private ReadOnlyCollection<Entity> _modifiedEntities;
-        private IEnumerable<ChangeSetEntry> _changeSetEntries;
+        private List<ChangeSetEntry> _changeSetEntries;
 
         internal EntityChangeSet(
             ReadOnlyCollection<Entity> addedEntities,
@@ -42,7 +42,7 @@ namespace OpenRiaServices.Client
         /// <summary>
         /// Gets the collection of added Entities
         /// </summary>
-        public ReadOnlyCollection<Entity> AddedEntities
+        public IReadOnlyList<Entity> AddedEntities
         {
             get
             {
@@ -50,7 +50,7 @@ namespace OpenRiaServices.Client
             }
             internal set
             {
-                this._addedEntities = value;
+                this._addedEntities = value is ReadOnlyCollection<Entity> list  ? list : new ReadOnlyCollection<Entity>(value.ToArray());
             }
         }
 
@@ -70,7 +70,7 @@ namespace OpenRiaServices.Client
         /// <summary>
         /// Gets the collection of modified entities
         /// </summary>
-        public ReadOnlyCollection<Entity> ModifiedEntities
+        public IReadOnlyList<Entity> ModifiedEntities
         {
             get
             {
@@ -78,14 +78,14 @@ namespace OpenRiaServices.Client
             }
             internal set
             {
-                this._modifiedEntities = value;
+                this._modifiedEntities = value is ReadOnlyCollection<Entity> list ? list : new ReadOnlyCollection<Entity>(value.ToArray());
             }
         }
 
         /// <summary>
         /// Gets the collection of removed entities
         /// </summary>
-        public ReadOnlyCollection<Entity> RemovedEntities
+        public IReadOnlyList<Entity> RemovedEntities
         {
             get
             {
@@ -93,7 +93,7 @@ namespace OpenRiaServices.Client
             }
             internal set
             {
-                this._removedEntities = value;
+                this._removedEntities = value is ReadOnlyCollection<Entity> list ? list : new ReadOnlyCollection<Entity>(value.ToArray());
             }
         }
 
@@ -115,7 +115,7 @@ namespace OpenRiaServices.Client
         /// Gets the collection of <see cref="ChangeSetEntry"/> items for this changeset.
         /// </summary>
         /// <returns>A collection of <see cref="ChangeSetEntry"/> items.</returns>
-        public IEnumerable<ChangeSetEntry> GetChangeSetEntries()
+        public IReadOnlyCollection<ChangeSetEntry> GetChangeSetEntries()
         {
             if (this._changeSetEntries == null)
             {

--- a/src/OpenRiaServices.Client/Framework/EntityConflict.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityConflict.cs
@@ -103,7 +103,7 @@ namespace OpenRiaServices.Client
         /// <summary>
         /// Gets a collection of the property names in conflict.
         /// </summary>
-        public IEnumerable<string> PropertyNames
+        public IReadOnlyCollection<string> PropertyNames
         {
             get
             {

--- a/src/OpenRiaServices.Client/Framework/ILoadResult.cs
+++ b/src/OpenRiaServices.Client/Framework/ILoadResult.cs
@@ -13,13 +13,13 @@ namespace OpenRiaServices.Client
         /// entities referenced by the top level entities. The collection returned implements
         /// <see cref="System.Collections.Specialized.INotifyCollectionChanged"/>.
         /// </summary>
-        IReadOnlyCollection<Entity> AllEntities { get; }
+        IReadOnlyList<Entity> AllEntities { get; }
 
         /// <summary>
         ///  /// Gets all the top level entities loaded by the operation. The collection returned implements
         /// <see cref="System.Collections.Specialized.INotifyCollectionChanged"/>.
         /// </summary>
-        IReadOnlyCollection<Entity> Entities { get; }
+        IReadOnlyList<Entity> Entities { get; }
 
         /// <summary>
         /// Gets the total server entity count for the query used by this operation. Automatic

--- a/src/OpenRiaServices.Client/Framework/LoadOperation.cs
+++ b/src/OpenRiaServices.Client/Framework/LoadOperation.cs
@@ -60,7 +60,7 @@ namespace OpenRiaServices.Client
         /// Gets all the top level entities loaded by the operation. The collection returned implements
         /// <see cref="System.Collections.Specialized.INotifyCollectionChanged"/>.
         /// </summary>
-        public IReadOnlyCollection<Entity> Entities
+        public IReadOnlyList<Entity> Entities
         {
             get
             {
@@ -78,7 +78,7 @@ namespace OpenRiaServices.Client
         /// entities referenced by the top level entities. The collection returned implements
         /// <see cref="System.Collections.Specialized.INotifyCollectionChanged"/>.
         /// </summary>
-        public IReadOnlyCollection<Entity> AllEntities
+        public IReadOnlyList<Entity> AllEntities
         {
             get
             {
@@ -232,7 +232,7 @@ namespace OpenRiaServices.Client
         /// entities referenced by the top level entities. The collection returned implements
         /// <see cref="System.Collections.Specialized.INotifyCollectionChanged"/>.
         /// </summary>
-        public new IReadOnlyCollection<TEntity> Entities
+        public new IReadOnlyList<TEntity> Entities
         {
             get
             {

--- a/src/OpenRiaServices.Client/Framework/LoadResult.cs
+++ b/src/OpenRiaServices.Client/Framework/LoadResult.cs
@@ -16,7 +16,7 @@ namespace OpenRiaServices.Client
     /// <typeparam name="TEntity">The type of the entity loaded.</typeparam>
     public class LoadResult<TEntity> : IEnumerable<TEntity>, ICollection, ILoadResult where TEntity : Entity
     {
-        private readonly ReadOnlyCollection<TEntity> _loadedEntites;
+        private readonly Data.ReadOnlyObservableLoaderCollection<TEntity> _loadedEntites;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LoadResult{TEntity}" /> class.
@@ -38,7 +38,7 @@ namespace OpenRiaServices.Client
         /// <param name="entities">Top level entities loaded.</param>
         /// <param name="allEntities">All entities loaded.</param>
         /// <param name="totalEntityCount">The total entity count.</param>
-        public LoadResult(EntityQuery<TEntity> query, LoadBehavior loadBehavior, IEnumerable<TEntity> entities, IReadOnlyCollection<Entity> allEntities, int totalEntityCount)
+        public LoadResult(EntityQuery<TEntity> query, LoadBehavior loadBehavior, IEnumerable<TEntity> entities, IReadOnlyList<Entity> allEntities, int totalEntityCount)
         {
             _loadedEntites = (entities as Data.ReadOnlyObservableLoaderCollection<TEntity>) ?? new Data.ReadOnlyObservableLoaderCollection<TEntity>(entities.ToList());
 
@@ -51,13 +51,13 @@ namespace OpenRiaServices.Client
         /// <summary>
         /// Gets all the top level entities loaded by the operation.
         /// </summary>
-        public IReadOnlyCollection<TEntity> Entities { get { return _loadedEntites; } }
+        public IReadOnlyList<TEntity> Entities { get { return _loadedEntites; } }
 
         /// <summary>
         ///  Gets all the entities loaded by the operation, including any
         /// entities referenced by the top level entities. 
         /// </summary>
-        public IReadOnlyCollection<Entity> AllEntities { get; private set; }
+        public IReadOnlyList<Entity> AllEntities { get; private set; }
 
         /// <summary>
         /// The <see cref="EntityQuery"/> for this load operation.
@@ -105,8 +105,7 @@ namespace OpenRiaServices.Client
         protected object SyncRoot { get { return ((ICollection)_loadedEntites).SyncRoot; } }
         object ICollection.SyncRoot { get { return this.SyncRoot; } }
 
-
-        IReadOnlyCollection<Entity> ILoadResult.Entities => this.Entities;
+        IReadOnlyList<Entity> ILoadResult.Entities => this.Entities;
 
         /// <summary>
         /// Returns an enumerator that iterates through the collection.

--- a/src/OpenRiaServices.Client/Framework/QueryCompletedResult.cs
+++ b/src/OpenRiaServices.Client/Framework/QueryCompletedResult.cs
@@ -47,7 +47,7 @@ namespace OpenRiaServices.Client
         /// <summary>
         /// Gets the entities returned from the query
         /// </summary>
-        public IEnumerable<Entity> Entities
+        public IReadOnlyCollection<Entity> Entities
         {
             get
             {
@@ -58,7 +58,7 @@ namespace OpenRiaServices.Client
         /// <summary>
         /// Gets the included entities returned from the query
         /// </summary>
-        public IEnumerable<Entity> IncludedEntities
+        public IReadOnlyCollection<Entity> IncludedEntities
         {
             get
             {
@@ -81,7 +81,7 @@ namespace OpenRiaServices.Client
         /// <summary>
         /// Gets the validation errors.
         /// </summary>
-        public IEnumerable<ValidationResult> ValidationErrors
+        public IReadOnlyCollection<ValidationResult> ValidationErrors
         {
             get
             {

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/ServerSideAsyncTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/ServerSideAsyncTests.cs
@@ -346,7 +346,7 @@ namespace OpenRiaServices.Client.Test
 
             // Verify
             Assert.AreEqual(42, rangeItem.Id);
-            CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.AddedEntities);
+            CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.AddedEntities.ToList());
         }
 
         [TestMethod]
@@ -382,7 +382,7 @@ namespace OpenRiaServices.Client.Test
 
             // Verify
             Assert.AreEqual("updated", rangeItem.Text);
-            CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.ModifiedEntities);
+            CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.ModifiedEntities.ToList());
         }
 
         [TestMethod]
@@ -421,7 +421,7 @@ namespace OpenRiaServices.Client.Test
 
             // Verify
             Assert.AreEqual("custom updated", rangeItem.Text);
-            CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.ModifiedEntities);
+            CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.ModifiedEntities.ToList());
         }
 
         [TestMethod]
@@ -457,7 +457,7 @@ namespace OpenRiaServices.Client.Test
             var result = await ctx.SubmitChangesAsync();
 
             // Verify
-            CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.RemovedEntities);
+            CollectionAssert.AreEqual(new[] { rangeItem }, result.ChangeSet.RemovedEntities.ToList());
         }
 
         [TestMethod]


### PR DESCRIPTION
Start removing usage of ReadOnlyCollection (use IReadOnlyCollection / IReadOnlyList for public API)

TO DO:
* Drop frameworks (< .NET 8, netstandard)
* Drop WCF based WebDomainClient
* possibly look at https://github.com/OpenRIAServices/OpenRiaServices/pull/512  (and / or remove code for handling AssociationAttribute code)

What to do with WCF server side ? 
* Drop in 2025 ?