### PR TITLE
Prevent duplicate association attributes on properties

### DIFF
--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/EFCoreTypeDescriptor.cs
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/EFCoreTypeDescriptor.cs
@@ -250,7 +250,12 @@ namespace OpenRiaServices.Server.EntityFrameworkCore
 
                 if (addAssociationAttribute)
                 {
-                    if (pd.Attributes[typeof(EntityAssociationAttribute)] is null)
+                    // Check for both EntityAssociationAttribute and the obsolete AssociationAttribute
+                    // to prevent duplicates when using the legacy AssociationAttribute
+                    if (pd.Attributes[typeof(EntityAssociationAttribute)] is null
+#pragma warning disable CS0618 // Type or member is obsolete
+                        && pd.Attributes[typeof(AssociationAttribute)] is null)
+#pragma warning restore CS0618 // Type or member is obsolete
                         attributes.Add(EFCoreTypeDescriptionContext.CreateAssociationAttribute(navigation));
 #if NET
                     if (navigation.TargetEntityType.IsOwned() && pd.Attributes[typeof(CompositionAttribute)] is null)


### PR DESCRIPTION
Check for both EntityAssociationAttribute and obsolete AssociationAttribute before adding a new association attribute to a property descriptor. Suppress obsolete warnings when checking for the legacy attribute to avoid compiler issues. This ensures no duplicate attributes are added when the legacy AssociationAttribute is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved association attribute detection to ensure proper handling of legacy attribute conventions alongside current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->