### PR TITLE
Binding Improvements (WPF, Avalonia and other)

### DIFF
--- a/src/OpenRiaServices.Client/Framework/ChangeSetBuilder.cs
+++ b/src/OpenRiaServices.Client/Framework/ChangeSetBuilder.cs
@@ -157,7 +157,7 @@ namespace OpenRiaServices.Client
             public UnmodifiedOperationAdder(List<ChangeSetEntry> changeSetEntries)
             {
                 this._changeSetEntries = changeSetEntries;
-                if (this._changeSetEntries.Any())
+                if (this._changeSetEntries.Count != 0)
                 {
                     this._id = this._changeSetEntries.Max(p => p.Id) + 1;
                 }

--- a/src/OpenRiaServices.Client/Framework/ComplexObject.cs
+++ b/src/OpenRiaServices.Client/Framework/ComplexObject.cs
@@ -117,7 +117,7 @@ namespace OpenRiaServices.Client
         {
             get
             {
-                return this.ValidationErrors.Any();
+                return this.ValidationErrors.Count != 0;
             }
         }
 

--- a/src/OpenRiaServices.Client/Framework/Entity.cs
+++ b/src/OpenRiaServices.Client/Framework/Entity.cs
@@ -223,7 +223,7 @@ namespace OpenRiaServices.Client
         {
             get
             {
-                return this.ValidationErrors.Any();
+                return this.ValidationErrors.Count != 0;
             }
         }
 

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -9,9 +9,6 @@ using System.Globalization;
 using System.Linq;
 using OpenRiaServices.Client.Internal;
 
-#if HAS_COLLECTIONVIEW
-using System.Windows.Data;
-#endif
 
 namespace OpenRiaServices.Client
 {
@@ -39,6 +36,14 @@ namespace OpenRiaServices.Client
         private TEntity _detachingEntity;
         private bool _entitiesLoaded;
         private bool _entitiesAdded;
+
+        /// <summary>
+        /// NOTE: This list is only used when Adding or Removing items through the IList interface
+        /// Entities removed from an EntityCollection aren't typically removed from the source EntitySet.
+        /// However, we need to track entities added through the view and manually remove them from the
+        /// source EntitySet to achieve correct AddNew/CancelNew behavior.
+        /// </summary>
+        private List<TEntity> _addedEntities;
 
         private EntityAssociationAttribute AssocAttribute => _metaMember.AssociationAttribute;
         private bool IsComposition => _metaMember.IsComposition;
@@ -813,199 +818,7 @@ namespace OpenRiaServices.Client
         /// <returns>A custom view for specialized sorting, filtering, grouping, and currency</returns>
         ICollectionView ICollectionViewFactory.CreateView()
         {
-            return new ListCollectionView(new ListCollectionViewProxy<TEntity>(this));
-        }
-
-        /// <summary>
-        /// <see cref="IList"/> proxy that makes the <see cref="EntityCollection{T}"/> usable in the default
-        /// collection views. All operations implemented against the proxy are passed through to the source
-        /// <see cref="EntityCollection{T}"/>.
-        /// </summary>
-        /// <remarks>
-        /// This proxy does not support a full set of list operations. However, the subset it does support
-        /// is sufficient for interaction with the ListCollectionView.
-        /// </remarks>
-        /// <typeparam name="T">The entity type of this proxy</typeparam>
-        internal class ListCollectionViewProxy<T> : IList, IEnumerable<T>, INotifyCollectionChanged, ICollectionChangedListener where T : Entity
-        {
-            private readonly object _syncRoot = new object();
-            private readonly EntityCollection<T> _source;
-            private readonly WeakCollectionChangedListener _weakCollectionChangedLister;
-            // Entities removed from an EntityCollection aren't typically removed from the source EntitySet.
-            // However, we need to track entities added through the view and manually remove them from the
-            // source EntitySet to achieve correct AddNew/CancelNew behavior.
-            private readonly List<T> _addedEntities = new List<T>();
-
-            internal ListCollectionViewProxy(EntityCollection<T> source)
-            {
-                this._source = source;
-                this._weakCollectionChangedLister =
-                    WeakCollectionChangedListener.CreateIfNecessary(this._source, this);
-            }
-
-            #region IList
-
-            public int Add(object value)
-            {
-                T entity = value as T;
-                if (entity == null)
-                {
-                    throw new ArgumentException(
-                        string.Format(CultureInfo.CurrentCulture, Resource.MustBeAnEntity, "value"),
-                        nameof(value));
-                }
-
-                this._addedEntities.Add(entity);
-                int countBefore = this.Source.Count;
-                this.Source.Add(entity);
-
-                return this.Source.Entities.IndexOf(entity, countBefore);
-            }
-
-            public void Clear()
-            {
-                throw new NotSupportedException(
-                    string.Format(CultureInfo.CurrentCulture, Resource.IsNotSupported, "Clear"));
-            }
-
-            public bool Contains(object value)
-            {
-                return this.Source.EntitiesHashSet.Contains(value);
-            }
-
-            public int IndexOf(object value)
-            {
-                return ((IList)this.Source.Entities).IndexOf(value);
-            }
-
-            public void Insert(int index, object value)
-            {
-                throw new NotSupportedException(
-                    string.Format(CultureInfo.CurrentCulture, Resource.IsNotSupported, "Insert"));
-            }
-
-            // Always returning false for these two will create scenarios where Add or Remove ends up
-            // throwing an exception because it is not actually a supported operation. However, there
-            // are too many edge cases where type-based inference would fail. Always returning false
-            // (to indicate CanAddNew and CanRemove should be true) provides a better experience by
-            // allowing the developer to customize the Add and Remove options in the UI.
-            public bool IsFixedSize
-            {
-                get { return false; }
-            }
-
-            public bool IsReadOnly
-            {
-                get { return false; }
-            }
-
-            public void Remove(object value)
-            {
-                T entity = value as T;
-                if (entity == null)
-                {
-                    return;
-                }
-
-                this.Source.Remove(entity);
-                if (this._addedEntities.Remove(entity))
-                {
-                    // In case of Composition, the entity in the SourceSet
-                    // may already be removed via this.Source.Remove above.
-                    if (this.Source.SourceSet.Contains(entity))
-                    {
-                        this.Source.SourceSet.Remove(entity);
-                    }
-                }
-            }
-
-            public void RemoveAt(int index)
-            {
-                this.Remove(this[index]);
-            }
-
-            public object this[int index]
-            {
-                get
-                {
-                    if ((index < 0) || (index >= this.Source.Count))
-                    {
-                        // We run into this scenario when the association reference is changed during an
-                        // AddNew. The scenario is not supported, but we're trying to improve the error
-                        // message. Instead of throwing an ArgumentOutOfRangeException, we'll simply return
-                        // null and allow the view to inform us the added item is not at the requested index.
-                        return null;
-                    }
-                    return this.Source.Entities[index];
-                }
-                set
-                {
-                    throw new NotSupportedException(
-                        string.Format(CultureInfo.CurrentCulture, Resource.IsNotSupported, "Indexed setting"));
-                }
-            }
-
-            public void CopyTo(Array array, int index)
-            {
-                ((IList)this.Source.Entities).CopyTo(array, index);
-            }
-
-            public int Count
-            {
-                get { return this.Source.Count; }
-            }
-
-            public bool IsSynchronized
-            {
-                get { return false; }
-            }
-
-            public object SyncRoot
-            {
-                get { return this._syncRoot; }
-            }
-
-            public IEnumerator<T> GetEnumerator()
-            {
-                return this.Source.GetEnumerator();
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-
-            private EntityCollection<T> Source
-            {
-                get { return this._source; }
-            }
-
-            #endregion
-
-            #region INotifyCollectionChanged
-
-            public event NotifyCollectionChangedEventHandler CollectionChanged;
-
-            private void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
-            {
-                this.CollectionChanged?.Invoke(this, e);
-            }
-
-            private void OnSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-            {
-                this.OnCollectionChanged(e);
-            }
-
-            #endregion
-
-            #region ICollectionChangedListener
-
-            void ICollectionChangedListener.OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-            {
-                this.OnSourceCollectionChanged(sender, e);
-            }
-
-            #endregion
+            return new NonLeakingListCollectionView(this);
         }
 #endif
         #endregion
@@ -1076,7 +889,22 @@ namespace OpenRiaServices.Client
         /// <inheritdoc cref="this[int]"/>
         object IList.this[int index]
         {
-            get => this[index];
+            get
+            {
+                var list = Entities;
+                if (((uint)index) < (uint)list.Count)
+                {
+                    return list[index];
+                }
+                else
+                {
+                    // We run into this scenario when the association reference is changed during an
+                    // AddNew. The scenario is not supported, but we're trying to improve the error
+                    // message. Instead of throwing an ArgumentOutOfRangeException, we'll simply return
+                    // null and allow the view to inform us the added item is not at the requested index.
+                    return null;
+                }
+            }
             set => throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, Resource.IsNotSupported, "Index setter"));
         }
 
@@ -1084,6 +912,9 @@ namespace OpenRiaServices.Client
         {
             int countBefore = this.Count;
             Add((TEntity)value);
+
+            _addedEntities ??= [];
+            _addedEntities.Add((TEntity)value);
 
             if (this.Count == countBefore + 1)
                 return countBefore;
@@ -1119,12 +950,29 @@ namespace OpenRiaServices.Client
 
         void IList.Remove(object value)
         {
-            Remove((TEntity)value);
+            TEntity entity = value as TEntity;
+            if (entity == null)
+            {
+                return;
+            }
+
+            this.Remove(entity);
+            if (this._addedEntities?.Remove(entity) == true)
+            {
+                // In case of Composition, the entity in the SourceSet
+                // may already be removed via this.Source.Remove above.
+                if (SourceSet.Contains(entity))
+                {
+                    this.SourceSet.Remove(entity);
+                }
+            }
         }
 
         void IList.RemoveAt(int index)
         {
-            throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, Resource.IsNotSupported, "RemoveAt"));
+            // Need to call into IList variant of remove to handle _addedEntities
+            IList This = (IList)this;
+            This.Remove(This[index]);
         }
 
         void ICollection.CopyTo(Array array, int index)

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -263,7 +263,7 @@ namespace OpenRiaServices.Client
 
                 // we may have to check for containment once more, since the EntitySet.Add calls
                 // above can cause a dynamic add to this EntityCollection behind the scenes
-                if (TryAddEntity(entity) || addedToSet)
+                if (TryAddEntityToCollection(entity) || addedToSet)
                 {
                     this.RaiseCollectionChangedNotification(NotifyCollectionChangedAction.Add, entity, this.Entities.Count - 1);
                 }
