### PR TITLE
Fix warning by using InvariantCulture in string.Format (and SYSLIB0051)

### DIFF
--- a/src/OpenRiaServices.Client/Framework/DomainException.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainException.cs
@@ -87,18 +87,19 @@ namespace OpenRiaServices.Client
             this.ErrorCode = errorCode;
         }
 
-#if !SILVERLIGHT
         /// <summary>
         /// Constructor that takes serialization info
         /// </summary>
         /// <param name="info">The serialization info</param>
         /// <param name="context">The streaming context used for serialization</param>
+#if NET8_0_OR_GREATER
+        [Obsolete(DiagnosticId = "SYSLIB0051")] // https://learn.microsoft.com/sv-se/dotnet/fundamentals/syslib-diagnostics/syslib0051
+#endif
         private DomainException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
             this.ErrorCode = info.GetInt32("ErrorCode");
         }
-#endif //!SILVERLIGHT
 
 #if !SERVERFX
         /// <summary>

--- a/src/OpenRiaServices.Server/Framework/Authentication/AuthenticationCodeProcessor.cs
+++ b/src/OpenRiaServices.Server/Framework/Authentication/AuthenticationCodeProcessor.cs
@@ -316,7 +316,7 @@ namespace OpenRiaServices.Server.Authentication
             if (!implementsLogin || !implementsLogout || !implementsGetUser || !implementsUpdateUser)
             {
                 throw new InvalidOperationException(string.Format(
-                    CultureInfo.InstalledUICulture,
+                    CultureInfo.InvariantCulture,
                     Resources.ApplicationServices_MustBeIAuthImpl,
                     authenticationServiceDescription.DomainServiceType.Name));
             }
@@ -474,14 +474,14 @@ namespace OpenRiaServices.Server.Authentication
                             if (!SerializationUtility.IsSerializableDataMember(property))
                             {
                                 throw new InvalidOperationException(string.Format(
-                                    CultureInfo.InstalledUICulture,
+                                    CultureInfo.InvariantCulture,
                                     Resources.ApplicationServices_MustBeSerializable,
                                     property.Name, user.Name));
                             }
                             if (property.Attributes[typeof(KeyAttribute)] == null)
                             {
                                 throw new InvalidOperationException(string.Format(
-                                    CultureInfo.InstalledUICulture,
+                                    CultureInfo.InvariantCulture,
                                     Resources.ApplicationServices_NameMustBeAKey,
                                     user.Name));
                             }
@@ -503,7 +503,7 @@ namespace OpenRiaServices.Server.Authentication
                             if (!SerializationUtility.IsSerializableDataMember(property))
                             {
                                 throw new InvalidOperationException(string.Format(
-                                    CultureInfo.InstalledUICulture,
+                                    CultureInfo.InvariantCulture,
                                     Resources.ApplicationServices_MustBeSerializable,
                                     property.Name, user.Name));
                             }
@@ -523,7 +523,7 @@ namespace OpenRiaServices.Server.Authentication
             if (!implementsName || !implementsRoles)
             {
                 throw new InvalidOperationException(string.Format(
-                    CultureInfo.InstalledUICulture,
+                    CultureInfo.InvariantCulture,
                     Resources.ApplicationServices_MustBeIUser,
                     user.Name));
             }

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -694,7 +694,7 @@ namespace OpenRiaServices.Server
                                         Resource.DomainService_MultipleEntityActionsNotAllowedFor,
                                         operation.Entity.GetType().Name,
                                         action.Key));
-                    }
+                            }
                         }
 
                         if (customMethodOperation.RequiresValidation)

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -690,10 +690,11 @@ namespace OpenRiaServices.Server
                             else if (((EntityActionAttribute)customMethodOperation.OperationAttribute).AllowMultipleInvocations == false)
                             {
                                 throw new InvalidOperationException(
-                                    string.Format(Resource.DomainService_MultipleEntityActionsNotAllowedFor,
-                                                operation.Entity.GetType().Name,
-                                                action.Key));
-                            }
+                                    string.Format(CultureInfo.InvariantCulture,
+                                        Resource.DomainService_MultipleEntityActionsNotAllowedFor,
+                                        operation.Entity.GetType().Name,
+                                        action.Key));
+                    }
                         }
 
                         if (customMethodOperation.RequiresValidation)

--- a/src/OpenRiaServices.Server/Framework/Data/DynamicMethodUtility.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DynamicMethodUtility.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading;
@@ -210,7 +211,7 @@ namespace OpenRiaServices.Server
                     var parameter = parameters[i];
 
                     if (parameter.ParameterType.IsByRef || parameter.ParameterType.IsPointer)
-                        throw new InvalidOperationException(string.Format(Resource.InvalidDomainOperationEntry_ParamMustBeByVal, method.Name, parameter.Name));
+                        throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, Resource.InvalidDomainOperationEntry_ParamMustBeByVal, method.Name, parameter.Name));
 
                     if (parameter.ParameterType == typeof(CancellationToken))
                     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message consistency across authentication and data validation operations through standardized culture-invariant formatting.

* **Chores**
  * Updated internal error handling for enhanced code quality and standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->