### PR TITLE
Update nuget packages for test (and MsBuild locator for codegen)

### DIFF
--- a/src/OpenRiaServices.Client/Test/Client.External.Test/OpenRiaServices.Client.External.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.External.Test/OpenRiaServices.Client.External.Test.csproj
@@ -4,7 +4,7 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
@@ -6,7 +6,7 @@
     <DefineConstants>$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
     <PackageReference Include="MSTest.Analyzers" Version="3.6.3">

--- a/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Vb.Test/OpenRiaServices.Client.Vb.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/OpenRiaServices.Hosting.AspNetCore.Test.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Test/OpenRiaServices.Hosting.AspNetCore.Test/OpenRiaServices.Hosting.AspNetCore.Test.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.5.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Local/Test/OpenRiaServices.Hosting.Local.Test.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.Wcf.Endpoint/Test/OpenRiaServices.Hosting.Wcf.Endpoint.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf.Endpoint/Test/OpenRiaServices.Hosting.Wcf.Endpoint.Test.csproj
@@ -5,7 +5,7 @@
     <Version>1.0.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Hosting.Wcf/Test/OpenRiaServices.Hosting.Wcf.Test.csproj
+++ b/src/OpenRiaServices.Hosting.Wcf/Test/OpenRiaServices.Hosting.Wcf.Test.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.5.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj
+++ b/src/OpenRiaServices.Server.Authentication.AspNetMembership/Test/OpenRiaServices.Server.Authentication.AspNetMembership.Test.csproj
@@ -10,7 +10,7 @@
     <Compile Include="..\..\OpenRiaServices.Server\Test\MockDataService.cs" Link="Shared\MockDataService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Test/OpenRiaServices.Server.EntityFrameworkCore.Test/OpenRiaServices.Server.EntityFrameworkCore.Test.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Test/OpenRiaServices.Server.EntityFrameworkCore.Test/OpenRiaServices.Server.EntityFrameworkCore.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
+++ b/src/OpenRiaServices.Server.UnitTesting/Test/OpenRiaServices.Server.UnitTesting.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
+++ b/src/OpenRiaServices.Server/Test/OpenRiaServices.Server.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Tools.CodeGenTask/OpenRiaServices.Tools.CodeGenTask.csproj
+++ b/src/OpenRiaServices.Tools.CodeGenTask/OpenRiaServices.Tools.CodeGenTask.csproj
@@ -17,7 +17,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\OpenRiaServices.Tools\Framework\OpenRiaServices.Tools.csproj" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.10.12" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 

--- a/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.5.1" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.10.12" />
     <PackageReference Include="Microsoft.Build" Version="17.8.43" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.8.43" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.43" PrivateAssets="All" ExcludeAssets="Runtime" />
@@ -35,7 +35,7 @@
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
+++ b/src/OpenRiaServices.Tools/Test/CompilerHelper.cs
@@ -88,7 +88,7 @@ namespace OpenRiaServices.Tools.Test
             }
             catch (Exception ex)
             {
-                Assert.Fail("Exception occurred on Csharp compilation. \nError: {0}", ex);
+                Assert.Fail($"Exception occurred on Csharp compilation. \nError: {ex}");
                 // We will never get here since assert will throw
                 return null;
             }
@@ -148,7 +148,7 @@ namespace OpenRiaServices.Tools.Test
             }
             catch (Exception ex)
             {
-                Assert.Fail("Exception occurred invoking compiling VB sources. \nError: {0}", ex);
+                Assert.Fail($"Exception occurred invoking compiling VB sources. \nError: {ex}");
                 // We will never get here since assert will throw
                 return null;
             }
@@ -201,7 +201,7 @@ namespace OpenRiaServices.Tools.Test
                 var emitResult = compilation.Emit(memoryStream, null, documentationStream);
                 if (!emitResult.Success)
                 {
-                    Assert.Fail("Failed to compile assembly \r\n {0}", string.Join(" \r\n", emitResult.Diagnostics));
+                    Assert.Fail($"Failed to compile assembly \r\n {string.Join(" \r\n", emitResult.Diagnostics)}");
                 }
                 return memoryStream;
             }

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.10.12" />
     <PackageReference Include="Microsoft.Build" Version="17.8.43" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.8.43" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.43" PrivateAssets="All" ExcludeAssets="Runtime" />

--- a/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/OpenRiaservices.EndToEnd.AspNetCore.Test.csproj
+++ b/src/Test/OpenRiaservices.EndToEnd.AspNetCore.Test/OpenRiaservices.EndToEnd.AspNetCore.Test.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OpenRiaservices.EndToEnd.Wcf.Test.csproj
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/OpenRiaservices.EndToEnd.Wcf.Test.csproj
@@ -10,7 +10,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>

--- a/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
+++ b/src/VisualStudio/Tools/Test/OpenRiaServices.VisualStudio.DomainServices.Tools.Test.csproj
@@ -14,8 +14,10 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="Microsoft.Build" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.Build" Version="17.8.43" PrivateAssets="all" ExcludeAssets="Runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>


### PR DESCRIPTION
 The updates include Microsoft.NET.Test.Sdk from version 17.11.1 to 18.0.1 and Microsoft.Build.Locator from 1.7.8 to 1.10.12. Additionally, string formatting in assertion error messages has been modernized from composite formatting to string interpolation.