@@ -315,7 +315,7 @@ namespace OpenRiaServices.Client
 
             if (idx != -1)
             {
-                if (this.RemoveEntity(entity, idx))
+                if (this.RemoveEntityFromCollection(entity, idx))
                 {
                     // If the entity was removed, raise a collection changed notification. Note that the Detach call above might
                     // have caused a dynamic removal behind the scenes resulting in the entity no longer being in the collection,
@@ -353,7 +353,7 @@ namespace OpenRiaServices.Client
         /// should be done through this method.
         /// </summary>
         /// <param name="entity">The <see cref="Entity"/>to add.</param>
-        private bool TryAddEntity(TEntity entity)
+        private bool TryAddEntityToCollection(TEntity entity)
         {
             if (this.EntitiesHashSet.Add(entity))
             {
@@ -372,7 +372,7 @@ namespace OpenRiaServices.Client
             }
         }
 
-        private bool RemoveEntity(TEntity entity, int index)
+        private bool RemoveEntityFromCollection(TEntity entity, int index)
         {
             if (this.EntitiesHashSet.Remove(entity))
             {
@@ -389,7 +389,7 @@ namespace OpenRiaServices.Client
         /// </summary>
         /// <param name="entity">entity to remove</param>
         /// <param name="index">the index of the entity before removal, or -1 if not removed</param>
-        private bool TryRemoveEntity(TEntity entity, out int index)
+        private bool TryRemoveEntityFromCollection(TEntity entity, out int index)
         {
             if (this.EntitiesHashSet.Remove(entity))
             {
@@ -458,7 +458,7 @@ namespace OpenRiaServices.Client
             EntitySet set = this._parent.EntitySet.EntityContainer.GetEntitySet(typeof(TEntity));
             foreach (TEntity entity in set.OfType<TEntity>().Where(this.Filter))
             {
-                this.TryAddEntity(entity);
+                this.TryAddEntityToCollection(entity);
             }
 
             // once we've loaded entities, we're caching them, so we need to update
@@ -642,13 +642,13 @@ namespace OpenRiaServices.Client
                 {
                     // Add matching entity to our set. When adding, we use the stronger Filter to
                     // filter out New entities
-                    if (this.TryAddEntity(typedEntity))
+                    if (this.TryAddEntityToCollection(typedEntity))
                         this.RaiseCollectionChangedNotification(NotifyCollectionChangedAction.Add, typedEntity, this.Entities.Count - 1);
                 }
                 // The entity is in our set but is no longer a match, so we need to remove it.
                 // Here we use the predicate directly, since even if the entity is New if it
                 // no longer matches it should be removed.
-                else if (!this._entityPredicate(typedEntity) && this.TryRemoveEntity(typedEntity, out int idx))
+                else if (!this._entityPredicate(typedEntity) && this.TryRemoveEntityFromCollection(typedEntity, out int idx))
                 {
                     this.RaiseCollectionChangedNotification(NotifyCollectionChangedAction.Remove, typedEntity, idx);
                 }
@@ -674,7 +674,7 @@ namespace OpenRiaServices.Client
                     List<object> affectedEntities = new List<object>();
                     foreach (TEntity newEntity in newEntities)
                     {
-                        if (this.TryAddEntity(newEntity))
+                        if (this.TryAddEntityToCollection(newEntity))
                         {
                             affectedEntities.Add(newEntity);
                         }
@@ -692,7 +692,7 @@ namespace OpenRiaServices.Client
                 foreach (TEntity entityToRemove in args.OldItems.OfType<TEntity>())
                 {
                     // If entity was part of the collection and removed, raise an event
-                    if (this.TryRemoveEntity(entityToRemove, out int idx))
+                    if (this.TryRemoveEntityFromCollection(entityToRemove, out int idx))
                     {
                         // Should we do a single reset event if multiple entitites are removed ??
                         this.RaiseCollectionChangedNotification(args.Action, entityToRemove, idx);
@@ -911,17 +911,19 @@ namespace OpenRiaServices.Client
         int IList.Add(object value)
         {
             int countBefore = this.Count;
-            Add((TEntity)value);
+            TEntity entity = (TEntity)value;
+            Add(entity);
+
+            if (this.Count == countBefore)
+                return -1;
 
             _addedEntities ??= [];
-            _addedEntities.Add((TEntity)value);
+            _addedEntities.Add(entity);
 
             if (this.Count == countBefore + 1)
                 return countBefore;
-            else if (this.Count == countBefore)
-                return -1;
             else
-                return Entities.IndexOf((TEntity)value, countBefore);
+                return Entities.IndexOf(entity, countBefore);
         }
 
         void IList.Clear()

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -957,21 +957,18 @@ namespace OpenRiaServices.Client
             }
 
             this.Remove(entity);
-            if (this._addedEntities?.Remove(entity) == true)
+            if (this._addedEntities?.Remove(entity) == true
+                // In case of Composition, the entity in the SourceSet may already be removed via this.Remove above.
+                && SourceSet?.Contains(entity) == true)
             {
-                // In case of Composition, the entity in the SourceSet
-                // may already be removed via this.Source.Remove above.
-                if (SourceSet.Contains(entity))
-                {
-                    this.SourceSet.Remove(entity);
-                }
+                this.SourceSet.Remove(entity);
             }
         }
 
         void IList.RemoveAt(int index)
         {
             // Need to call into IList variant of remove to handle _addedEntities
-            IList This = (IList)this;
+            IList This = this;
             This.Remove(This[index]);
         }
 
@@ -983,3 +980,4 @@ namespace OpenRiaServices.Client
         #endregion
     }
 }
+

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -968,8 +968,7 @@ namespace OpenRiaServices.Client
         void IList.RemoveAt(int index)
         {
             // Need to call into IList variant of remove to handle _addedEntities
-            IList This = this;
-            This.Remove(This[index]);
+            ((IList)this).Remove(this[index]);
         }
 
         void ICollection.CopyTo(Array array, int index)

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -908,9 +908,8 @@ namespace OpenRiaServices.Client
                 }
 
                 this.Source.Remove(entity);
-                if (this._addedEntities.Contains(entity))
+                if (this._addedEntities.Remove(entity))
                 {
-                    this._addedEntities.Remove(entity);
                     // In case of Composition, the entity in the SourceSet
                     // may already be removed via this.Source.Remove above.
                     if (this.Source.SourceSet.Contains(entity))

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -7,7 +7,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using OpenRiaServices.Client.Internal;
 
 #if HAS_COLLECTIONVIEW
@@ -814,8 +813,7 @@ namespace OpenRiaServices.Client
         /// <returns>A custom view for specialized sorting, filtering, grouping, and currency</returns>
         ICollectionView ICollectionViewFactory.CreateView()
         {
-            // We use the CollectionViewSource to obtain a ListCollectionView, a type internal to Silverlight
-            return new CollectionViewSource() { Source = new ListCollectionViewProxy<TEntity>(this) }.View;
+            return new ListCollectionView(new ListCollectionViewProxy<TEntity>(this));
         }
 
         /// <summary>

--- a/src/OpenRiaServices.Client/Framework/EntityQuery.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityQuery.cs
@@ -165,7 +165,7 @@ namespace OpenRiaServices.Client
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the <see cref="DomainClientResult.TotalEntityCount"/> property is required.
+        /// Gets or sets a value indicating whether the <see cref="ILoadResult.TotalEntityCount"/> property should be set on result.
         /// </summary>
         public bool IncludeTotalCount
         {

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -444,12 +444,6 @@ namespace OpenRiaServices.Client
         {
             this.EnsureEntityType(entity);
 
-            // Recursively remove any children
-            if (entity.MetaType.HasComposition)
-            {
-                CompositionalChildRemover.RemoveChildren(entity);
-            }
-
             if (entity.EntityState != EntityState.New)
             {
                 // removing a new entity from the set is not considered
@@ -465,6 +459,12 @@ namespace OpenRiaServices.Client
             }
             if (idx == -1)
                 return false;
+
+            // Recursively remove any children
+            if (entity.MetaType.HasComposition)
+            {
+                CompositionalChildRemover.RemoveChildren(entity);
+            }
 
             if (entity.EntitySet != null && entity.IsInferred)
             {

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -429,6 +429,19 @@ namespace OpenRiaServices.Client
         /// <param name="entity">The entity to remove.</param>
         public void Remove(Entity entity)
         {
+            if (!TryRemove(entity))
+                throw new InvalidOperationException(Resource.EntitySet_EntityNotInSet);
+        }
+
+        /// <summary>
+        /// Removes the specified entity from the set.
+        /// </summary>
+        /// <remarks>
+        /// If the entity is the root of a compositional hierarchy, all child entities will also be removed.
+        /// </remarks>
+        /// <param name="entity">The entity to remove.</param>
+        private protected bool TryRemove(Entity entity)
+        {
             this.EnsureEntityType(entity);
 
             // Recursively remove any children
@@ -448,12 +461,10 @@ namespace OpenRiaServices.Client
             int idx = -1;
             if (entity.EntitySet == this)
             {
-                idx = this._list.IndexOf(entity);
+                idx = _list.IndexOf(entity);
             }
             if (idx == -1)
-            {
-                throw new InvalidOperationException(Resource.EntitySet_EntityNotInSet);
-            }
+                return false;
 
             if (entity.EntitySet != null && entity.IsInferred)
             {
@@ -479,6 +490,7 @@ namespace OpenRiaServices.Client
             this._list.RemoveAt(idx);
             this._set.Remove(entity);
             this.OnCollectionChanged(NotifyCollectionChangedAction.Remove, entity, idx);
+            return true;
         }
 
         /// <summary>Determines whether the <see cref="EntitySet"/> contains the specified entity.</summary>
@@ -984,15 +996,8 @@ namespace OpenRiaServices.Client
 
         void IList.Remove(object value)
         {
-            try
-            {
-                if (value is Entity entity)
-                    Remove(entity);
-            }
-            catch (InvalidOperationException ioe) when (ioe.Message == Resource.EntitySet_EntityNotInSet)
-            {
-                // Don't throw if item was not in the collection
-            }
+            if (value is Entity entity)
+                TryRemove(entity);
         }
 
         void IList.RemoveAt(int index)
@@ -1417,20 +1422,7 @@ namespace OpenRiaServices.Client
 
         bool ICollection<TEntity>.Remove(TEntity item)
         {
-            try
-            {
-                // Ordinary remove throws on error, so if it did not then we can return true
-                Remove(item);
-                return true;
-            }
-            catch (InvalidOperationException ioe)
-            {
-                // If the entiy was not part of the set return false
-                if (ioe.Message == Resource.EntitySet_EntityNotInSet)
-                    return false;
-                else
-                    throw;
-            }
+            return base.TryRemove(item);
         }
         #endregion
 

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -997,7 +997,7 @@ namespace OpenRiaServices.Client
 
         void IList.RemoveAt(int index)
         {
-            throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, Resource.IsNotSupported, "RemoveAt"));
+            Remove((Entity)_list[index]);
         }
 
         #endregion
@@ -1444,10 +1444,9 @@ namespace OpenRiaServices.Client
         /// Returns a custom view for specialized sorting, filtering, grouping, and currency.
         /// </summary>
         /// <returns>A custom view for specialized sorting, filtering, grouping, and currency</returns>
-        [Obsolete("Consider removing in next major version, not implementing ICollectionViewFactory should give the same behaviour")]
         ICollectionView ICollectionViewFactory.CreateView()
         {
-            return new ListCollectionView(this);
+            return new NonLeakingListCollectionView(this);
         }
 #endif
         #endregion

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -18,7 +18,7 @@ namespace OpenRiaServices.Client
     /// <summary>
     /// Represents a collection of <see cref="Entity"/> instances.
     /// </summary>
-    public abstract class EntitySet : IEnumerable, ICollection, IList, INotifyCollectionChanged, IRevertibleChangeTracking, INotifyPropertyChanged
+    public abstract class EntitySet : IList, INotifyCollectionChanged, IRevertibleChangeTracking, INotifyPropertyChanged
     {
         private readonly Dictionary<EntityAssociationAttribute, Action<Entity>> _associationUpdateCallbackMap = new();
         private readonly Type _entityType;
@@ -1444,148 +1444,10 @@ namespace OpenRiaServices.Client
         /// Returns a custom view for specialized sorting, filtering, grouping, and currency.
         /// </summary>
         /// <returns>A custom view for specialized sorting, filtering, grouping, and currency</returns>
+        [Obsolete("Consider removing in next major version, not implementing ICollectionViewFactory should give the same behaviour")]
         ICollectionView ICollectionViewFactory.CreateView()
         {
-            // We use the CollectionViewSource to obtain a ListCollectionView, a type internal to Silverlight
-            return new CollectionViewSource() { Source = new ListCollectionViewProxy<TEntity>(this) }.View;
-        }
-
-        /// <summary>
-        /// <see cref="IList"/> proxy that makes the <see cref="EntitySet"/> usable in the default collection views.
-        /// All operations implemented against the proxy are passed through to the source <see cref="EntitySet"/>.
-        /// </summary>
-        /// <remarks>
-        /// This proxy does not support a full set of list operations. However, the subset it does support
-        /// is sufficient for interaction with the ListCollectionView.
-        /// </remarks>
-        /// <typeparam name="T">The entity type of this proxy</typeparam>
-        private class ListCollectionViewProxy<T> : IList, IEnumerable<T>, INotifyCollectionChanged, ICollectionChangedListener where T : Entity
-        {
-            private readonly object _syncRoot = new object();
-            private readonly EntitySet<T> _source;
-            private readonly WeakCollectionChangedListener _weakCollectionChangedLister;
-
-            internal ListCollectionViewProxy(EntitySet<T> source)
-            {
-                this._source = source;
-                this._weakCollectionChangedLister =
-                    WeakCollectionChangedListener.CreateIfNecessary(this._source, this);
-            }
-
-            #region IList
-
-            public int Add(object value)
-                => ((IList)Source).Add(value);
-
-            public void Clear()
-            {
-                this.Source.Clear();
-            }
-
-            public bool Contains(object value)
-            {
-                return (value is Entity e) && this.Source.Contains(e);
-            }
-
-            public int IndexOf(object value)
-            {
-                return ((IList)this.Source.List).IndexOf(value);
-            }
-
-            public void Insert(int index, object value)
-                => ((IList)Source).Insert(index, value);
-
-            public bool IsFixedSize => ((IList)Source).IsFixedSize;
-
-            public bool IsReadOnly => ((IList)Source).IsReadOnly;
-
-            public void Remove(object value)
-            {
-                if (value is T entity)
-                {
-                    this.Source.Remove(entity);
-                }
-            }
-
-            public void RemoveAt(int index)
-            {
-                Source.Remove(Source.List[index]);
-            }
-
-            public object this[int index]
-            {
-                get
-                {
-                    return this.Source.List[index];
-                }
-                set
-                {
-                    throw new NotSupportedException(
-                        string.Format(CultureInfo.CurrentCulture, Resource.IsNotSupported, "Indexed setting"));
-                }
-            }
-
-            public void CopyTo(Array array, int index)
-            {
-                ((IList)this.Source.List).CopyTo(array, index);
-            }
-
-            public int Count
-            {
-                get { return this.Source.Count; }
-            }
-
-            public bool IsSynchronized
-            {
-                get { return false; }
-            }
-
-            public object SyncRoot
-            {
-                get { return this._syncRoot; }
-            }
-
-            public IEnumerator<T> GetEnumerator()
-            {
-                return this.Source.GetEnumerator();
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return this.GetEnumerator();
-            }
-
-            private EntitySet<T> Source
-            {
-                get { return this._source; }
-            }
-
-            #endregion
-
-            #region INotifyCollectionChanged
-
-            public event NotifyCollectionChangedEventHandler CollectionChanged;
-
-            private void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
-            {
-                this.CollectionChanged?.Invoke(this, e);
-            }
-
-            private void OnSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-            {
-                this.OnCollectionChanged(e);
-            }
-
-            #endregion
-
-            #region ICollectionChangedListener
-
-            void ICollectionChangedListener.OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-            {
-                this.OnSourceCollectionChanged(sender, e);
-            }
-
-            #endregion
+            return new ListCollectionView(this);
         }
 #endif
         #endregion

--- a/src/OpenRiaServices.Client/Framework/Internal/MetaType.cs
+++ b/src/OpenRiaServices.Client/Framework/Internal/MetaType.cs
@@ -110,7 +110,7 @@ namespace OpenRiaServices.Client.Internal
             this.Type = type;
 
             _validationAttributes = new ReadOnlyCollection<ValidationAttribute>(this.Type.GetCustomAttributes(typeof(ValidationAttribute), true).OfType<ValidationAttribute>().ToArray());
-            _requiresObjectValidation = _validationAttributes.Any() || typeof(IValidatableObject).IsAssignableFrom(type);
+            _requiresObjectValidation = _validationAttributes.Count != 0 || typeof(IValidatableObject).IsAssignableFrom(type);
             _requiresValidation = _requiresValidation || _requiresObjectValidation;
 
             // for identity purposes, we need to make sure values are always ordered

--- a/src/OpenRiaServices.Client/Framework/InvokeOperation.cs
+++ b/src/OpenRiaServices.Client/Framework/InvokeOperation.cs
@@ -93,7 +93,7 @@ namespace OpenRiaServices.Client
         private protected new void SetError(Exception error)
         {
             if (error is DomainOperationException doe
-                && doe.ValidationErrors.Any())
+                && doe.ValidationErrors.Count != 0)
             {
                 this._validationErrors = doe.ValidationErrors;
                 this.RaisePropertyChanged(nameof(ValidationErrors));

--- a/src/OpenRiaServices.Client/Framework/LoadOperation.cs
+++ b/src/OpenRiaServices.Client/Framework/LoadOperation.cs
@@ -122,7 +122,7 @@ namespace OpenRiaServices.Client
         private protected new void SetError(Exception error)
         {
             if (error is DomainOperationException doe
-                && doe.ValidationErrors.Any())
+                && doe.ValidationErrors.Count != 0)
             {
                 this._validationErrors = doe.ValidationErrors;
                 this.RaisePropertyChanged(nameof(ValidationErrors));
@@ -286,7 +286,7 @@ namespace OpenRiaServices.Client
             // before calling base, we need to update any cached
             // observable collection results so the correct data
             // is accessible in the completion callback
-            if (result.Entities.Any())
+            if (result.Entities.Count != 0)
             {
                 this.UpdateResults(result);
             }
@@ -295,7 +295,7 @@ namespace OpenRiaServices.Client
 
             // raise our property events after all base property
             // events have been raised
-            if (result.Entities.Any())
+            if (result.Entities.Count != 0)
             {
                 this.RaisePropertyChanged(nameof(TotalEntityCount));
             }

--- a/src/OpenRiaServices.Client/Framework/NonLeakingListCollectionView.cs
+++ b/src/OpenRiaServices.Client/Framework/NonLeakingListCollectionView.cs
@@ -1,0 +1,47 @@
+﻿#if HAS_COLLECTIONVIEW
+
+using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.Windows;
+using System.Windows.Data;
+
+namespace OpenRiaServices.Client
+{
+    /// <summary>
+    /// Fix for WPF leaking memory unless DetachFromSourceCollection is called,
+    /// https://www.eidias.com/blog/2014/2/24/wpf-collectionview-can-leak-memory
+    /// </summary>
+    class NonLeakingListCollectionView : ListCollectionView, IWeakEventListener
+    {
+        public NonLeakingListCollectionView(IList list)
+            : base(list)
+        {
+            // Replace the strong event handler with a weak event handler to avoid ListCollectionView holding a strong reference to the EntityCollection through the event handler, which would cause a memory leak since ListCollectionView doesn't unsubscribe from the event.
+            if (list is INotifyCollectionChanged notifyCollectionChanged)
+            {
+                notifyCollectionChanged.CollectionChanged -= this.OnCollectionChanged;
+                CollectionChangedEventManager.AddListener(notifyCollectionChanged, this);
+            }
+        }
+
+        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
+        {
+            // we need to override this method to avoid ListCollectionView holding a strong reference to the EntityCollection through the event handler, which would cause a memory leak since ListCollectionView doesn't unsubscribe from the event.
+            base.OnCollectionChanged(args);
+        }
+
+        bool IWeakEventListener.ReceiveWeakEvent(Type managerType, object sender, EventArgs e)
+        {
+            if (e is NotifyCollectionChangedEventArgs collectionChangedEventArgs)
+            {
+                this.OnCollectionChanged(sender, collectionChangedEventArgs);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}
+#endif
+

--- a/src/OpenRiaServices.Client/Framework/NonLeakingListCollectionView.cs
+++ b/src/OpenRiaServices.Client/Framework/NonLeakingListCollectionView.cs
@@ -25,12 +25,6 @@ namespace OpenRiaServices.Client
             }
         }
 
-        protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
-        {
-            // we need to override this method to avoid ListCollectionView holding a strong reference to the EntityCollection through the event handler, which would cause a memory leak since ListCollectionView doesn't unsubscribe from the event.
-            base.OnCollectionChanged(args);
-        }
-
         bool IWeakEventListener.ReceiveWeakEvent(Type managerType, object sender, EventArgs e)
         {
             if (e is NotifyCollectionChangedEventArgs collectionChangedEventArgs)

--- a/src/OpenRiaServices.Client/Framework/ObjectStateUtility.cs
+++ b/src/OpenRiaServices.Client/Framework/ObjectStateUtility.cs
@@ -23,7 +23,7 @@ namespace OpenRiaServices.Client
             return ExtractState(o, new HashSet<object>());
         }
 
-        private static IDictionary<string, object> ExtractState(object o, HashSet<object> visited)
+        private static Dictionary<string, object> ExtractState(object o, HashSet<object> visited)
         {
             MetaType metaType = MetaType.GetMetaType(o.GetType());
             Dictionary<string, object> extractedState = new Dictionary<string, object>();

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/DomainOperationExceptionTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/DomainOperationExceptionTests.cs
@@ -20,7 +20,7 @@ namespace OpenRiaServices.Client.Test
             Assert.IsNull(doe.StackTrace, "Default stack trace s/b null");
             Assert.AreEqual(0, doe.ErrorCode, "Error code s/b 0");
             Assert.AreEqual(OperationErrorStatus.ServerError, doe.Status, "Default status s/b ServerError");
-            Assert.IsFalse(doe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(doe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(message)
             doe = new DomainOperationException("message");
@@ -29,7 +29,7 @@ namespace OpenRiaServices.Client.Test
             Assert.IsNull(doe.StackTrace, "Default stack trace s/b null");
             Assert.AreEqual(0, doe.ErrorCode, "Error code s/b 0");
             Assert.AreEqual(OperationErrorStatus.ServerError, doe.Status, "Default status s/b ServerError");
-            Assert.IsFalse(doe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(doe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(message, status)
             doe = new DomainOperationException("message", OperationErrorStatus.Unauthorized);
@@ -38,7 +38,7 @@ namespace OpenRiaServices.Client.Test
             Assert.IsNull(doe.StackTrace, "Default stack trace s/b null");
             Assert.AreEqual(0, doe.ErrorCode, "Error code s/b 0");
             Assert.AreEqual(OperationErrorStatus.Unauthorized, doe.Status, "ctor(msg, status) failed status");
-            Assert.IsFalse(doe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(doe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(message, status, errCode)
             doe = new DomainOperationException("message", OperationErrorStatus.Unauthorized, 5);
@@ -47,7 +47,7 @@ namespace OpenRiaServices.Client.Test
             Assert.IsNull(doe.StackTrace, "Default stack trace s/b null");
             Assert.AreEqual(5, doe.ErrorCode, "Error code failed");
             Assert.AreEqual(OperationErrorStatus.Unauthorized, doe.Status, "ctor(msg, status) failed status");
-            Assert.IsFalse(doe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(doe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(message, status, errCode, stackTrace)
             doe = new DomainOperationException("message", OperationErrorStatus.Unauthorized, 5, "stackTrace");
@@ -56,7 +56,7 @@ namespace OpenRiaServices.Client.Test
             Assert.AreEqual("stackTrace", doe.StackTrace, "StackTrace failed");
             Assert.AreEqual(5, doe.ErrorCode, "Error code failed");
             Assert.AreEqual(OperationErrorStatus.Unauthorized, doe.Status, "ctor(msg, status) failed status");
-            Assert.IsFalse(doe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(doe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(message, innerException)
             InvalidOperationException ioe = new InvalidOperationException("ioe");
@@ -66,7 +66,7 @@ namespace OpenRiaServices.Client.Test
             Assert.IsNull(doe.StackTrace, "Default stack trace s/b null");
             Assert.AreEqual(0, doe.ErrorCode, "Error code s/b 0");
             Assert.AreEqual(OperationErrorStatus.ServerError, doe.Status, "Default status s/b ServerError");
-            Assert.IsFalse(doe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(doe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(message, doe)
             DomainOperationException doe2 = new DomainOperationException("message", OperationErrorStatus.Unauthorized, 5, "stackTrace");
@@ -76,7 +76,7 @@ namespace OpenRiaServices.Client.Test
             Assert.AreEqual("stackTrace", doe.StackTrace, "StackTrace failed");
             Assert.AreEqual(5, doe.ErrorCode, "Error code failed");
             Assert.AreEqual(OperationErrorStatus.Unauthorized, doe.Status, "ctor(msg, status) failed status");
-            Assert.IsFalse(doe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(doe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(message, validationerrors)
             var validationErrors = new List<ValidationResult>() {new ValidationResult("validation message")};

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.AvaloniaTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.AvaloniaTests.cs
@@ -1,0 +1,277 @@
+﻿#if NET
+using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Cities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
+
+namespace OpenRiaServices.Client.Test
+{
+    public partial class EntityCollectionTests
+    {
+        /// <summary>
+        /// Verify that EntityCollection works as intended with <see cref="ItemsSourceView"/> and <see cref="IEditableCollectionView"/> so
+        /// it works as intended with WPF bindings.
+        /// </summary>
+        [TestClass]
+        public class AvaloniaTests
+        {
+            [TestMethod]
+            [Description("Tests that create view returns an ItemsSourceView.")]
+            public void CreateView()
+            {
+                EntityCollection<City> entityCollection = CreateEntityCollection();
+                var view = ItemsSourceView.GetOrCreate(entityCollection);
+
+                Assert.IsNotNull(view, "View should not be null.");
+                Assert.AreNotSame(ItemsSourceView<City>.Empty, view, "View should not be null.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling AddNew and CommitNew on the View adds to the EntityCollection and EntitySet.")]
+            public void AddNew()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                DataGridCollectionView view = new(entityCollection);
+
+                City city = (City)view.AddNew();
+                Assert.IsTrue(entityCollection.Contains(city),
+                    "EntityCollection should contain the first entity after AddNew.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the first entity after AddNew.");
+                city.Name = "Burien";
+                city.CountyName = "King";
+                city.StateName = "WA";
+                view.CommitNew();
+                Assert.IsTrue(entityCollection.Contains(city),
+                    "EntityCollection should contain the first entity after CommitNew.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the first entity after CommitNew.");
+            }
+
+
+            [TestMethod]
+            [Description("Tests that calling AddNew on the View adds to the EntityCollection and EntitySet and CancelNew removes both.")]
+            public void CancelNew()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                DataGridCollectionView view = new(entityCollection);
+
+                City city = (City)view.AddNew();
+                Assert.IsTrue(entityCollection.Contains(city),
+                    "EntityCollection should contain the second entity after AddNew.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the second entity after AddNew.");
+
+                view.CancelNew();
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the second entity after CancelNew.");
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the second entity after CancelNew.");
+            }
+
+            [TestMethod]
+            [Description("Tests that CanAddNew and CanRemove on the View are always true.")]
+            public void CanAddOrRemove()
+            {
+                EntityCollection<City> entityCollection = CreateEntityCollection();
+                DataGridCollectionView view = new(entityCollection);
+
+                // Justification for these assertions is documented in the EntityCollection source
+                Assert.IsTrue(view.CanAddNew,
+                    "CanAddNew should be true.");
+                Assert.IsTrue(view.CanRemove,
+                    "CanRemove should be true.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling Remove on the View remove from the EntityCollection and EntitySet.")]
+            public void Remove()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                DataGridCollectionView view = new(entityCollection);
+
+                City city = (City)view.AddNew();
+                city.Name = "Des Moines";
+                city.CountyName = "King";
+                city.StateName = "WA";
+                view.CommitNew();
+                entityCollection.Add(CreateLocalCity("Normandy Park"));
+                entityCollection.Add(CreateLocalCity("SeaTac"));
+
+                // This one was added through the view and will be removed from both
+                view.Remove(city);
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the first entity.");
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the first entity.");
+
+                // This one was added directly and will only be removed for the collection
+                city = entityCollection.ElementAt(1);
+                view.Remove(city);
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the entity at index 1.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should still contain the entity at index 1.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling RemoveAt on the View remove from the EntityCollection and EntitySet.")]
+            public void RemoveAt()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                DataGridCollectionView view = new(entityCollection);
+
+                City city = (City)view.AddNew();
+                city.Name = "Des Moines";
+                city.CountyName = "King";
+                city.StateName = "WA";
+                view.CommitNew();
+                entityCollection.Add(CreateLocalCity("Normandy Park"));
+                entityCollection.Add(CreateLocalCity("SeaTac"));
+
+                // This one was added through the view and will be removed from both
+                city = entityCollection.ElementAt(0);
+                view.RemoveAt(0);
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the entity at index 0.");
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the entity at index 0.");
+
+                // This one was added directly and will only be removed for the collection
+                city = entityCollection.ElementAt(1);
+                view.RemoveAt(1);
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the entity at index 1.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should still contain the entity at index 1.");
+            }
+
+            [TestMethod]
+            [Description("Tests that enumerating the View in its default order matches enumerating the EntityCollection.")]
+            public void Enumerate()
+            {
+                EntityCollection<City> entityCollection = CreateEntityCollection();
+                ItemsSourceView view = ItemsSourceView.GetOrCreate(entityCollection);
+
+                IEnumerator entityCollectionEnumerator = entityCollection.GetEnumerator();
+                IEnumerator viewEnumerator = view.GetEnumerator();
+
+                while (entityCollectionEnumerator.MoveNext())
+                {
+                    Assert.IsTrue(viewEnumerator.MoveNext(),
+                        "The view enumerator should be able to move to the next item.");
+                    Assert.AreEqual(entityCollectionEnumerator.Current, viewEnumerator.Current,
+                        "Current enumerator items should be equal.");
+                }
+                Assert.IsFalse(viewEnumerator.MoveNext(),
+                    "The view enumerator should not have any more items to move to.");
+            }
+
+            [TestMethod]
+            [Description("Tests that adding to or removing from the EntityCollection is reflected in the View.")]
+            public void CollectionChanged()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                ItemsSourceView view = ItemsSourceView.GetOrCreate(entityCollection);
+
+                NotifyCollectionChangedEventArgs eventArgs = null;
+                NotifyCollectionChangedEventHandler handler = (sender, e) =>
+                {
+                    Assert.IsNull(eventArgs,
+                        "Only a single event should have occurred.");
+                    eventArgs = e;
+                };
+
+                view.CollectionChanged += handler;
+
+                // Add
+                eventArgs = null;
+                City city = CreateLocalCity("Snoqualmie");
+                entityCollection.Add(city);
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after adding an entity.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgs.Action,
+                    "Actions should be equal after adding an entity.");
+                Assert.IsNotNull(eventArgs.NewItems,
+                    "NewItems should not be null after adding an entity.");
+                Assert.AreEqual(1, eventArgs.NewItems.Count,
+                    "NewItems count should be 1 after adding an entity.");
+                Assert.AreEqual(city, eventArgs.NewItems[0],
+                    "The new items should be equal.");
+
+                Assert.IsTrue(view.Contains(city),
+                    "View should contain entity after Add.");
+
+                // Remove
+                eventArgs = null;
+                city = CreateLocalCity("Sammamish");
+                entityCollection.Add(city);
+
+                Assert.IsTrue(view.Contains(city),
+                    "View should contain entity after second Add.");
+
+                eventArgs = null;
+                entityCollection.Remove(city);
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after removing an entity.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgs.Action,
+                    "Actions should be equal after removing  an entity.");
+                Assert.IsNotNull(eventArgs.OldItems,
+                    "OldItems should not be null after removing  an entity.");
+                Assert.AreEqual(1, eventArgs.OldItems.Count,
+                    "OldItems count should be 1 after removing  an entity.");
+                Assert.AreEqual(city, eventArgs.OldItems[0],
+                    "The old items should be equal.");
+
+                Assert.IsFalse(view.Contains(city),
+                    "View should not contain entity after Remove.");
+
+                // Reset
+                eventArgs = null;
+                entitySet.Clear();
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after clearing the EntitySet.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action,
+                    "Actions should be equal after clearing the EntitySet.");
+
+                Assert.HasCount(0, view,
+                    "View should be empty after Clear.");
+
+                view.CollectionChanged -= handler;
+            }
+
+            [TestMethod]
+            [WorkItem(201155)]
+            [Description("Tests that the memory leak in ICVF Proxies is fixed.")]
+            public void MemoryLeakTest()
+            {
+                // Use NoInline so JIT will not keep temp variable alive 
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                WeakReference CreateCollectionViewWeakRef(EntityCollection<City> entityCollection)
+                    => new WeakReference(ItemsSourceView.GetOrCreate(entityCollection));
+
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                WeakReference weakRef = CreateCollectionViewWeakRef(entityCollection);
+                System.GC.Collect();
+                Assert.IsFalse(weakRef.IsAlive);
+            }
+        }
+    }
+}
+#endif

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.AvaloniaTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.AvaloniaTests.cs
@@ -16,7 +16,7 @@ namespace OpenRiaServices.Client.Test
     public partial class EntityCollectionTests
     {
         /// <summary>
-        /// Verify that EntityCollection works as intended with <see cref="ItemsSourceView"/> and <see cref="IEditableCollectionView"/> so
+        /// Verify that EntityCollection works as intended with <see cref="ItemsSourceView"/> and <see cref="DataGridCollectionView"/> so
         /// it works as intended with WPF bindings.
         /// </summary>
         [TestClass]

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.CollectionViewTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.CollectionViewTests.cs
@@ -1,0 +1,281 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Cities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
+
+namespace OpenRiaServices.Client.Test
+{
+    public partial class EntityCollectionTests
+    {
+        /// <summary>
+        /// Verify that EntityCollection works as intended with <see cref="ICollectionView"/> and <see cref="IEditableCollectionView"/> so
+        /// it works as intended with WPF bindings.
+        /// </summary>
+        [TestClass]
+        public class CollectionViewTests
+        {
+            [TestMethod]
+            [Description("Tests that create view returns an ICollectionView.")]
+            public void ICVF_CreateView()
+            {
+                EntityCollection<City> entityCollection = CreateEntityCollection();
+                Assert.IsNotNull(this.GetICV(entityCollection),
+                    "View should not be null.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling AddNew and CommitNew on the View adds to the EntityCollection and EntitySet.")]
+            public void ICVF_AddNew()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                IEditableCollectionView view = this.GetIECV(entityCollection);
+
+                City city = (City)view.AddNew();
+                Assert.IsTrue(entityCollection.Contains(city),
+                    "EntityCollection should contain the first entity after AddNew.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the first entity after AddNew.");
+                city.Name = "Burien";
+                city.CountyName = "King";
+                city.StateName = "WA";
+                view.CommitNew();
+                Assert.IsTrue(entityCollection.Contains(city),
+                    "EntityCollection should contain the first entity after CommitNew.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the first entity after CommitNew.");
+            }
+
+
+            [TestMethod]
+            [Description("Tests that calling AddNew on the View adds to the EntityCollection and EntitySet and CancelNew removes both.")]
+            public void ICVF_CancelNew()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                IEditableCollectionView view = this.GetIECV(entityCollection);
+
+                City city = (City)view.AddNew();
+                Assert.IsTrue(entityCollection.Contains(city),
+                    "EntityCollection should contain the second entity after AddNew.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the second entity after AddNew.");
+
+                view.CancelNew();
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the second entity after CancelNew.");
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the second entity after CancelNew.");
+            }
+
+            [TestMethod]
+            [Description("Tests that CanAddNew and CanRemove on the View are always true.")]
+            public void ICVF_CanAddOrRemove()
+            {
+                EntityCollection<City> entityCollection = CreateEntityCollection();
+                IEditableCollectionView view = this.GetIECV(entityCollection);
+
+                // Justification for these assertions is documented in the EntityCollection source
+                Assert.IsTrue(view.CanAddNew,
+                    "CanAddNew should be true.");
+                Assert.IsTrue(view.CanRemove,
+                    "CanRemove should be true.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling Remove on the View remove from the EntityCollection and EntitySet.")]
+            public void ICVF_Remove()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                IEditableCollectionView view = this.GetIECV(entityCollection);
+
+                City city = (City)view.AddNew();
+                city.Name = "Des Moines";
+                city.CountyName = "King";
+                city.StateName = "WA";
+                view.CommitNew();
+                entityCollection.Add(CreateLocalCity("Normandy Park"));
+                entityCollection.Add(CreateLocalCity("SeaTac"));
+
+                // This one was added through the view and will be removed from both
+                view.Remove(city);
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the first entity.");
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the first entity.");
+
+                // This one was added directly and will only be removed for the collection
+                city = entityCollection.ElementAt(1);
+                view.Remove(city);
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the entity at index 1.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should still contain the entity at index 1.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling RemoveAt on the View remove from the EntityCollection and EntitySet.")]
+            public void ICVF_RemoveAt()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                IEditableCollectionView view = this.GetIECV(entityCollection);
+
+                City city = (City)view.AddNew();
+                city.Name = "Des Moines";
+                city.CountyName = "King";
+                city.StateName = "WA";
+                view.CommitNew();
+                entityCollection.Add(CreateLocalCity("Normandy Park"));
+                entityCollection.Add(CreateLocalCity("SeaTac"));
+
+                // This one was added through the view and will be removed from both
+                city = entityCollection.ElementAt(0);
+                view.RemoveAt(0);
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the entity at index 0.");
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the entity at index 0.");
+
+                // This one was added directly and will only be removed for the collection
+                city = entityCollection.ElementAt(1);
+                view.RemoveAt(1);
+                Assert.IsFalse(entityCollection.Contains(city),
+                    "EntityCollection should no longer contain the entity at index 1.");
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should still contain the entity at index 1.");
+            }
+
+            [TestMethod]
+            [Description("Tests that enumerating the View in its default order matches enumerating the EntityCollection.")]
+            public void ICVF_Enumerate()
+            {
+                EntityCollection<City> entityCollection = CreateEntityCollection();
+                ICollectionView view = this.GetICV(entityCollection);
+
+                IEnumerator entityCollectionEnumerator = entityCollection.GetEnumerator();
+                IEnumerator viewEnumerator = view.GetEnumerator();
+
+                while (entityCollectionEnumerator.MoveNext())
+                {
+                    Assert.IsTrue(viewEnumerator.MoveNext(),
+                        "The view enumerator should be able to move to the next item.");
+                    Assert.AreEqual(entityCollectionEnumerator.Current, viewEnumerator.Current,
+                        "Current enumerator items should be equal.");
+                }
+                Assert.IsFalse(viewEnumerator.MoveNext(),
+                    "The view enumerator should not have any more items to move to.");
+            }
+
+            [TestMethod]
+            [Description("Tests that adding to or removing from the EntityCollection is reflected in the View.")]
+            public void ICVF_CollectionChanged()
+            {
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                ICollectionView view = this.GetICV(entityCollection);
+
+                NotifyCollectionChangedEventArgs eventArgs = null;
+                NotifyCollectionChangedEventHandler handler = (sender, e) =>
+                {
+                    Assert.IsNull(eventArgs,
+                        "Only a single event should have occurred.");
+                    eventArgs = e;
+                };
+
+                view.CollectionChanged += handler;
+
+                // Add
+                eventArgs = null;
+                City city = CreateLocalCity("Snoqualmie");
+                entityCollection.Add(city);
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after adding an entity.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgs.Action,
+                    "Actions should be equal after adding an entity.");
+                Assert.IsNotNull(eventArgs.NewItems,
+                    "NewItems should not be null after adding an entity.");
+                Assert.AreEqual(1, eventArgs.NewItems.Count,
+                    "NewItems count should be 1 after adding an entity.");
+                Assert.AreEqual(city, eventArgs.NewItems[0],
+                    "The new items should be equal.");
+
+                Assert.IsTrue(view.Contains(city),
+                    "View should contain entity after Add.");
+
+                // Remove
+                eventArgs = null;
+                city = CreateLocalCity("Sammamish");
+                entityCollection.Add(city);
+
+                Assert.IsTrue(view.Contains(city),
+                    "View should contain entity after second Add.");
+
+                eventArgs = null;
+                entityCollection.Remove(city);
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after removing an entity.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgs.Action,
+                    "Actions should be equal after removing  an entity.");
+                Assert.IsNotNull(eventArgs.OldItems,
+                    "OldItems should not be null after removing  an entity.");
+                Assert.AreEqual(1, eventArgs.OldItems.Count,
+                    "OldItems count should be 1 after removing  an entity.");
+                Assert.AreEqual(city, eventArgs.OldItems[0],
+                    "The old items should be equal.");
+
+                Assert.IsFalse(view.Contains(city),
+                    "View should not contain entity after Remove.");
+
+                // Reset
+                eventArgs = null;
+                entitySet.Clear();
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after clearing the EntitySet.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action,
+                    "Actions should be equal after clearing the EntitySet.");
+
+                Assert.IsTrue(view.IsEmpty,
+                    "View should be empty after Clear.");
+
+                view.CollectionChanged -= handler;
+            }
+
+            [TestMethod]
+            [WorkItem(201155)]
+            [Description("Tests that the memory leak in ICVF Proxies is fixed.")]
+            public void ICVF_MemoryLeakTest()
+            {
+                // Use NoInline so JIT will not keep temp variable alive 
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                WeakReference CreateCollectionViewWeakRef(EntityCollection<City> entityCollection)
+                    => new WeakReference(this.GetICV(entityCollection));
+
+                EntitySet<City> entitySet;
+                EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+                WeakReference weakRef = CreateCollectionViewWeakRef(entityCollection);
+                System.GC.Collect();
+                Assert.IsFalse(weakRef.IsAlive);
+            }
+
+            private ICollectionView GetICV(EntityCollection<City> entityCollection)
+            {
+                return ((ICollectionViewFactory)entityCollection).CreateView();
+            }
+
+            private IEditableCollectionView GetIECV(EntityCollection<City> entityCollection)
+            {
+                return (IEditableCollectionView)this.GetICV(entityCollection);
+            }
+        }
+    }
+}

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntityCollectionTests.cs
@@ -1,10 +1,6 @@
-﻿extern alias SSmDsClient;
-using System;
-using System.Collections;
-using System.Collections.Specialized;
+﻿using System;
 using System.ComponentModel;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Cities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
@@ -12,270 +8,15 @@ using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttr
 
 namespace OpenRiaServices.Client.Test
 {
-
     [TestClass]
-    public class EntityCollectionTests : UnitTestBase
+    public partial class EntityCollectionTests : UnitTestBase
     {
-#if HAS_COLLECTIONVIEW
-        [TestMethod]
-        [Description("Tests that create view returns an ICollectionView.")]
-        public void ICVF_CreateView()
-        {
-            EntityCollection<City> entityCollection = this.CreateEntityCollection();
-            Assert.IsNotNull(this.GetICV(entityCollection),
-                "View should not be null.");
-        }
-
-        [TestMethod]
-        [Description("Tests that calling AddNew and CommitNew on the View adds to the EntityCollection and EntitySet.")]
-        public void ICVF_AddNew()
-        {
-            EntitySet<City> entitySet;
-            EntityCollection <City> entityCollection = this.CreateEntityCollection(out entitySet);
-            IEditableCollectionView view = this.GetIECV(entityCollection);
-
-            City city = (City)view.AddNew();
-            Assert.IsTrue(entityCollection.Contains(city),
-                "EntityCollection should contain the first entity after AddNew.");
-            Assert.IsTrue(entitySet.Contains(city),
-                "EntitySet should contain the first entity after AddNew.");
-            city.Name = "Burien";
-            city.CountyName = "King";
-            city.StateName = "WA";
-            view.CommitNew();
-            Assert.IsTrue(entityCollection.Contains(city),
-                "EntityCollection should contain the first entity after CommitNew.");
-            Assert.IsTrue(entitySet.Contains(city),
-                "EntitySet should contain the first entity after CommitNew.");
-        }
-
-        [TestMethod]
-        [Description("Tests that ListCollectionViewProxy returns correct index")]
-        public void ICVF_ListCollectionViewProxy_Add()
-        {
-            EntitySet<City> entitySet;
-            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
-            EntityCollection<City>.ListCollectionViewProxy<City> collection = new(entityCollection);
-
-            for (int i=0; i < 3; ++i)
-            {
-                var city = new City() {  ZoneID = i };
-
-                Assert.IsFalse(collection.Contains(city));
-                int idx = collection.Add(city);
-
-                Assert.AreEqual(i, idx);
-                Assert.AreSame(city, collection[idx]);
-                Assert.IsTrue(collection.Contains(city));
-                Assert.IsTrue(entityCollection.Contains(city));
-            }
-        }
-
-        [TestMethod]
-        [Description("Tests that calling AddNew on the View adds to the EntityCollection and EntitySet and CancelNew removes both.")]
-        public void ICVF_CancelNew()
-        {
-            EntitySet<City> entitySet;
-            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
-            IEditableCollectionView view = this.GetIECV(entityCollection);
-
-            City city = (City)view.AddNew();
-            Assert.IsTrue(entityCollection.Contains(city),
-                "EntityCollection should contain the second entity after AddNew.");
-            Assert.IsTrue(entitySet.Contains(city),
-                "EntitySet should contain the second entity after AddNew.");
-
-            view.CancelNew();
-            Assert.IsFalse(entityCollection.Contains(city),
-                "EntityCollection should no longer contain the second entity after CancelNew.");
-            Assert.IsFalse(entitySet.Contains(city),
-                "EntitySet should no longer contain the second entity after CancelNew.");
-        }
-
-        [TestMethod]
-        [Description("Tests that CanAddNew and CanRemove on the View are always true.")]
-        public void ICVF_CanAddOrRemove()
-        {
-            EntityCollection<City> entityCollection = this.CreateEntityCollection();
-            IEditableCollectionView view = this.GetIECV(entityCollection);
-
-            // Justification for these assertions is documented in the EntityCollection source
-            Assert.IsTrue(view.CanAddNew,
-                "CanAddNew should be true.");
-            Assert.IsTrue(view.CanRemove,
-                "CanRemove should be true.");
-        }
-
-        [TestMethod]
-        [Description("Tests that calling Remove on the View remove from the EntityCollection and EntitySet.")]
-        public void ICVF_Remove()
-        {
-            EntitySet<City> entitySet;
-            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
-            IEditableCollectionView view = this.GetIECV(entityCollection);
-
-            City city = (City)view.AddNew();
-            city.Name = "Des Moines";
-            city.CountyName = "King";
-            city.StateName = "WA";
-            view.CommitNew();
-            entityCollection.Add(this.CreateLocalCity("Normandy Park"));
-            entityCollection.Add(this.CreateLocalCity("SeaTac"));
-
-            // This one was added through the view and will be removed from both
-            view.Remove(city);
-            Assert.IsFalse(entityCollection.Contains(city),
-                "EntityCollection should no longer contain the first entity.");
-            Assert.IsFalse(entitySet.Contains(city),
-                "EntitySet should no longer contain the first entity.");
-
-            // This one was added directly and will only be removed for the collection
-            city = entityCollection.ElementAt(1);
-            view.Remove(city);
-            Assert.IsFalse(entityCollection.Contains(city),
-                "EntityCollection should no longer contain the entity at index 1.");
-            Assert.IsTrue(entitySet.Contains(city),
-                "EntitySet should still contain the entity at index 1.");
-        }
-
-        [TestMethod]
-        [Description("Tests that calling RemoveAt on the View remove from the EntityCollection and EntitySet.")]
-        public void ICVF_RemoveAt()
-        {
-            EntitySet<City> entitySet;
-            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
-            IEditableCollectionView view = this.GetIECV(entityCollection);
-
-            City city = (City)view.AddNew();
-            city.Name = "Des Moines";
-            city.CountyName = "King";
-            city.StateName = "WA";
-            view.CommitNew();
-            entityCollection.Add(this.CreateLocalCity("Normandy Park"));
-            entityCollection.Add(this.CreateLocalCity("SeaTac"));
-
-            // This one was added through the view and will be removed from both
-            city = entityCollection.ElementAt(0);
-            view.RemoveAt(0);
-            Assert.IsFalse(entityCollection.Contains(city),
-                "EntityCollection should no longer contain the entity at index 0.");
-            Assert.IsFalse(entitySet.Contains(city),
-                "EntitySet should no longer contain the entity at index 0.");
-
-            // This one was added directly and will only be removed for the collection
-            city = entityCollection.ElementAt(1);
-            view.RemoveAt(1);
-            Assert.IsFalse(entityCollection.Contains(city),
-                "EntityCollection should no longer contain the entity at index 1.");
-            Assert.IsTrue(entitySet.Contains(city),
-                "EntitySet should still contain the entity at index 1.");
-        }
-
-        [TestMethod]
-        [Description("Tests that enumerating the View in its default order matches enumerating the EntityCollection.")]
-        public void ICVF_Enumerate()
-        {
-            EntityCollection<City> entityCollection = this.CreateEntityCollection();
-            ICollectionView view = this.GetICV(entityCollection);
-
-            IEnumerator entityCollectionEnumerator = entityCollection.GetEnumerator();
-            IEnumerator viewEnumerator = view.GetEnumerator();
-
-            while (entityCollectionEnumerator.MoveNext())
-            {
-                Assert.IsTrue(viewEnumerator.MoveNext(),
-                    "The view enumerator should be able to move to the next item.");
-                Assert.AreEqual(entityCollectionEnumerator.Current, viewEnumerator.Current,
-                    "Current enumerator items should be equal.");
-            }
-            Assert.IsFalse(viewEnumerator.MoveNext(),
-                "The view enumerator should not have any more items to move to.");
-        }
-
-        [TestMethod]
-        [Description("Tests that adding to or removing from the EntityCollection is reflected in the View.")]
-        public void ICVF_CollectionChanged()
-        {
-            EntitySet<City> entitySet;
-            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
-            ICollectionView view = this.GetICV(entityCollection);
-
-            NotifyCollectionChangedEventArgs eventArgs = null;
-            NotifyCollectionChangedEventHandler handler = (sender, e) =>
-            {
-                Assert.IsNull(eventArgs,
-                    "Only a single event should have occurred.");
-                eventArgs = e;
-            };
-
-            view.CollectionChanged += handler;
-
-            // Add
-            eventArgs = null;
-            City city = this.CreateLocalCity("Snoqualmie");
-            entityCollection.Add(city);
-
-            Assert.IsNotNull(eventArgs,
-                "Event should not be null after adding an entity.");
-            Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgs.Action,
-                "Actions should be equal after adding an entity.");
-            Assert.IsNotNull(eventArgs.NewItems,
-                "NewItems should not be null after adding an entity.");
-            Assert.AreEqual(1, eventArgs.NewItems.Count,
-                "NewItems count should be 1 after adding an entity.");
-            Assert.AreEqual(city, eventArgs.NewItems[0],
-                "The new items should be equal.");
-
-            Assert.IsTrue(view.Contains(city),
-                "View should contain entity after Add.");
-
-            // Remove
-            eventArgs = null;
-            city = this.CreateLocalCity("Sammamish");
-            entityCollection.Add(city);
-
-            Assert.IsTrue(view.Contains(city),
-                "View should contain entity after second Add.");
-
-            eventArgs = null;
-            entityCollection.Remove(city);
-
-            Assert.IsNotNull(eventArgs,
-                "Event should not be null after removing an entity.");
-            Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgs.Action,
-                "Actions should be equal after removing  an entity.");
-            Assert.IsNotNull(eventArgs.OldItems,
-                "OldItems should not be null after removing  an entity.");
-            Assert.AreEqual(1, eventArgs.OldItems.Count,
-                "OldItems count should be 1 after removing  an entity.");
-            Assert.AreEqual(city, eventArgs.OldItems[0],
-                "The old items should be equal.");
-
-            Assert.IsFalse(view.Contains(city),
-                "View should not contain entity after Remove.");
-
-            // Reset
-            eventArgs = null;
-            entitySet.Clear();
-
-            Assert.IsNotNull(eventArgs,
-                "Event should not be null after clearing the EntitySet.");
-            Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action,
-                "Actions should be equal after clearing the EntitySet.");
-
-            Assert.IsTrue(view.IsEmpty,
-                "View should be empty after Clear.");
-
-            view.CollectionChanged -= handler;
-        }
-#endif
-
         [TestMethod]
         [Description("EntityAdded and EntityRemoved events should be raised when adding and removing from an EntityCollection")]
         public void EntityEventsOnDirectUpdate()
         {
             EntitySet<City> entitySet;
-            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
+            EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
 
             EntityCollectionChangedEventArgs<City> eventArgs = null;
             EventHandler<EntityCollectionChangedEventArgs<City>> handler = (sender, e) =>
@@ -290,7 +31,7 @@ namespace OpenRiaServices.Client.Test
 
             // Add
             eventArgs = null;
-            City city = this.CreateLocalCity("Newcastle");
+            City city = CreateLocalCity("Newcastle");
             entityCollection.Add(city);
 
             Assert.IsTrue(entityCollection.Contains(city),
@@ -302,7 +43,7 @@ namespace OpenRiaServices.Client.Test
 
             // Remove
             eventArgs = null;
-            city = this.CreateLocalCity("Medina");
+            city = CreateLocalCity("Medina");
             entityCollection.Add(city);
 
             Assert.IsTrue(entityCollection.Contains(city),
@@ -324,7 +65,7 @@ namespace OpenRiaServices.Client.Test
         public void EntityEventsOnIndirectUpdate()
         {
             EntitySet<City> entitySet;
-            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
+            EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
 
             EntityCollectionChangedEventArgs<City> eventArgs = null;
             EventHandler<EntityCollectionChangedEventArgs<City>> handler = (sender, e) =>
@@ -339,7 +80,7 @@ namespace OpenRiaServices.Client.Test
 
             // Add
             eventArgs = null;
-            City city = this.CreateLocalCity("Enumclaw");
+            City city = CreateLocalCity("Enumclaw");
             entitySet.Attach(city);
 
             Assert.IsTrue(entityCollection.Contains(city),
@@ -351,7 +92,7 @@ namespace OpenRiaServices.Client.Test
 
             // Remove
             eventArgs = null;
-            city = this.CreateLocalCity("Duvall");
+            city = CreateLocalCity("Duvall");
             entitySet.Attach(city);
 
             Assert.IsTrue(entityCollection.Contains(city),
@@ -367,38 +108,43 @@ namespace OpenRiaServices.Client.Test
             Assert.AreEqual(city, eventArgs.Entity,
                 "Entities shoudl be equal after removing.");
         }
-#if HAS_COLLECTIONVIEW
+
+
         [TestMethod]
-        [WorkItem(201155)]
-        [Description("Tests that the memory leak in ICVF Proxies is fixed.")]
-
-        public void ICVF_MemoryLeakTest()
-        {
-            // Use NoInline so JIT will not keep temp variable alive 
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            WeakReference CreateCollectionViewWeakRef(EntityCollection<City> entityCollection)
-                => new WeakReference(this.GetICV(entityCollection));
-
-            EntitySet<City> entitySet;
-            EntityCollection<City> entityCollection = this.CreateEntityCollection(out entitySet);
-            WeakReference weakRef = CreateCollectionViewWeakRef(entityCollection);
-            System.GC.Collect();
-            Assert.IsFalse(weakRef.IsAlive);
-        }
-#endif
-
-        private EntityCollection<City> CreateEntityCollection()
+        [Description("Tests that ListCollectionViewProxy returns correct index")]
+        public void IList_Add_And_Index()
         {
             EntitySet<City> entitySet;
-            return this.CreateEntityCollection(EntitySetOperations.All, out entitySet);
+            EntityCollection<City> entityCollection = CreateEntityCollection(out entitySet);
+            System.Collections.IList list = entityCollection;
+
+            for (int i = 0; i < 3; ++i)
+            {
+                var city = new City() { ZoneID = i };
+
+                Assert.IsFalse(list.Contains(city));
+                int idx = list.Add(city);
+
+                Assert.AreEqual(i, idx);
+                Assert.AreSame(city, list[idx]);
+                Assert.AreSame(city, entityCollection[idx]);
+                Assert.IsTrue(list.Contains(city));
+                Assert.IsTrue(entityCollection.Contains(city));
+            }
         }
 
-        private EntityCollection<City> CreateEntityCollection(out EntitySet<City> entitySet)
+        private static EntityCollection<City> CreateEntityCollection()
         {
-            return this.CreateEntityCollection(EntitySetOperations.All, out entitySet);
+            EntitySet<City> entitySet;
+            return CreateEntityCollection(EntitySetOperations.All, out entitySet);
         }
 
-        private EntityCollection<City> CreateEntityCollection(EntitySetOperations operations, out EntitySet<City> entitySet)
+        private static EntityCollection<City> CreateEntityCollection(out EntitySet<City> entitySet)
+        {
+            return CreateEntityCollection(EntitySetOperations.All, out entitySet);
+        }
+
+        private static EntityCollection<City> CreateEntityCollection(EntitySetOperations operations, out EntitySet<City> entitySet)
         {
             DynamicEntityContainer container = new DynamicEntityContainer();
             County county = new County { Name = "King", StateName = "WA" };
@@ -408,22 +154,10 @@ namespace OpenRiaServices.Client.Test
             return county.Cities;
         }
 
-        private City CreateLocalCity(string name)
+        private static City CreateLocalCity(string name)
         {
             return new City { Name = name, CountyName = "King", StateName = "WA" };
         }
-
-#if HAS_COLLECTIONVIEW
-        private ICollectionView GetICV(EntityCollection<City> entityCollection)
-        {
-            return ((ICollectionViewFactory)entityCollection).CreateView();
-        }
-
-        private IEditableCollectionView GetIECV(EntityCollection<City> entityCollection)
-        {
-            return (IEditableCollectionView)this.GetICV(entityCollection);
-        }
-#endif
 
         /// <summary>
         /// An dynamic EntityContainer class that allows external configuration of

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.AvaloniaTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.AvaloniaTests.cs
@@ -1,0 +1,264 @@
+﻿#if NET
+using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Cities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
+
+namespace OpenRiaServices.Client.Test
+{
+    public partial class EntitySetTests
+    {
+        /// <summary>
+        /// Mirror of <see cref="EntitySetTests.CollectionViewTests"/> to verify that
+        /// EntitySet works as intended with <see cref="ItemsSourceView"/> and <see cref="DataGridCollectionView"/> in Avalonia.
+        /// </summary>
+        [TestClass]
+        public class AvaloniaItemsSourceView
+        {
+            [TestMethod]
+            [Description("Tests that create view returns an ICollectionView.")]
+            public void Avalonia_CVF_CreateView()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+
+                var view = ItemsSourceView.GetOrCreate(entitySet);
+                Assert.IsNotNull(view, "View should not be null.");
+                Assert.AreNotSame(view, ItemsSourceView<City>.Empty);
+            }
+
+            [TestMethod]
+            [Description("Tests that calling AddNew and CommitNew on the View adds to the EntitySet.")]
+            public void AddNew()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                DataGridCollectionView view = new(entitySet);
+
+                City city = (City)view.AddNew();
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the first entity after AddNew.");
+                city.Name = "Tukwila";
+                city.CountyName = "King";
+                city.StateName = "WA";
+                view.CommitNew();
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the first entity after CommitNew.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling AddNew on the View adds to the EntitySet and CancelNew removes.")]
+            public void CancelNew()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                DataGridCollectionView view = new(entitySet);
+
+                City city = (City)view.AddNew();
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the second entity after AddNew.");
+
+                view.CancelNew();
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the second entity after CancelNew.");
+            }
+
+            [TestMethod]
+            [Description("Tests that CanAddNew and CanRemove on the View are representative of the valid EntitySetOperations.")]
+            public void CanAddOrRemove()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>(EntitySetOperations.Add | EntitySetOperations.Remove);
+                DataGridCollectionView view = new(entitySet);
+                Assert.IsTrue(view.CanAddNew,
+                    "CanAddNew should be true when Add and Remove are supported.");
+                Assert.IsTrue(view.CanRemove,
+                    "CanRemove should be true when Add and Remove are supported.");
+
+                // It is a known issue that we cannot differentiate with the current design. Instead
+                // we'll see CanAddNew and CanRemove both be true if either should be supported. This
+                // leaves the control in the hands of the developers.
+                entitySet = CreateEntitySet<City>(EntitySetOperations.Add);
+                view = new DataGridCollectionView(entitySet);
+                Assert.IsTrue(view.CanAddNew,
+                    "CanAddNew should be true when only Add is supported.");
+                Assert.IsTrue(view.CanRemove,
+                    "CanRemove should be true when only Add is supported.");
+                //Assert.IsFalse(view.CanRemove,
+                //    "CanRemove should be false when only Add is supported.");
+
+                entitySet = CreateEntitySet<City>(EntitySetOperations.Remove);
+                view = new DataGridCollectionView(entitySet);
+                Assert.IsTrue(view.CanAddNew,
+                    "CanAddNew should be true when only Remove is supported.");
+                //Assert.IsFalse(view.CanAddNew,
+                //    "CanAddNew should be false when only Remove is supported.");
+                Assert.IsTrue(view.CanRemove,
+                    "CanRemove should be true when only Remove is supported.");
+
+                entitySet = CreateEntitySet<City>(EntitySetOperations.None);
+                view = new DataGridCollectionView(entitySet);
+                Assert.IsFalse(view.CanAddNew,
+                    "CanAddNew should be true when only neither Add nor Remove is supported.");
+                Assert.IsFalse(view.CanRemove,
+                    "CanRemove should be true when only neither Add nor Remove is supported.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling Remove on the View remove from the EntitySet.")]
+            public void Remove()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                DataGridCollectionView view = new(entitySet);
+
+                entitySet.Add(CreateLocalCity("Renton"));
+                entitySet.Add(CreateLocalCity("Kent"));
+                entitySet.Add(CreateLocalCity("Auburn"));
+
+                City city = entitySet.First();
+                view.Remove(city);
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the first entity.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling RemoveAt on the View remove from the EntitySet.")]
+            public void RemoveAt()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                DataGridCollectionView view = new(entitySet);
+
+                entitySet.Add(CreateLocalCity("Renton"));
+                entitySet.Add(CreateLocalCity("Kent"));
+                entitySet.Add(CreateLocalCity("Auburn"));
+
+                City city = entitySet.ElementAt(1);
+                view.RemoveAt(1);
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the entity at index 1.");
+            }
+
+            [TestMethod]
+            [Description("Tests that enumerating the View in its default order matches enumerating the EntitySet.")]
+            public void Enumerate()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                var view = ItemsSourceView.GetOrCreate(entitySet);
+
+                IEnumerator entitySetEnumerator = entitySet.GetEnumerator();
+                IEnumerator viewEnumerator = view.GetEnumerator();
+
+                while (entitySetEnumerator.MoveNext())
+                {
+                    Assert.IsTrue(viewEnumerator.MoveNext(),
+                        "The view enumerator should be able to move to the next item.");
+                    Assert.AreEqual(entitySetEnumerator.Current, viewEnumerator.Current,
+                        "Current enumerator items should be equal.");
+                }
+                Assert.IsFalse(viewEnumerator.MoveNext(),
+                    "The view enumerator should not have any more items to move to.");
+            }
+
+            [TestMethod]
+            [Description("Tests that adding to or removing from the EntitySet is reflected in the View.")]
+            public void CollectionChanged()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                var view = ItemsSourceView.GetOrCreate(entitySet);
+
+                NotifyCollectionChangedEventArgs eventArgs = null;
+                NotifyCollectionChangedEventHandler handler = (sender, e) =>
+                {
+                    Assert.IsNull(eventArgs,
+                        "Only a single event should have occurred.");
+                    eventArgs = e;
+                };
+
+                view.CollectionChanged += handler;
+
+                // Add
+                eventArgs = null;
+                City city = CreateLocalCity("Maple Valley");
+                entitySet.Add(city);
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after adding an entity.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgs.Action,
+                    "Actions should be equal after adding an entity.");
+                Assert.IsNotNull(eventArgs.NewItems,
+                    "NewItems should not be null after adding an entity.");
+                Assert.AreEqual(1, eventArgs.NewItems.Count,
+                    "NewItems count should be 1 after adding an entity.");
+                Assert.AreEqual(city, eventArgs.NewItems[0],
+                    "The new items should be equal.");
+
+                Assert.IsTrue(view.Contains(city),
+                    "View should contain entity after Add.");
+
+                // Remove
+                eventArgs = null;
+                city = CreateLocalCity("Covington");
+                entitySet.Add(city);
+
+                Assert.IsTrue(view.Contains(city),
+                    "View should contain entity after second Add.");
+
+                eventArgs = null;
+                entitySet.Remove(city);
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after removing an entity.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgs.Action,
+                    "Actions should be equal after removing  an entity.");
+                Assert.IsNotNull(eventArgs.OldItems,
+                    "OldItems should not be null after removing  an entity.");
+                Assert.AreEqual(1, eventArgs.OldItems.Count,
+                    "OldItems count should be 1 after removing  an entity.");
+                Assert.AreEqual(city, eventArgs.OldItems[0],
+                    "The old items should be equal.");
+
+                Assert.IsFalse(view.Contains(city),
+                    "View should not contain entity after Remove.");
+
+                // Reset
+                eventArgs = null;
+                entitySet.Clear();
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after clearing the EntitySet.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action,
+                    "Actions should be equal after clearing the EntitySet.");
+
+                Assert.IsTrue(view.Count == 0,
+                    "View should be empty after Clear.");
+
+                view.CollectionChanged -= handler;
+            }
+
+            [TestMethod]
+            [WorkItem(201155)]
+            [Description("Tests that the memory leak in ICVF Proxies is fixed.")]
+            public void MemoryLeakTest()
+            {
+                // Use NoInline so JIT will not keep temp variable alive 
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                WeakReference CreateCollectionViewWeakRef(EntitySet<City> enitySet)
+                    => new WeakReference(ItemsSourceView.GetOrCreate(enitySet));
+
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                WeakReference weakRef = CreateCollectionViewWeakRef(entitySet);
+                GC.Collect();
+                Assert.IsFalse(weakRef.IsAlive);
+            }
+
+            private ItemsSourceView GetICV(EntitySet entitySet)
+            {
+                return ItemsSourceView.GetOrCreate(entitySet);
+            }
+        }
+    }
+}
+#endif

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.AvaloniaTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.AvaloniaTests.cs
@@ -253,11 +253,6 @@ namespace OpenRiaServices.Client.Test
                 GC.Collect();
                 Assert.IsFalse(weakRef.IsAlive);
             }
-
-            private ItemsSourceView GetICV(EntitySet entitySet)
-            {
-                return ItemsSourceView.GetOrCreate(entitySet);
-            }
         }
     }
 }

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.CollectionViewTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.CollectionViewTests.cs
@@ -1,0 +1,268 @@
+﻿extern alias SSmDsClient;
+using System;
+using System.Collections;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Windows.Data;
+using Cities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
+
+namespace OpenRiaServices.Client.Test
+{
+    public partial class EntitySetTests
+    {
+#if HAS_COLLECTIONVIEW
+        /// <summary>
+        /// Verify that EntitySet works as intended with <see cref="ICollectionView"/> and <see cref="IEditableCollectionView"/> so
+        /// it works as intended with WPF bindings.
+        /// </summary>
+        [TestClass]
+        public class CollectionViewTests
+        {
+            [TestMethod]
+            [Description("Tests that create view returns an ICollectionView.")]
+            public void ICVF_CreateView()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                Assert.IsNotNull(this.GetICV(entitySet),
+                    "View should not be null.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling AddNew and CommitNew on the View adds to the EntitySet.")]
+            public void ICVF_AddNew()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                IEditableCollectionView view = this.GetIECV(entitySet);
+
+                City city = (City)view.AddNew();
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the first entity after AddNew.");
+                city.Name = "Tukwila";
+                city.CountyName = "King";
+                city.StateName = "WA";
+                view.CommitNew();
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the first entity after CommitNew.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling AddNew on the View adds to the EntitySet and CancelNew removes.")]
+            public void ICVF_CancelNew()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                IEditableCollectionView view = this.GetIECV(entitySet);
+
+                City city = (City)view.AddNew();
+                Assert.IsTrue(entitySet.Contains(city),
+                    "EntitySet should contain the second entity after AddNew.");
+
+                view.CancelNew();
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the second entity after CancelNew.");
+            }
+
+            [TestMethod]
+            [Description("Tests that CanAddNew and CanRemove on the View are representative of the valid EntitySetOperations.")]
+            public void ICVF_CanAddOrRemove()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>(EntitySetOperations.Add | EntitySetOperations.Remove);
+                IEditableCollectionView view = this.GetIECV(entitySet);
+                Assert.IsTrue(view.CanAddNew,
+                    "CanAddNew should be true when Add and Remove are supported.");
+                Assert.IsTrue(view.CanRemove,
+                    "CanRemove should be true when Add and Remove are supported.");
+
+                // It is a known issue that we cannot differentiate with the current design. Instead
+                // we'll see CanAddNew and CanRemove both be true if either should be supported. This
+                // leaves the control in the hands of the developers.
+                entitySet = CreateEntitySet<City>(EntitySetOperations.Add);
+                view = this.GetIECV(entitySet);
+                Assert.IsTrue(view.CanAddNew,
+                    "CanAddNew should be true when only Add is supported.");
+                Assert.IsTrue(view.CanRemove,
+                    "CanRemove should be true when only Add is supported.");
+                //Assert.IsFalse(view.CanRemove,
+                //    "CanRemove should be false when only Add is supported.");
+
+                entitySet = CreateEntitySet<City>(EntitySetOperations.Remove);
+                view = this.GetIECV(entitySet);
+                Assert.IsTrue(view.CanAddNew,
+                    "CanAddNew should be true when only Remove is supported.");
+                //Assert.IsFalse(view.CanAddNew,
+                //    "CanAddNew should be false when only Remove is supported.");
+                Assert.IsTrue(view.CanRemove,
+                    "CanRemove should be true when only Remove is supported.");
+
+                entitySet = CreateEntitySet<City>(EntitySetOperations.None);
+                view = this.GetIECV(entitySet);
+                Assert.IsFalse(view.CanAddNew,
+                    "CanAddNew should be true when only neither Add nor Remove is supported.");
+                Assert.IsFalse(view.CanRemove,
+                    "CanRemove should be true when only neither Add nor Remove is supported.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling Remove on the View remove from the EntitySet.")]
+            public void ICVF_Remove()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                IEditableCollectionView view = this.GetIECV(entitySet);
+
+                entitySet.Add(CreateLocalCity("Renton"));
+                entitySet.Add(CreateLocalCity("Kent"));
+                entitySet.Add(CreateLocalCity("Auburn"));
+
+                City city = entitySet.First();
+                view.Remove(city);
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the first entity.");
+            }
+
+            [TestMethod]
+            [Description("Tests that calling RemoveAt on the View remove from the EntitySet.")]
+            public void ICVF_RemoveAt()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                IEditableCollectionView view = this.GetIECV(entitySet);
+
+                entitySet.Add(CreateLocalCity("Renton"));
+                entitySet.Add(CreateLocalCity("Kent"));
+                entitySet.Add(CreateLocalCity("Auburn"));
+
+                City city = entitySet.ElementAt(1);
+                view.RemoveAt(1);
+                Assert.IsFalse(entitySet.Contains(city),
+                    "EntitySet should no longer contain the entity at index 1.");
+            }
+
+            [TestMethod]
+            [Description("Tests that enumerating the View in its default order matches enumerating the EntitySet.")]
+            public void ICVF_Enumerate()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                ICollectionView view = this.GetICV(entitySet);
+
+                IEnumerator entitySetEnumerator = entitySet.GetEnumerator();
+                IEnumerator viewEnumerator = view.GetEnumerator();
+
+                while (entitySetEnumerator.MoveNext())
+                {
+                    Assert.IsTrue(viewEnumerator.MoveNext(),
+                        "The view enumerator should be able to move to the next item.");
+                    Assert.AreEqual(entitySetEnumerator.Current, viewEnumerator.Current,
+                        "Current enumerator items should be equal.");
+                }
+                Assert.IsFalse(viewEnumerator.MoveNext(),
+                    "The view enumerator should not have any more items to move to.");
+            }
+
+            [TestMethod]
+            [Description("Tests that adding to or removing from the EntitySet is reflected in the View.")]
+            public void ICVF_CollectionChanged()
+            {
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                ICollectionView view = this.GetICV(entitySet);
+
+                NotifyCollectionChangedEventArgs eventArgs = null;
+                NotifyCollectionChangedEventHandler handler = (sender, e) =>
+                {
+                    Assert.IsNull(eventArgs,
+                        "Only a single event should have occurred.");
+                    eventArgs = e;
+                };
+
+                view.CollectionChanged += handler;
+
+                // Add
+                eventArgs = null;
+                City city = CreateLocalCity("Maple Valley");
+                entitySet.Add(city);
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after adding an entity.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgs.Action,
+                    "Actions should be equal after adding an entity.");
+                Assert.IsNotNull(eventArgs.NewItems,
+                    "NewItems should not be null after adding an entity.");
+                Assert.AreEqual(1, eventArgs.NewItems.Count,
+                    "NewItems count should be 1 after adding an entity.");
+                Assert.AreEqual(city, eventArgs.NewItems[0],
+                    "The new items should be equal.");
+
+                Assert.IsTrue(view.Contains(city),
+                    "View should contain entity after Add.");
+
+                // Remove
+                eventArgs = null;
+                city = CreateLocalCity("Covington");
+                entitySet.Add(city);
+
+                Assert.IsTrue(view.Contains(city),
+                    "View should contain entity after second Add.");
+
+                eventArgs = null;
+                entitySet.Remove(city);
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after removing an entity.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgs.Action,
+                    "Actions should be equal after removing  an entity.");
+                Assert.IsNotNull(eventArgs.OldItems,
+                    "OldItems should not be null after removing  an entity.");
+                Assert.AreEqual(1, eventArgs.OldItems.Count,
+                    "OldItems count should be 1 after removing  an entity.");
+                Assert.AreEqual(city, eventArgs.OldItems[0],
+                    "The old items should be equal.");
+
+                Assert.IsFalse(view.Contains(city),
+                    "View should not contain entity after Remove.");
+
+                // Reset
+                eventArgs = null;
+                entitySet.Clear();
+
+                Assert.IsNotNull(eventArgs,
+                    "Event should not be null after clearing the EntitySet.");
+                Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action,
+                    "Actions should be equal after clearing the EntitySet.");
+
+                Assert.IsTrue(view.IsEmpty,
+                    "View should be empty after Clear.");
+
+                view.CollectionChanged -= handler;
+            }
+
+            [TestMethod]
+            [WorkItem(201155)]
+            [Description("Tests that the memory leak in ICVF Proxies is fixed.")]
+            public void ICVF_MemoryLeakTest()
+            {
+                // Use NoInline so JIT will not keep temp variable alive 
+                [MethodImpl(MethodImplOptions.NoInlining)]
+                WeakReference CreateCollectionViewWeakRef(EntitySet<City> enitySet)
+                    => new WeakReference(this.GetICV(enitySet));
+
+                EntitySet<City> entitySet = CreateEntitySet<City>();
+                WeakReference weakRef = CreateCollectionViewWeakRef(entitySet);
+                GC.Collect();
+                Assert.IsFalse(weakRef.IsAlive);
+            }
+
+            private ICollectionView GetICV(EntitySet entitySet)
+            {
+                return CollectionViewSource.GetDefaultView(entitySet);
+            }
+
+            private IEditableCollectionView GetIECV(EntitySet entitySet)
+            {
+                return (IEditableCollectionView)this.GetICV(entitySet);
+            }
+
+        }
+#endif
+    }
+}

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Windows.Data;
 using Cities;
 using DataTests.Northwind.LTS;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -327,7 +328,7 @@ namespace OpenRiaServices.Client.Test
 #if HAS_COLLECTIONVIEW
         private ICollectionView GetICV(EntitySet entitySet)
         {
-            return ((ICollectionViewFactory)entitySet).CreateView();
+            return CollectionViewSource.GetDefaultView(entitySet);
         }
 
         private IEditableCollectionView GetIECV(EntitySet entitySet)

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.cs
@@ -16,240 +16,8 @@ namespace OpenRiaServices.Client.Test
 {
 
     [TestClass]
-    public class EntitySetTests : UnitTestBase
+    public partial class EntitySetTests : UnitTestBase
     {
-#if HAS_COLLECTIONVIEW
-        [TestMethod]
-        [Description("Tests that create view returns an ICollectionView.")]
-        public void ICVF_CreateView()
-        {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            Assert.IsNotNull(this.GetICV(entitySet),
-                "View should not be null.");
-        }
-
-        [TestMethod]
-        [Description("Tests that calling AddNew and CommitNew on the View adds to the EntitySet.")]
-        public void ICVF_AddNew()
-        {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            IEditableCollectionView view = this.GetIECV(entitySet);
-
-            City city = (City)view.AddNew();
-            Assert.IsTrue(entitySet.Contains(city),
-                "EntitySet should contain the first entity after AddNew.");
-            city.Name = "Tukwila";
-            city.CountyName = "King";
-            city.StateName = "WA";
-            view.CommitNew();
-            Assert.IsTrue(entitySet.Contains(city),
-                "EntitySet should contain the first entity after CommitNew.");
-        }
-
-        [TestMethod]
-        [Description("Tests that calling AddNew on the View adds to the EntitySet and CancelNew removes.")]
-        public void ICVF_CancelNew()
-        {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            IEditableCollectionView view = this.GetIECV(entitySet);
-
-            City city = (City)view.AddNew();
-            Assert.IsTrue(entitySet.Contains(city),
-                "EntitySet should contain the second entity after AddNew.");
-
-            view.CancelNew();
-            Assert.IsFalse(entitySet.Contains(city),
-                "EntitySet should no longer contain the second entity after CancelNew.");
-        }
-
-        [TestMethod]
-        [Description("Tests that CanAddNew and CanRemove on the View are representative of the valid EntitySetOperations.")]
-        public void ICVF_CanAddOrRemove()
-        {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>(EntitySetOperations.Add | EntitySetOperations.Remove);
-            IEditableCollectionView view = this.GetIECV(entitySet);
-            Assert.IsTrue(view.CanAddNew,
-                "CanAddNew should be true when Add and Remove are supported.");
-            Assert.IsTrue(view.CanRemove,
-                "CanRemove should be true when Add and Remove are supported.");
-
-            // It is a known issue that we cannot differentiate with the current design. Instead
-            // we'll see CanAddNew and CanRemove both be true if either should be supported. This
-            // leaves the control in the hands of the developers.
-            entitySet = this.CreateEntitySet<City>(EntitySetOperations.Add);
-            view = this.GetIECV(entitySet);
-            Assert.IsTrue(view.CanAddNew,
-                "CanAddNew should be true when only Add is supported.");
-            Assert.IsTrue(view.CanRemove,
-                "CanRemove should be true when only Add is supported.");
-            //Assert.IsFalse(view.CanRemove,
-            //    "CanRemove should be false when only Add is supported.");
-
-            entitySet = this.CreateEntitySet<City>(EntitySetOperations.Remove);
-            view = this.GetIECV(entitySet);
-            Assert.IsTrue(view.CanAddNew,
-                "CanAddNew should be true when only Remove is supported.");
-            //Assert.IsFalse(view.CanAddNew,
-            //    "CanAddNew should be false when only Remove is supported.");
-            Assert.IsTrue(view.CanRemove,
-                "CanRemove should be true when only Remove is supported.");
-
-            entitySet = this.CreateEntitySet<City>(EntitySetOperations.None);
-            view = this.GetIECV(entitySet);
-            Assert.IsFalse(view.CanAddNew,
-                "CanAddNew should be true when only neither Add nor Remove is supported.");
-            Assert.IsFalse(view.CanRemove,
-                "CanRemove should be true when only neither Add nor Remove is supported.");
-        }
-
-        [TestMethod]
-        [Description("Tests that calling Remove on the View remove from the EntitySet.")]
-        public void ICVF_Remove()
-        {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            IEditableCollectionView view = this.GetIECV(entitySet);
-
-            entitySet.Add(this.CreateLocalCity("Renton"));
-            entitySet.Add(this.CreateLocalCity("Kent"));
-            entitySet.Add(this.CreateLocalCity("Auburn"));
-
-            City city = entitySet.First();
-            view.Remove(city);
-            Assert.IsFalse(entitySet.Contains(city),
-                "EntitySet should no longer contain the first entity.");
-        }
-
-        [TestMethod]
-        [Description("Tests that calling RemoveAt on the View remove from the EntitySet.")]
-        public void ICVF_RemoveAt()
-        {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            IEditableCollectionView view = this.GetIECV(entitySet);
-
-            entitySet.Add(this.CreateLocalCity("Renton"));
-            entitySet.Add(this.CreateLocalCity("Kent"));
-            entitySet.Add(this.CreateLocalCity("Auburn"));
-
-            City city = entitySet.ElementAt(1);
-            view.RemoveAt(1);
-            Assert.IsFalse(entitySet.Contains(city),
-                "EntitySet should no longer contain the entity at index 1.");
-        }
-
-        [TestMethod]
-        [Description("Tests that enumerating the View in its default order matches enumerating the EntitySet.")]
-        public void ICVF_Enumerate()
-        {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            ICollectionView view = this.GetICV(entitySet);
-
-            IEnumerator entitySetEnumerator = entitySet.GetEnumerator();
-            IEnumerator viewEnumerator = view.GetEnumerator();
-
-            while (entitySetEnumerator.MoveNext())
-            {
-                Assert.IsTrue(viewEnumerator.MoveNext(),
-                    "The view enumerator should be able to move to the next item.");
-                Assert.AreEqual(entitySetEnumerator.Current, viewEnumerator.Current,
-                    "Current enumerator items should be equal.");
-            }
-            Assert.IsFalse(viewEnumerator.MoveNext(),
-                "The view enumerator should not have any more items to move to.");
-        }
-
-        [TestMethod]
-        [Description("Tests that adding to or removing from the EntitySet is reflected in the View.")]
-        public void ICVF_CollectionChanged()
-        {
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            ICollectionView view = this.GetICV(entitySet);
-
-            NotifyCollectionChangedEventArgs eventArgs = null;
-            NotifyCollectionChangedEventHandler handler = (sender, e) =>
-            {
-                Assert.IsNull(eventArgs,
-                    "Only a single event should have occurred.");
-                eventArgs = e;
-            };
-
-            view.CollectionChanged += handler;
-
-            // Add
-            eventArgs = null;
-            City city = this.CreateLocalCity("Maple Valley");
-            entitySet.Add(city);
-
-            Assert.IsNotNull(eventArgs,
-                "Event should not be null after adding an entity.");
-            Assert.AreEqual(NotifyCollectionChangedAction.Add, eventArgs.Action,
-                "Actions should be equal after adding an entity.");
-            Assert.IsNotNull(eventArgs.NewItems,
-                "NewItems should not be null after adding an entity.");
-            Assert.AreEqual(1, eventArgs.NewItems.Count,
-                "NewItems count should be 1 after adding an entity.");
-            Assert.AreEqual(city, eventArgs.NewItems[0],
-                "The new items should be equal.");
-
-            Assert.IsTrue(view.Contains(city),
-                "View should contain entity after Add.");
-
-            // Remove
-            eventArgs = null;
-            city = this.CreateLocalCity("Covington");
-            entitySet.Add(city);
-
-            Assert.IsTrue(view.Contains(city),
-                "View should contain entity after second Add.");
-
-            eventArgs = null;
-            entitySet.Remove(city);
-
-            Assert.IsNotNull(eventArgs,
-                "Event should not be null after removing an entity.");
-            Assert.AreEqual(NotifyCollectionChangedAction.Remove, eventArgs.Action,
-                "Actions should be equal after removing  an entity.");
-            Assert.IsNotNull(eventArgs.OldItems,
-                "OldItems should not be null after removing  an entity.");
-            Assert.AreEqual(1, eventArgs.OldItems.Count,
-                "OldItems count should be 1 after removing  an entity.");
-            Assert.AreEqual(city, eventArgs.OldItems[0],
-                "The old items should be equal.");
-
-            Assert.IsFalse(view.Contains(city),
-                "View should not contain entity after Remove.");
-
-            // Reset
-            eventArgs = null;
-            entitySet.Clear();
-
-            Assert.IsNotNull(eventArgs,
-                "Event should not be null after clearing the EntitySet.");
-            Assert.AreEqual(NotifyCollectionChangedAction.Reset, eventArgs.Action,
-                "Actions should be equal after clearing the EntitySet.");
-
-            Assert.IsTrue(view.IsEmpty,
-                "View should be empty after Clear.");
-
-            view.CollectionChanged -= handler;
-        }
-
-        [TestMethod]
-        [WorkItem(201155)]
-        [Description("Tests that the memory leak in ICVF Proxies is fixed.")]
-        public void ICVF_MemoryLeakTest()
-        {
-            // Use NoInline so JIT will not keep temp variable alive 
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            WeakReference CreateCollectionViewWeakRef(EntitySet<City> enitySet)
-                => new WeakReference(this.GetICV(enitySet));
-
-            EntitySet<City> entitySet = this.CreateEntitySet<City>();
-            WeakReference weakRef = CreateCollectionViewWeakRef(entitySet);
-            GC.Collect();
-            Assert.IsFalse(weakRef.IsAlive);
-        }
-#endif
-
         [TestMethod]
         public void InferredAddThenAttach_EntityCollection()
         {
@@ -309,33 +77,21 @@ namespace OpenRiaServices.Client.Test
             Assert.AreEqual(1, productsCollectionChanged);
         }
 
-        private EntitySet<T> CreateEntitySet<T>() where T : Entity
+        private static EntitySet<T> CreateEntitySet<T>() where T : Entity
         {
-            return this.CreateEntitySet<T>(EntitySetOperations.All);
+            return CreateEntitySet<T>(EntitySetOperations.All);
         }
 
-        private EntitySet<T> CreateEntitySet<T>(EntitySetOperations operations) where T : Entity
+        private static EntitySet<T> CreateEntitySet<T>(EntitySetOperations operations) where T : Entity
         {
             DynamicEntityContainer container = new DynamicEntityContainer();
             return container.AddEntitySet<T>(operations);
         }
 
-        private City CreateLocalCity(string name)
+        private static City CreateLocalCity(string name)
         {
             return new City { Name = name, CountyName = "King", StateName = "WA" };
         }
-
-#if HAS_COLLECTIONVIEW
-        private ICollectionView GetICV(EntitySet entitySet)
-        {
-            return CollectionViewSource.GetDefaultView(entitySet);
-        }
-
-        private IEditableCollectionView GetIECV(EntitySet entitySet)
-        {
-            return (IEditableCollectionView)this.GetICV(entitySet);
-        }
-#endif
 
         /// <summary>
         /// An dynamic EntityContainer class that allows external configuration of

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/EntitySetTests.cs
@@ -1,16 +1,9 @@
-﻿extern alias SSmDsClient;
-using System;
-using System.Collections;
-using System.Collections.Specialized;
+﻿using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Windows.Data;
 using Cities;
 using DataTests.Northwind.LTS;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Silverlight.Testing;
-using Description = Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute;
 
 namespace OpenRiaServices.Client.Test
 {

--- a/src/OpenRiaServices.Client/Test/Client.Test/Data/SubmitOperationExceptionTests.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Data/SubmitOperationExceptionTests.cs
@@ -26,7 +26,7 @@ namespace OpenRiaServices.Client.Test
             Assert.IsNull(soe.StackTrace, "Default stack trace s/b null");
             Assert.AreEqual(0, soe.ErrorCode, "Error code s/b 0");
             Assert.AreEqual(OperationErrorStatus.Unauthorized, soe.Status, "ctor(msg, status) failed status");
-            Assert.IsFalse(soe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(soe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(changeSet, message, innerException)
             var ioe = new InvalidOperationException("ioe");
@@ -37,7 +37,7 @@ namespace OpenRiaServices.Client.Test
             Assert.IsNull(soe.StackTrace, "Default stack trace s/b null");
             Assert.AreEqual(0, soe.ErrorCode, "Error code s/b 0");
             Assert.AreEqual(OperationErrorStatus.ServerError, soe.Status, "Default status s/b ServerError");
-            Assert.IsFalse(soe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(soe.ValidationErrors.Count != 0, "default validationErrors should be empty");
 
             // ctor(changeSet, message, doe)
             var doe2 = new DomainOperationException("message", OperationErrorStatus.Unauthorized, 5, "stackTrace");
@@ -48,7 +48,7 @@ namespace OpenRiaServices.Client.Test
             Assert.AreEqual("stackTrace", soe.StackTrace, "StackTrace failed");
             Assert.AreEqual(5, soe.ErrorCode, "Error code failed");
             Assert.AreEqual(OperationErrorStatus.Unauthorized, soe.Status, "ctor(msg, status) failed status");
-            Assert.IsFalse(soe.ValidationErrors.Any(), "default validationErrors should be empty");
+            Assert.IsFalse(soe.ValidationErrors.Count != 0, "default validationErrors should be empty");
         }
     }
 }

--- a/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
+++ b/src/OpenRiaServices.Client/Test/Client.Test/OpenRiaServices.Client.Test.csproj
@@ -25,6 +25,10 @@
     <Reference Include="System.Web.Services" />    
     <Reference Include="WindowsBase" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net472'">
+    <PackageReference Include="Avalonia" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Test\Desktop\OpenRiaServices.Common.DomainServices.Test\Baselines\Default\Cities\Cities.g.cs" Link="Data\DomainClients\Cities.g.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/OpenRiaServices.Server/Framework/Authentication/AuthenticationCodeProcessor.cs
+++ b/src/OpenRiaServices.Server/Framework/Authentication/AuthenticationCodeProcessor.cs
@@ -374,7 +374,7 @@ namespace OpenRiaServices.Server.Authentication
             {
                 implementsLogout = false;
             }
-            if (doe.Parameters.Any())
+            if (doe.Parameters.Count != 0)
             {
                 implementsLogout = false;
             }
@@ -402,7 +402,7 @@ namespace OpenRiaServices.Server.Authentication
             {
                 implementsGetUser = false;
             }
-            if (doe.Parameters.Any())
+            if (doe.Parameters.Count != 0)
             {
                 implementsGetUser = false;
             }

--- a/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescription.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescription.cs
@@ -1619,7 +1619,7 @@ namespace OpenRiaServices.Server
         private void ValidateDefaultQuery(DomainOperationEntry method)
         {
             // Default queries may not declare any parameters
-            if (method.Parameters.Any())
+            if (method.Parameters.Count != 0)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.DomainServiceDescription_DefaultQuery_Cannot_Have_Params, method.Name));
             }

--- a/src/OpenRiaServices.Tools/Test/TestWap/Web.config
+++ b/src/OpenRiaServices.Tools/Test/TestWap/Web.config
@@ -40,7 +40,7 @@
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
 				<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
@@ -56,7 +56,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0"/>
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/DomainContextTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/DomainContextTests.cs
@@ -314,7 +314,7 @@ namespace OpenRiaServices.Client.Test
 
                 this.SubmitOperation = domainContext.SubmitChanges();
 
-                Assert.IsTrue(!newCity.ValidationErrors.Any(), "There should not be any errors after valid submission");
+                Assert.IsTrue(newCity.ValidationErrors.Count == 0, "There should not be any errors after valid submission");
                 Assert.IsTrue(actualErrors.OrderBy(s => s).SequenceEqual(new string[] { null, "MakeBelieveProperty" }.OrderBy(s => s)), "We should have received notifications that the entity-level and property-level erros were cleared");
             });
 
