### PR TITLE
AspNetCore: Improve HTTP Status code on Submit failed and wrong ContentType

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## AspNetCore - UNRELEASED
+
+* **New Http status codes** returned
+   * Submit can now return 409 and 422 Unprocessable Entity (for conflicts and validation failure)
+   * Use 415 unsupported media type instead of 400 for unsupported content type
+
 # 5.6.0 / AspNetCore 1.3.0
 
 ## AspNetCore 1.3.0 (#518)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-## AspNetCore - UNRELEASED
+## AspNetCore - 1.3.1
 
 * **New Http status codes** returned
    * Submit can now return 409 and 422 Unprocessable Entity (for conflicts and validation failure)

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/InvokeOperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/InvokeOperationInvoker.cs
@@ -30,7 +30,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
                 {
                     if (context.Request.ContentType != "application/msbin1")
                     {
-                        context.Response.StatusCode = 400; // maybe 406 / System.Net.HttpStatusCode.NotAcceptable
+                        context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
                         return;
                     }
                     (_, inputs) = await ReadParametersFromBodyAsync(context);

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/OperationInvoker.cs
@@ -373,7 +373,6 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
 
                 var response = context.Response;
                 response.Headers.ContentType = "application/msbin1";
-                response.StatusCode = 200;
                 response.ContentLength = bufferMemory.Length;
                 response.Headers.CacheControl = "private, no-store";
 

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/QueryOperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/QueryOperationInvoker.cs
@@ -40,7 +40,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
                 {
                     if (context.Request.ContentType != "application/msbin1")
                     {
-                        context.Response.StatusCode = 400; // maybe 406 / System.Net.HttpStatusCode.NotAcceptable
+                        context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
                         return;
                     }
 

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/SubmitOperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/SubmitOperationInvoker.cs
@@ -32,7 +32,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
 
                 if (context.Request.ContentType != "application/msbin1")
                 {
-                    context.Response.StatusCode = 400; // maybe 406 / System.Net.HttpStatusCode.NotAcceptable
+                    context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
                     return;
                 }
 

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/SubmitOperationInvoker.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Operations/SubmitOperationInvoker.cs
@@ -50,6 +50,20 @@ namespace OpenRiaServices.Hosting.AspNetCore.Operations
                     return;
                 }
 
+                // Set HTTP StatusCode on failed requests
+                foreach (var change in result)
+                {
+                    if (change.HasError)
+                    {
+                        if (change.HasConflict)
+                            context.Response.StatusCode = StatusCodes.Status409Conflict;
+                        else
+                            context.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+
+                        break;
+                    }
+                }
+
                 await WriteResponse(context, result);
             }
             catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)


### PR DESCRIPTION
* Submit can now return 409 and 422 Unprocessable Entity (for conflicts and validation failure)
* Use 415 unsupported media type instead of 400 for unsupported content type