@@ -348,7 +348,7 @@ namespace OpenRiaServices.Client.Test
             await domainContext.SubmitChangesAsync();
 
             Assert.IsFalse(newCity.HasValidationErrors, "Entity should not have any validation errors");
-            Assert.IsFalse(newCity.ValidationErrors.Any());
+            Assert.IsFalse(newCity.ValidationErrors.Count != 0);
         }
 
         private void BeginSubmitCityData(Action<SubmitOperation> callback)

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/ErrorPropagationTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/ErrorPropagationTests.cs
@@ -253,7 +253,7 @@ namespace OpenRiaServices.Client.Test
 
                 // Call RejectChanges and verify ValidationErrors collection is cleared
                 citiesProvider.RejectChanges();
-                Assert.IsFalse(zip.ValidationErrors.Any());
+                Assert.IsFalse(zip.ValidationErrors.Count != 0);
 
                 // Invoke domain method that does not throw on same entity
                 zip.ReassignZipCode(1, true);
@@ -267,7 +267,7 @@ namespace OpenRiaServices.Client.Test
             {
                 Zip zip = citiesProvider.Zips.First();
                 Assert.IsNull(so.Error);
-                Assert.IsFalse(zip.ValidationErrors.Any());
+                Assert.IsFalse(zip.ValidationErrors.Count != 0);
                 Assert.AreEqual(refZip + 1, zip.Code);
             });
 

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/InvokeOperationTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/InvokeOperationTests.cs
@@ -587,7 +587,7 @@ namespace OpenRiaServices.Client.Test
             {
                 // verify invocation completed succesfully
                 Assert.IsNull(invoke.Error);
-                Assert.IsFalse(invoke.ValidationErrors.Any());
+                Assert.IsFalse(invoke.ValidationErrors.Count != 0);
 
                 Assert.IsTrue(invoke.Value);
 
@@ -631,7 +631,7 @@ namespace OpenRiaServices.Client.Test
             {
                 // verify invocation completed succesfully
                 Assert.IsNull(invoke.Error);
-                Assert.IsFalse(invoke.ValidationErrors.Any());
+                Assert.IsFalse(invoke.ValidationErrors.Count != 0);
 
                 Assert.IsTrue(invoke.Value);
             });
@@ -674,7 +674,7 @@ namespace OpenRiaServices.Client.Test
             {
                 // verify invocation completed succesfully
                 Assert.IsNull(invoke.Error, "InvokeEventArgs.Error should be null");
-                Assert.IsFalse(invoke.ValidationErrors.Any());
+                Assert.IsFalse(invoke.ValidationErrors.Count != 0);
 
                 Assert.IsTrue(invoke.Value);
             });
@@ -917,7 +917,7 @@ namespace OpenRiaServices.Client.Test
             {
                 // verify invocation completed succesfully
                 Assert.IsNull(invoke.Error, string.Format("InvokeEventArgs.Error should be null.\r\nMessage: {0}\r\nStack Trace:\r\n{1}", invoke.Error != null ? invoke.Error.Message : string.Empty, invoke.Error != null ? invoke.Error.StackTrace : string.Empty));
-                Assert.IsFalse(invoke.ValidationErrors.Any());
+                Assert.IsFalse(invoke.ValidationErrors.Count != 0);
 
                 AssertValuesAreEqual(inputValue, invoke.Value);
 

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/ServerSideAsyncTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/ServerSideAsyncTests.cs
@@ -131,7 +131,7 @@ namespace OpenRiaServices.Client.Test
                 Assert.IsNull(asyncLoad.Exception, "Async load failed");
                 CollectionAssert.AreEquivalent(normalLoad.Entities.ToArray(), asyncLoad.Result);
 
-                Assert.IsTrue(normalLoad.Entities.Any(), "No entities loaded");
+                Assert.IsTrue(normalLoad.Entities.Count != 0, "No entities loaded");
                 Assert.AreEqual(normalLoad.TotalEntityCount, asyncLoad.Result.TotalEntityCount, "TotalEntityCount different");
             });
             this.EnqueueTestComplete();

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/UpdateTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/UpdateTests.cs
@@ -3092,6 +3092,7 @@ namespace OpenRiaServices.Client.Test
         [TestMethod]
         [Asynchronous]
         [Microsoft.VisualStudio.TestTools.UnitTesting.Description("Three entities in conflict and all resolve methods return true using a combination of resolve policies")]
+        [Retry(3)]
         public virtual void ResolveTest_MultipleInstances_MixedResolveMethods()
         {
             Northwind nw1 = new Northwind(this.ServiceUri);
@@ -3230,6 +3231,7 @@ namespace OpenRiaServices.Client.Test
         [TestMethod]
         [Asynchronous]
         [Microsoft.VisualStudio.TestTools.UnitTesting.Description("Two entities in conflict, one return true and the other returns false")]
+        [Retry(3)]
         public virtual void ResolveTest_MultipleInstances_ReturnTrueFalse()
         {
             Northwind nw1 = new Northwind(this.ServiceUri);
@@ -3339,6 +3341,7 @@ namespace OpenRiaServices.Client.Test
         [TestMethod]
         [Asynchronous]
         [Microsoft.VisualStudio.TestTools.UnitTesting.Description("Two entities in conflict, both return true")]
+        [Retry(3)]
         public virtual void ResolveTest_MultipleInstances_ReturnTrueTrue()
         {
             Northwind nw1 = new Northwind(this.ServiceUri);
@@ -3459,6 +3462,7 @@ namespace OpenRiaServices.Client.Test
         [TestMethod]
         [Asynchronous]
         [Microsoft.VisualStudio.TestTools.UnitTesting.Description("Two entities in conflict, one throws exception and the other resolves successfully")]
+        [Retry(3)]
         public virtual void ResolveTest_MultipleInstances_FirstThrowsSecondSucceeds()
         {
             Northwind nw1 = new Northwind(this.ServiceUri);
@@ -3533,6 +3537,7 @@ namespace OpenRiaServices.Client.Test
         [TestMethod]
         [Asynchronous]
         [Microsoft.VisualStudio.TestTools.UnitTesting.Description("Two entities in conflict, resolution succeeds for and the other throws an exception")]
+        [Retry(3)]
         public virtual void ResolveTest_MultipleInstances_FirstSucceedsSecondThrows()
         {
             Northwind nw1 = new Northwind(this.ServiceUri);

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/UpdateTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/UpdateTests.cs
@@ -2378,6 +2378,7 @@ namespace OpenRiaServices.Client.Test
         [TestMethod]
         [Asynchronous]
         [Microsoft.VisualStudio.TestTools.UnitTesting.Description("Resolve method returns false but conflicts are resolved")]
+        [Retry(3)] // Known flaky test, retry intil it is rewritten
         public virtual void ResolveTest_ReturnFalseWithResolve()
         {
             Northwind nw1 = new Northwind(this.ServiceUri);


### PR DESCRIPTION
* Make EntityCollection IList implementation mirror WPF collection view so that added and later cancelled items are removed 
* Add collectionview related tests for avalonia
* Remove ListCollectionViewProxy and replace with custom ListCollectionView
* Fix CA1860: Prefer comparing 'Count' to 0 rather than using 'Any()'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized collection/validation emptiness checks and narrowed public collection interfaces across the framework.

* **Bug Fixes**
  * Replaced collection-view plumbing with a non-leaking view implementation to prevent strong-event memory leaks.

* **Tests**
  * Added comprehensive collection-view tests for WPF and Avalonia, updated many assertions/helpers, and added retries for flaky update tests.

* **Chores**
  * Test project updated with Avalonia test dependencies and adjusted assembly binding redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->