### PR TITLE
Use ArgumentNullException.ThrowIfNull where possible

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,8 @@ This release gives some ❤️ to AvaloniaUI and other frameworks which use ILis
 
 ### Other
 
+* Changed parameter validation to use `ArgumentNullException.ThrowIfNull` for better performance and more consistent exception messages
+  * **IMPORTANT**: This is a breaking change if you expect `ArgumentNullException` thrown by OpenRiaServices for empty strings
 * Fixed build pipeline problems after updating to VS 2026
 * Improved polyfills to allow modernization of the codebase
 * Analyzer fixes

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -112,8 +112,6 @@ tab_width = 4
 dotnet_diagnostic.VSTHRD010.severity = suggestion
 
 ## These suggestions does not make sense as long as we multitarget with old frameworks
-# CA1510: Use 'ArgumentNullException.ThrowIfNull' instead of explicitly throwing a new exception instance
-dotnet_diagnostic.CA1510.severity = none
 # CA1863: Cache a 'CompositeFormat' for repeated use in this formatting operation
 dotnet_diagnostic.CA1863.severity = none
 dotnet_diagnostic.CA1826.severity = warning

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/Http/DataContractHttpDomainClient.cs
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/Http/DataContractHttpDomainClient.cs
@@ -46,8 +46,7 @@ namespace OpenRiaServices.Client.DomainClients.Http
 
         private protected DataContractHttpDomainClient(HttpClient httpClient, Type serviceInterface)
         {
-            if (serviceInterface is null)
-                throw new ArgumentNullException(nameof(serviceInterface));
+            ArgumentNullException.ThrowIfNull(serviceInterface);
 
             HttpClient = httpClient;
             lock (s_globalCacheHelpers)

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/HttpDomainClientFactory.cs
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/HttpDomainClientFactory.cs
@@ -31,8 +31,7 @@ namespace OpenRiaServices.Client.DomainClients
         private protected HttpDomainClientFactory(Uri serverBaseUri, Func<HttpClient> httpClientFactory)
         {
             base.ServerBaseUri = serverBaseUri;
-            if (httpClientFactory is null)
-                throw new ArgumentNullException(nameof(httpClientFactory));
+            ArgumentNullException.ThrowIfNull(httpClientFactory);
 
             this._httpClientFactory = (Uri uri) =>
             {

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <RootNamespace>OpenRiaServices.Client.DomainClients</RootNamespace>
     <NeutralLanguage>en</NeutralLanguage>
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\OpenRiaServices.Client\Framework\OpenRiaServices.Client.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Update="Http\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/SystemServiceModel.Dispatcher/QueryStringConverter.cs
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/SystemServiceModel.Dispatcher/QueryStringConverter.cs
@@ -70,10 +70,7 @@ namespace System.ServiceModel.Dispatcher
 
         public virtual string ConvertValueToString(object parameter, Type parameterType)
         {
-            if (parameterType == null)
-            {
-                throw new ArgumentNullException(nameof(parameterType));
-            }
+            ArgumentNullException.ThrowIfNull(parameterType);
             if (parameterType.IsValueType && parameter == null)
             {
                 throw new ArgumentNullException(nameof(parameter));

--- a/src/OpenRiaServices.Client.Web/Framework/Data/ServiceQueryPart.cs
+++ b/src/OpenRiaServices.Client.Web/Framework/Data/ServiceQueryPart.cs
@@ -35,14 +35,8 @@ namespace OpenRiaServices.Client
         /// <param name="expression">The query expression</param>
         public ServiceQueryPart(string queryOperator, string expression)
         {
-            if (queryOperator == null)
-            {
-                throw new ArgumentNullException(nameof(queryOperator));
-            }
-            if (expression == null)
-            {
-                throw new ArgumentNullException(nameof(expression));
-            }
+            ArgumentNullException.ThrowIfNull(queryOperator);
+            ArgumentNullException.ThrowIfNull(expression);
 
             if (queryOperator != "where" && queryOperator != "orderby" &&
                queryOperator != "skip" && queryOperator != "take")

--- a/src/OpenRiaServices.Client.Web/Framework/Data/WebDomainClient.cs
+++ b/src/OpenRiaServices.Client.Web/Framework/Data/WebDomainClient.cs
@@ -77,13 +77,9 @@ namespace OpenRiaServices.Client
         /// </exception>
         public WebDomainClient(Uri serviceUri, bool usesHttps, WcfDomainClientFactory domainClientFactory)
         {
-            if (serviceUri == null)
-            {
-                throw new ArgumentNullException(nameof(serviceUri));
-            }
+            ArgumentNullException.ThrowIfNull(serviceUri);
 
-            if (domainClientFactory == null)
-                throw new ArgumentNullException(nameof(domainClientFactory));
+            ArgumentNullException.ThrowIfNull(domainClientFactory);
 
 #if !SILVERLIGHT
             if (!serviceUri.IsAbsoluteUri)

--- a/src/OpenRiaServices.Client.Web/Framework/OpenRiaServices.Client.Web.csproj
+++ b/src/OpenRiaServices.Client.Web/Framework/OpenRiaServices.Client.Web.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\BinaryTypeUtility.cs">
       <Link>Utilities\BinaryTypeUtility.cs</Link>
     </Compile>

--- a/src/OpenRiaServices.Client.Web/Framework/Web/WcfDomainClientFactory.cs
+++ b/src/OpenRiaServices.Client.Web/Framework/Web/WcfDomainClientFactory.cs
@@ -40,8 +40,7 @@ namespace OpenRiaServices.Client.Web
         /// E.g  "binary", "soap"</param>
         protected WcfDomainClientFactory(string endpointSuffix)
         {
-            if (endpointSuffix == null)
-                throw new ArgumentNullException(nameof(endpointSuffix));
+            ArgumentNullException.ThrowIfNull(endpointSuffix);
 
             _createInstanceMethod = typeof(WcfDomainClientFactory).GetMethod(nameof(CreateInstance), BindingFlags.NonPublic | BindingFlags.Instance);
 

--- a/src/OpenRiaServices.Client/Framework/Authentication/AuthenticationEventArgs.cs
+++ b/src/OpenRiaServices.Client/Framework/Authentication/AuthenticationEventArgs.cs
@@ -16,10 +16,7 @@ namespace OpenRiaServices.Client.Authentication
         /// </exception>
         internal AuthenticationEventArgs(IPrincipal user)
         {
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
+            ArgumentNullException.ThrowIfNull(user);
             this.User = user;
         }
 

--- a/src/OpenRiaServices.Client/Framework/Authentication/AuthenticationService.cs
+++ b/src/OpenRiaServices.Client/Framework/Authentication/AuthenticationService.cs
@@ -457,10 +457,7 @@ namespace OpenRiaServices.Client.Authentication
         /// </exception>
         protected void RaisePropertyChanged(string propertyName)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
             this._propertyChangedEventHandler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }

--- a/src/OpenRiaServices.Client/Framework/Authentication/WebAuthenticationService.cs
+++ b/src/OpenRiaServices.Client/Framework/Authentication/WebAuthenticationService.cs
@@ -150,10 +150,7 @@ namespace OpenRiaServices.Client.Authentication
         {
             this.Initialize();
 
-            if (parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
+            ArgumentNullException.ThrowIfNull(parameters);
 
             EntityQuery query;
 

--- a/src/OpenRiaServices.Client/Framework/Authentication/WebContextBase.cs
+++ b/src/OpenRiaServices.Client/Framework/Authentication/WebContextBase.cs
@@ -101,10 +101,7 @@ namespace OpenRiaServices.Client.Authentication
             }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value);
                 if (this._started)
                 {
                     throw new InvalidOperationException(Resources.WebContext_CannotModifyAuthentication);

--- a/src/OpenRiaServices.Client/Framework/Authentication/WebContextBase.cs
+++ b/src/OpenRiaServices.Client/Framework/Authentication/WebContextBase.cs
@@ -127,10 +127,7 @@ namespace OpenRiaServices.Client.Authentication
         /// </exception>
         protected void RaisePropertyChanged(string propertyName)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
             this._propertyChangedEventHandler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 

--- a/src/OpenRiaServices.Client/Framework/ComplexObject.INotifyDataErrorInfo.cs
+++ b/src/OpenRiaServices.Client/Framework/ComplexObject.INotifyDataErrorInfo.cs
@@ -52,7 +52,7 @@ namespace OpenRiaServices.Client
                 // If the property name is null or empty, then we want to include errors
                 // where the member names array is empty, or where the member names array
                 // contains a null or empty string.
-                results = this.ValidationResultCollection.Where(e => !e.MemberNames.Any() || e.MemberNames.Contains(propertyName));
+                results = this.ValidationResultCollection.Where(e => !e.MemberNames.Any() || e.MemberNames.Any(string.IsNullOrEmpty));
             }
             else
             {

--- a/src/OpenRiaServices.Client/Framework/ComplexObject.cs
+++ b/src/OpenRiaServices.Client/Framework/ComplexObject.cs
@@ -168,10 +168,7 @@ namespace OpenRiaServices.Client
         internal void Attach(object parent, string propertyName, Action onDataMemberChanging, Action onDataMemberChanged, Action<string, IEnumerable<ValidationResult>> onMemberValidationChanged)
         {
             ArgumentNullException.ThrowIfNull(parent);
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
             ArgumentNullException.ThrowIfNull(onDataMemberChanging);
             ArgumentNullException.ThrowIfNull(onDataMemberChanged);
             ArgumentNullException.ThrowIfNull(onMemberValidationChanged);
@@ -215,10 +212,7 @@ namespace OpenRiaServices.Client
         /// <param name="propertyName">The name of the property that has changed</param>
         protected void RaisePropertyChanged(string propertyName)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
             OnPropertyChanged(propertyName);
         }
@@ -240,10 +234,7 @@ namespace OpenRiaServices.Client
         /// <param name="propertyName">The name of the property that has changed</param>
         protected void RaiseDataMemberChanged(string propertyName)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
             // Note, RaiseDataMemberChanged is called on every property update. We need to avoid as
             // much overhead as possible.
@@ -309,10 +300,7 @@ namespace OpenRiaServices.Client
         /// <param name="propertyName">The name of the property that is changing</param>
         protected void RaiseDataMemberChanging(string propertyName)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
             this.OnDataMemberChanging();
         }
@@ -393,10 +381,7 @@ namespace OpenRiaServices.Client
         /// configured to prevent editing.</exception>
         protected void ValidateProperty(string propertyName, object value)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
             // if this instance is currently being deserialized, or if it is hosted by an
             // entity that is being deserialized or is having state applied to it, skip

--- a/src/OpenRiaServices.Client/Framework/ComplexObject.cs
+++ b/src/OpenRiaServices.Client/Framework/ComplexObject.cs
@@ -167,26 +167,14 @@ namespace OpenRiaServices.Client
         /// <param name="onMemberValidationChanged">The callback to call when validation has changed for a property.</param>
         internal void Attach(object parent, string propertyName, Action onDataMemberChanging, Action onDataMemberChanged, Action<string, IEnumerable<ValidationResult>> onMemberValidationChanged)
         {
-            if (parent == null)
-            {
-                throw new ArgumentNullException(nameof(parent));
-            }
+            ArgumentNullException.ThrowIfNull(parent);
             if (string.IsNullOrEmpty(propertyName))
             {
                 throw new ArgumentNullException(nameof(propertyName));
             }
-            if (onDataMemberChanging == null)
-            {
-                throw new ArgumentNullException(nameof(onDataMemberChanging));
-            }
-            if (onDataMemberChanged == null)
-            {
-                throw new ArgumentNullException(nameof(onDataMemberChanged));
-            }
-            if (onMemberValidationChanged == null)
-            {
-                throw new ArgumentNullException(nameof(onMemberValidationChanged));
-            }
+            ArgumentNullException.ThrowIfNull(onDataMemberChanging);
+            ArgumentNullException.ThrowIfNull(onDataMemberChanged);
+            ArgumentNullException.ThrowIfNull(onMemberValidationChanged);
             Debug.Assert(typeof(Entity).IsAssignableFrom(parent.GetType()) || typeof(ComplexObject).IsAssignableFrom(parent.GetType()), "Parent must be an Entity or ComplexObject.");
 
             this.CheckForCycles(parent);
@@ -480,10 +468,7 @@ namespace OpenRiaServices.Client
         /// <exception cref="ArgumentNullException"> is thrown if <paramref name="validationContext"/> is <c>null</c>.</exception>
         protected virtual void ValidateProperty(ValidationContext validationContext, object value)
         {
-            if (validationContext == null)
-            {
-                throw new ArgumentNullException(nameof(validationContext));
-            }
+            ArgumentNullException.ThrowIfNull(validationContext);
 
             List<ValidationResult> validationResults = new List<ValidationResult>();
             Validator.TryValidateProperty(value, validationContext, validationResults);

--- a/src/OpenRiaServices.Client/Framework/DomainClient.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainClient.cs
@@ -78,10 +78,7 @@ namespace OpenRiaServices.Client
         /// <returns>The results returned by the submit request.</returns>
         public Task<SubmitCompletedResult> SubmitAsync(EntityChangeSet changeSet, CancellationToken cancellationToken)
         {
-            if (changeSet == null)
-            {
-                throw new ArgumentNullException(nameof(changeSet));
-            }
+            ArgumentNullException.ThrowIfNull(changeSet);
 
             if (changeSet.IsEmpty)
             {

--- a/src/OpenRiaServices.Client/Framework/DomainClientFactory.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainClientFactory.cs
@@ -40,8 +40,7 @@ namespace OpenRiaServices.Client
             }
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
                 if (!value.IsAbsoluteUri)
                     throw new ArgumentException("ServiceBaseUri must be absolute", nameof(value));
 
@@ -63,10 +62,8 @@ namespace OpenRiaServices.Client
         /// <returns>A <see cref="DomainClient"/> to use when communicating with the service</returns>
         public DomainClient CreateDomainClient([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type serviceContract, Uri serviceUri, bool requiresSecureEndpoint)
         {
-            if (serviceContract == null)
-                throw new ArgumentNullException(nameof(serviceContract));
-            if (serviceUri == null)
-                throw new ArgumentNullException(nameof(serviceUri));
+            ArgumentNullException.ThrowIfNull(serviceContract);
+            ArgumentNullException.ThrowIfNull(serviceUri);
             if (!serviceContract.IsInterface)
                 throw new ArgumentException(Resource.DomainClientFactory_ServiceContractMustBeAnInterface, nameof(serviceContract));
 

--- a/src/OpenRiaServices.Client/Framework/DomainContext.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainContext.cs
@@ -904,10 +904,7 @@ namespace OpenRiaServices.Client
         /// <param name="propertyName">The property to raise the event for</param>
         protected void RaisePropertyChanged(string propertyName)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
             this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
@@ -938,10 +935,7 @@ namespace OpenRiaServices.Client
         /// <param name="parameters">The parameters to the method.</param>
         protected void ValidateMethod(string methodName, IDictionary<string, object?>? parameters)
         {
-            if (string.IsNullOrEmpty(methodName))
-            {
-                throw new ArgumentNullException(nameof(methodName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(methodName);
 
             object?[] paramValues = parameters != null ? parameters.Values.ToArray() : Array.Empty<object>();
             if (!this.MethodRequiresValidation(methodName, paramValues))

--- a/src/OpenRiaServices.Client/Framework/DomainContext.cs
+++ b/src/OpenRiaServices.Client/Framework/DomainContext.cs
@@ -50,10 +50,7 @@ namespace OpenRiaServices.Client
         /// <param name="domainClient">The <see cref="DomainClient"/> instance this <see cref="DomainContext"/> should use</param>
         protected DomainContext(DomainClient domainClient)
         {
-            if (domainClient == null)
-            {
-                throw new ArgumentNullException(nameof(domainClient));
-            }
+            ArgumentNullException.ThrowIfNull(domainClient);
 
             this._domainClient = domainClient;
         }
@@ -91,8 +88,7 @@ namespace OpenRiaServices.Client
             }
             set
             {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                ArgumentNullException.ThrowIfNull(value);
                 s_domainClientFactory = value;
             }
         }
@@ -221,15 +217,9 @@ namespace OpenRiaServices.Client
         /// <param name="domainContext">A <see cref="DomainContext"/> to register as an external reference.</param>
         public void AddReference(Type entityType, DomainContext domainContext)
         {
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
 
-            if (domainContext == null)
-            {
-                throw new ArgumentNullException(nameof(domainContext));
-            }
+            ArgumentNullException.ThrowIfNull(domainContext);
 
             EntitySet entitySet = domainContext.EntityContainer.GetEntitySet(entityType);
             this.EntityContainer.AddReference(entitySet);
@@ -562,10 +552,7 @@ namespace OpenRiaServices.Client
         public virtual Task<LoadResult<TEntity>> LoadAsync<TEntity>(EntityQuery<TEntity> query, LoadBehavior loadBehavior, CancellationToken cancellationToken)
                 where TEntity : Entity
         {
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
+            ArgumentNullException.ThrowIfNull(query);
 
             // verify the specified query was created by this DomainContext
             if (this.DomainClient != query.DomainClient)
@@ -874,10 +861,7 @@ namespace OpenRiaServices.Client
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resource.Parameter_NullOrEmpty, "operationName"));
             }
 
-            if (returnType is null)
-            {
-                throw new ArgumentNullException(nameof(returnType));
-            }
+            ArgumentNullException.ThrowIfNull(returnType);
 
             InvokeArgs invokeArgs = new InvokeArgs(operationName, returnType, parameters, hasSideEffects);
             return this.DomainClient.InvokeAsync(invokeArgs, cancellationToken)

--- a/src/OpenRiaServices.Client/Framework/Entity.cs
+++ b/src/OpenRiaServices.Client/Framework/Entity.cs
@@ -1311,10 +1311,7 @@ namespace OpenRiaServices.Client
         /// <exception cref="ArgumentNullException"> is thrown if <paramref name="validationContext"/> is <c>null</c>.</exception>
         protected virtual void ValidateProperty(ValidationContext validationContext, object? value)
         {
-            if (validationContext == null)
-            {
-                throw new ArgumentNullException(nameof(validationContext));
-            }
+            ArgumentNullException.ThrowIfNull(validationContext);
 
             List<ValidationResult> validationResults = new List<ValidationResult>();
             Validator.TryValidateProperty(value, validationContext, validationResults);
@@ -1532,8 +1529,7 @@ namespace OpenRiaServices.Client
         /// <exception cref="System.ArgumentException">If the action does not belong to this Entity's<see cref="EntityActions" /></exception>
         private void UndoAction(EntityAction action, bool throwIfSubmitting)
         {
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
+            ArgumentNullException.ThrowIfNull(action);
 
             // verify that the action can currently be invoked
             if (throwIfSubmitting && this.IsSubmitting)

--- a/src/OpenRiaServices.Client/Framework/Entity.cs
+++ b/src/OpenRiaServices.Client/Framework/Entity.cs
@@ -1088,10 +1088,7 @@ namespace OpenRiaServices.Client
         /// <param name="propertyName">The name of the property that has changed</param>
         protected void RaiseDataMemberChanged(string propertyName)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
             this.OnDataMemberChanged();
 
@@ -1183,10 +1180,7 @@ namespace OpenRiaServices.Client
         /// <param name="propertyName">The name of the property that is changing</param>
         protected void RaiseDataMemberChanging(string propertyName)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
             this.OnDataMemberChanging();
 
@@ -1238,10 +1232,7 @@ namespace OpenRiaServices.Client
         /// configured to prevent editing.</exception>
         protected void ValidateProperty(string propertyName, object? value)
         {
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(propertyName);
 
             if (this.IsDeserializing || this.IsApplyingState)
             {

--- a/src/OpenRiaServices.Client/Framework/EntityChangeSet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityChangeSet.cs
@@ -21,18 +21,9 @@ namespace OpenRiaServices.Client
             ReadOnlyCollection<Entity> modifiedEntities,
             ReadOnlyCollection<Entity> removedEntities)
         {
-            if (addedEntities == null)
-            {
-                throw new ArgumentNullException(nameof(addedEntities));
-            }
-            if (modifiedEntities == null)
-            {
-                throw new ArgumentNullException(nameof(modifiedEntities));
-            }
-            if (removedEntities == null)
-            {
-                throw new ArgumentNullException(nameof(removedEntities));
-            }
+            ArgumentNullException.ThrowIfNull(addedEntities);
+            ArgumentNullException.ThrowIfNull(modifiedEntities);
+            ArgumentNullException.ThrowIfNull(removedEntities);
 
             this._addedEntities = addedEntities;
             this._removedEntities = removedEntities;

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -58,18 +58,12 @@ namespace OpenRiaServices.Client
         /// which are members of this collection.</param>
         public EntityCollection(Entity parent, string memberName, Func<TEntity, bool> entityPredicate)
         {
-            if (parent == null)
-            {
-                throw new ArgumentNullException(nameof(parent));
-            }
+            ArgumentNullException.ThrowIfNull(parent);
             if (string.IsNullOrEmpty(memberName))
             {
                 throw new ArgumentNullException(nameof(memberName));
             }
-            if (entityPredicate == null)
-            {
-                throw new ArgumentNullException(nameof(entityPredicate));
-            }
+            ArgumentNullException.ThrowIfNull(entityPredicate);
 
             this._parent = parent;
             this._entityPredicate = entityPredicate;
@@ -105,14 +99,8 @@ namespace OpenRiaServices.Client
         public EntityCollection(Entity parent, string memberName, Func<TEntity, bool> entityPredicate, Action<TEntity> attachAction, Action<TEntity> detachAction)
             : this(parent, memberName, entityPredicate)
         {
-            if (attachAction == null)
-            {
-                throw new ArgumentNullException(nameof(attachAction));
-            }
-            if (detachAction == null)
-            {
-                throw new ArgumentNullException(nameof(detachAction));
-            }
+            ArgumentNullException.ThrowIfNull(attachAction);
+            ArgumentNullException.ThrowIfNull(detachAction);
 
             this._attachAction = attachAction;
             this._detachAction = detachAction;
@@ -217,10 +205,7 @@ namespace OpenRiaServices.Client
         /// <param name="entity">The entity to add</param>
         public void Add(TEntity entity)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
 
             if (this.IsSourceExternal)
             {
@@ -288,10 +273,7 @@ namespace OpenRiaServices.Client
         /// <param name="entity">The entity to remove</param>
         public void Remove(TEntity entity)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
 
             if (entity == this._detachingEntity)
             {

--- a/src/OpenRiaServices.Client/Framework/EntityCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollection.cs
@@ -59,10 +59,7 @@ namespace OpenRiaServices.Client
         public EntityCollection(Entity parent, string memberName, Func<TEntity, bool> entityPredicate)
         {
             ArgumentNullException.ThrowIfNull(parent);
-            if (string.IsNullOrEmpty(memberName))
-            {
-                throw new ArgumentNullException(nameof(memberName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(memberName);
             ArgumentNullException.ThrowIfNull(entityPredicate);
 
             this._parent = parent;

--- a/src/OpenRiaServices.Client/Framework/EntityCollectionChangedEventArgs.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityCollectionChangedEventArgs.cs
@@ -19,10 +19,7 @@ namespace OpenRiaServices.Client
         /// <param name="entity">The affected <see cref="Entity"/></param>
         public EntityCollectionChangedEventArgs(TEntity entity)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
 
             this._entity = entity;
         }

--- a/src/OpenRiaServices.Client/Framework/EntityConflict.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityConflict.cs
@@ -30,25 +30,16 @@ namespace OpenRiaServices.Client
         /// is null.</exception>
         internal EntityConflict(Entity currentEntity, Entity storeEntity, IEnumerable<string> propertyNames, bool isDeleted)
         {
-            if (currentEntity == null)
-            {
-                throw new ArgumentNullException(nameof(currentEntity));
-            }
+            ArgumentNullException.ThrowIfNull(currentEntity);
             this._currentEntity = currentEntity;
             this._isDeleted = isDeleted;
 
             if (!isDeleted)
             {
-                if (storeEntity == null)
-                {
-                    throw new ArgumentNullException(nameof(storeEntity));
-                }
+                ArgumentNullException.ThrowIfNull(storeEntity);
 
-                if (propertyNames == null)
-                {
-                    throw new ArgumentNullException(nameof(propertyNames));
-                }
-                
+                ArgumentNullException.ThrowIfNull(propertyNames);
+
                 this._storeEntity = storeEntity;
                 this._propertyNames = new ReadOnlyCollection<string>(propertyNames.ToList());
             }

--- a/src/OpenRiaServices.Client/Framework/EntityConflict.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityConflict.cs
@@ -37,7 +37,6 @@ namespace OpenRiaServices.Client
             if (!isDeleted)
             {
                 ArgumentNullException.ThrowIfNull(storeEntity);
-
                 ArgumentNullException.ThrowIfNull(propertyNames);
 
                 this._storeEntity = storeEntity;

--- a/src/OpenRiaServices.Client/Framework/EntityContainer.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityContainer.cs
@@ -88,10 +88,7 @@ namespace OpenRiaServices.Client
         /// <param name="entitySet">A <see cref="EntitySet"/> to register as an external reference.</param>
         public void AddReference(EntitySet entitySet)
         {
-            if (entitySet == null)
-            {
-                throw new ArgumentNullException(nameof(entitySet));
-            }
+            ArgumentNullException.ThrowIfNull(entitySet);
 
             Type entityType = entitySet.EntityType;
             if (this._entitySets.ContainsKey(entityType) 
@@ -376,10 +373,7 @@ namespace OpenRiaServices.Client
         /// are already cached locally, the return set will contain the cached instances.</returns>
         public IReadOnlyCollection<Entity> LoadEntities(IEnumerable<Entity> entities, LoadBehavior loadBehavior)
         {
-            if (entities == null)
-            {
-                throw new ArgumentNullException(nameof(entities));
-            }
+            ArgumentNullException.ThrowIfNull(entities);
 
             // group the entities by type, and load each group into it's entity
             // list (ensuring we don't modify the relative ordering of each sequence 

--- a/src/OpenRiaServices.Client/Framework/EntityKey.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityKey.cs
@@ -45,10 +45,7 @@ namespace OpenRiaServices.Client
         /// <returns>The entity key</returns>
         public static EntityKey Create(params object[] keyValues)
         {
-            if (keyValues == null)
-            {
-                throw new ArgumentNullException(nameof(keyValues));
-            }
+            ArgumentNullException.ThrowIfNull(keyValues);
 
             int keyLength = keyValues.Length;
             if (keyLength == 0)
@@ -120,10 +117,7 @@ namespace OpenRiaServices.Client
         /// <param name="value">The key value to format</param>
         internal static void FormatKeyValue<T>(StringBuilder sb, T value)
         {
-            if (sb == null)
-            {
-                throw new ArgumentNullException(nameof(sb));
-            }
+            ArgumentNullException.ThrowIfNull(sb);
             if (value == null)
             {
                 throw new ArgumentNullException(Resource.EntityKey_CannotBeNull);
@@ -202,10 +196,7 @@ namespace OpenRiaServices.Client
         /// <returns>True if the keys are equal</returns>
         public bool Equals(EntityKey<T> other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
             return EqualityComparer<T>.Default.Equals(this._v, other._v);
         }
 
@@ -277,10 +268,7 @@ namespace OpenRiaServices.Client
         /// <returns>True if the keys are equal</returns>
         public bool Equals(EntityKey<T1, T2> other)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
+            ArgumentNullException.ThrowIfNull(other);
             return EqualityComparer<T1>.Default.Equals(this._v1, other._v1) &&
                    EqualityComparer<T2>.Default.Equals(this._v2, other._v2);
         }

--- a/src/OpenRiaServices.Client/Framework/EntityList.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityList.cs
@@ -55,10 +55,7 @@ namespace OpenRiaServices.Client
         /// <param name="source">The source collection used to populate this list</param>
         public EntityList(EntitySet<T> entitySet, IEnumerable<T> source)
         {
-            if (entitySet == null)
-            {
-                throw new ArgumentNullException(nameof(entitySet));
-            }
+            ArgumentNullException.ThrowIfNull(entitySet);
 
             _entitySet = entitySet;
             _weakCollectionChangedLister =

--- a/src/OpenRiaServices.Client/Framework/EntityQuery.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityQuery.cs
@@ -33,18 +33,12 @@ namespace OpenRiaServices.Client
         /// <param name="isComposable">True if the query supports composition, false otherwise.</param>
         private protected EntityQuery(DomainClient domainClient, string queryName, Type entityType, IDictionary<string, object?>? parameters, bool hasSideEffects, bool isComposable)
         {
-            if (domainClient == null)
-            {
-                throw new ArgumentNullException(nameof(domainClient));
-            }
+            ArgumentNullException.ThrowIfNull(domainClient);
             if (string.IsNullOrEmpty(queryName))
             {
                 throw new ArgumentNullException(nameof(queryName));
             }
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
             this._domainClient = domainClient;
             this._queryName = queryName;
             this._entityType = entityType;
@@ -62,14 +56,8 @@ namespace OpenRiaServices.Client
         /// <param name="query">The new query.</param>
         internal EntityQuery(EntityQuery baseQuery, IQueryable query)
         {
-            if (baseQuery == null)
-            {
-                throw new ArgumentNullException(nameof(baseQuery));
-            }
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
+            ArgumentNullException.ThrowIfNull(baseQuery);
+            ArgumentNullException.ThrowIfNull(query);
             this._domainClient = baseQuery._domainClient;
             this._queryName = baseQuery._queryName;
             this._entityType = baseQuery._entityType;
@@ -195,7 +183,6 @@ namespace OpenRiaServices.Client
         {
         }
 
-        /// <inheritdoc cref="EntityQuery.Query" />
         /// <inheritdoc cref="EntityQuery.Query"/>
         internal new IQueryable<TEntity>? Query
         {

--- a/src/OpenRiaServices.Client/Framework/EntityQuery.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityQuery.cs
@@ -34,10 +34,7 @@ namespace OpenRiaServices.Client
         private protected EntityQuery(DomainClient domainClient, string queryName, Type entityType, IDictionary<string, object?>? parameters, bool hasSideEffects, bool isComposable)
         {
             ArgumentNullException.ThrowIfNull(domainClient);
-            if (string.IsNullOrEmpty(queryName))
-            {
-                throw new ArgumentNullException(nameof(queryName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(queryName);
             ArgumentNullException.ThrowIfNull(entityType);
             this._domainClient = domainClient;
             this._queryName = queryName;

--- a/src/OpenRiaServices.Client/Framework/EntityQueryable.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityQueryable.cs
@@ -21,14 +21,8 @@ namespace OpenRiaServices.Client
         /// <returns>The composed query.</returns>
         public static EntityQuery<TEntity> OrderBy<TEntity, TKey>(this EntityQuery<TEntity> source, Expression<Func<TEntity, TKey>> keySelector) where TEntity : Entity
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(keySelector);
             if (!source.IsComposable)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.EntityQuery_NotComposable, typeof(TEntity).Name, source.QueryName));
@@ -46,14 +40,8 @@ namespace OpenRiaServices.Client
         /// <returns>The composed query.</returns>
         public static EntityQuery<TEntity> OrderByDescending<TEntity, TKey>(this EntityQuery<TEntity> source, Expression<Func<TEntity, TKey>> keySelector) where TEntity : Entity
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(keySelector);
             if (!source.IsComposable)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.EntityQuery_NotComposable, typeof(TEntity).Name, source.QueryName));
@@ -70,10 +58,7 @@ namespace OpenRiaServices.Client
         /// <returns>The composed query.</returns>
         public static EntityQuery<TEntity> Skip<TEntity>(this EntityQuery<TEntity> source, int count) where TEntity : Entity
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ArgumentNullException.ThrowIfNull(source);
             if (!source.IsComposable)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.EntityQuery_NotComposable, typeof(TEntity).Name, source.QueryName));
@@ -90,10 +75,7 @@ namespace OpenRiaServices.Client
         /// <returns>The composed query.</returns>
         public static EntityQuery<TEntity> Take<TEntity>(this EntityQuery<TEntity> source, int count) where TEntity : Entity
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
+            ArgumentNullException.ThrowIfNull(source);
             if (!source.IsComposable)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.EntityQuery_NotComposable, typeof(TEntity).Name, source.QueryName));
@@ -111,14 +93,8 @@ namespace OpenRiaServices.Client
         /// <returns>The composed query.</returns>
         public static EntityQuery<TEntity> ThenBy<TEntity, TKey>(this EntityQuery<TEntity> source, Expression<Func<TEntity, TKey>> keySelector) where TEntity : Entity
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(keySelector);
             if (!source.IsComposable)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.EntityQuery_NotComposable, typeof(TEntity).Name, source.QueryName));
@@ -136,14 +112,8 @@ namespace OpenRiaServices.Client
         /// <returns>The composed query.</returns>
         public static EntityQuery<TEntity> ThenByDescending<TEntity, TKey>(this EntityQuery<TEntity> source, Expression<Func<TEntity, TKey>> keySelector) where TEntity : Entity
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(keySelector);
             if (!source.IsComposable)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.EntityQuery_NotComposable, typeof(TEntity).Name, source.QueryName));
@@ -160,14 +130,8 @@ namespace OpenRiaServices.Client
         /// <returns>The composed query.</returns>
         public static EntityQuery<TEntity> Where<TEntity>(this EntityQuery<TEntity> source, Expression<Func<TEntity, bool>> predicate) where TEntity : Entity
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            if (predicate == null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(predicate);
             if (!source.IsComposable)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.EntityQuery_NotComposable, typeof(TEntity).Name, source.QueryName));
@@ -185,14 +149,8 @@ namespace OpenRiaServices.Client
         /// <returns>The composed query.</returns>
         public static EntityQuery<TEntity> Select<TEntity>(this EntityQuery<TEntity> source, Expression<Func<TEntity, TEntity>> selector) where TEntity : Entity
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            if (selector == null)
-            {
-                throw new ArgumentNullException(nameof(selector));
-            }
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(selector);
             return new EntityQuery<TEntity>(source, Queryable.Select<TEntity, TEntity>(source.QueryRoot, selector));
         }
     }

--- a/src/OpenRiaServices.Client/Framework/EntityRef.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityRef.cs
@@ -39,18 +39,12 @@ namespace OpenRiaServices.Client
         /// <param name="entityPredicate">The function used to filter the associated entity.</param>
         public EntityRef(Entity parent, string memberName, Func<TEntity, bool> entityPredicate)
         {
-            if (parent == null)
-            {
-                throw new ArgumentNullException(nameof(parent));
-            }
+            ArgumentNullException.ThrowIfNull(parent);
             if (string.IsNullOrEmpty(memberName))
             {
                 throw new ArgumentNullException(nameof(memberName));
             }
-            if (entityPredicate == null)
-            {
-                throw new ArgumentNullException(nameof(entityPredicate));
-            }
+            ArgumentNullException.ThrowIfNull(entityPredicate);
 
             this._parent = parent;
             this._entityPredicate = entityPredicate;

--- a/src/OpenRiaServices.Client/Framework/EntityRef.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityRef.cs
@@ -40,10 +40,7 @@ namespace OpenRiaServices.Client
         public EntityRef(Entity parent, string memberName, Func<TEntity, bool> entityPredicate)
         {
             ArgumentNullException.ThrowIfNull(parent);
-            if (string.IsNullOrEmpty(memberName))
-            {
-                throw new ArgumentNullException(nameof(memberName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(memberName);
             ArgumentNullException.ThrowIfNull(entityPredicate);
 
             this._parent = parent;

--- a/src/OpenRiaServices.Client/Framework/EntitySet.cs
+++ b/src/OpenRiaServices.Client/Framework/EntitySet.cs
@@ -41,10 +41,7 @@ namespace OpenRiaServices.Client
         /// <param name="entityType">The type of <see cref="Entity"/> the set will contain</param>
         private protected EntitySet(Type entityType)
         {
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
             if (!typeof(Entity).IsAssignableFrom(entityType))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resource.Type_Not_Entity, entityType), nameof(entityType));
@@ -243,10 +240,7 @@ namespace OpenRiaServices.Client
 
         private void EnsureEntityType(object entity)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
             if (!this._entityType.IsAssignableFrom(entity.GetType()))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resource.EntitySet_Wrong_Type, this._entityType, entity.GetType()), nameof(entity));
@@ -666,10 +660,7 @@ namespace OpenRiaServices.Client
         /// <param name="entity">The entity to detach</param>
         public void Detach(Entity entity)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
 
             this.EnsureEntityType(entity);
 
@@ -1085,18 +1076,9 @@ namespace OpenRiaServices.Client
 
             public static void Infer(EntityContainer container, Entity entity, Action<EntitySet, Entity> action)
             {
-                if (container == null)
-                {
-                    throw new ArgumentNullException(nameof(container));
-                }
-                if (entity == null)
-                {
-                    throw new ArgumentNullException(nameof(entity));
-                }
-                if (action == null)
-                {
-                    throw new ArgumentNullException(nameof(action));
-                }
+                ArgumentNullException.ThrowIfNull(container);
+                ArgumentNullException.ThrowIfNull(entity);
+                ArgumentNullException.ThrowIfNull(action);
 
                 new AddAttachInferrer(container, action).Visit(entity);
             }

--- a/src/OpenRiaServices.Client/Framework/EntityVisitor.cs
+++ b/src/OpenRiaServices.Client/Framework/EntityVisitor.cs
@@ -17,10 +17,7 @@ namespace OpenRiaServices.Client
         /// <param name="entity">The entity to visit</param>
         public virtual void Visit(Entity entity)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
 
             foreach (MetaMember association in entity.MetaType.AssociationMembers)
             {

--- a/src/OpenRiaServices.Client/Framework/InvokeArgs.cs
+++ b/src/OpenRiaServices.Client/Framework/InvokeArgs.cs
@@ -20,10 +20,7 @@ namespace OpenRiaServices.Client
         /// <param name="hasSideEffects">True if the operation has side-effects, false otherwise.</param>
         public InvokeArgs(string operationName, Type returnType, IDictionary<string, object?>? parameters, bool hasSideEffects)
         {
-            if (string.IsNullOrEmpty(operationName))
-            {
-                throw new ArgumentNullException(nameof(operationName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(operationName);
             ArgumentNullException.ThrowIfNull(returnType);
 
             OperationName = operationName;

--- a/src/OpenRiaServices.Client/Framework/InvokeArgs.cs
+++ b/src/OpenRiaServices.Client/Framework/InvokeArgs.cs
@@ -24,10 +24,7 @@ namespace OpenRiaServices.Client
             {
                 throw new ArgumentNullException(nameof(operationName));
             }
-            if (returnType == null)
-            {
-                throw new ArgumentNullException(nameof(returnType));
-            }
+            ArgumentNullException.ThrowIfNull(returnType);
 
             OperationName = operationName;
             ReturnType = returnType;

--- a/src/OpenRiaServices.Client/Framework/InvokeCompletedResult.cs
+++ b/src/OpenRiaServices.Client/Framework/InvokeCompletedResult.cs
@@ -30,10 +30,7 @@ namespace OpenRiaServices.Client
         /// <param name="validationErrors">A collection of validation errors.</param>
         public InvokeCompletedResult(object? returnValue, IEnumerable<ValidationResult> validationErrors)
         {
-            if (validationErrors == null)
-            {
-                throw new ArgumentNullException(nameof(validationErrors));
-            }
+            ArgumentNullException.ThrowIfNull(validationErrors);
 
             ReturnValue = returnValue;
             ValidationErrors = validationErrors.ToList().AsReadOnly();

--- a/src/OpenRiaServices.Client/Framework/InvokeOperation.cs
+++ b/src/OpenRiaServices.Client/Framework/InvokeOperation.cs
@@ -32,10 +32,7 @@ namespace OpenRiaServices.Client
             CancellationTokenSource? cancellationTokenSource)
             : base(userState, cancellationTokenSource)
         {
-            if (string.IsNullOrEmpty(operationName))
-            {
-                throw new ArgumentNullException(nameof(operationName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(operationName);
             this.OperationName = operationName;
             this._parameters = parameters;
             this._completeAction = completeAction;

--- a/src/OpenRiaServices.Client/Framework/LoadOperation.cs
+++ b/src/OpenRiaServices.Client/Framework/LoadOperation.cs
@@ -35,10 +35,7 @@ namespace OpenRiaServices.Client
         private protected LoadOperation(EntityQuery query, LoadBehavior loadBehavior, object? userState, CancellationTokenSource? cancellationTokenSource)
             : base(userState, cancellationTokenSource)
         {
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
+            ArgumentNullException.ThrowIfNull(query);
             this._query = query;
             this._loadBehavior = loadBehavior;
         }
@@ -139,10 +136,7 @@ namespace OpenRiaServices.Client
         /// <param name="result">The results of the completed load operation.</param>
         private protected virtual void UpdateResults(ILoadResult result)
         {
-            if (result == null)
-            {
-                throw new ArgumentNullException(nameof(result));
-            }
+            ArgumentNullException.ThrowIfNull(result);
 
             // if the Entities property has been examined, update the backing
             // observable collection
@@ -202,10 +196,7 @@ namespace OpenRiaServices.Client
             CancellationTokenSource? cancellationTokenSource)
             : base(query, loadBehavior, userState, cancellationTokenSource)
         {
-            if (loadResultTask == null)
-            {
-                throw new ArgumentNullException(nameof(loadResultTask));
-            }
+            ArgumentNullException.ThrowIfNull(loadResultTask);
 
             this._completeAction = completeAction;
 
@@ -280,10 +271,7 @@ namespace OpenRiaServices.Client
         /// <param name="result">The result.</param>
         private void SetResult(LoadResult<TEntity> result)
         {
-            if (result == null)
-            {
-                throw new ArgumentNullException(nameof(result));
-            }
+            ArgumentNullException.ThrowIfNull(result);
 
             // before calling base, we need to update any cached
             // observable collection results so the correct data

--- a/src/OpenRiaServices.Client/Framework/OpenRiaServices.Client.csproj
+++ b/src/OpenRiaServices.Client/Framework/OpenRiaServices.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0;net8.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net8.0-windows</TargetFrameworks>
 
     <DefineConstants Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net8.0-windows' ">$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
     <UseWPF Condition=" '$(TargetFramework)' == 'net8.0-windows' ">true</UseWPF>

--- a/src/OpenRiaServices.Client/Framework/OperationBase.cs
+++ b/src/OpenRiaServices.Client/Framework/OperationBase.cs
@@ -300,10 +300,7 @@ namespace OpenRiaServices.Client
         /// <param name="error">The error.</param>
         protected void SetError(Exception error)
         {
-            if (error == null)
-            {
-                throw new ArgumentNullException(nameof(error));
-            }
+            ArgumentNullException.ThrowIfNull(error);
 
             this.EnsureNotCompleted();
 

--- a/src/OpenRiaServices.Client/Framework/Polyfills.cs
+++ b/src/OpenRiaServices.Client/Framework/Polyfills.cs
@@ -44,7 +44,7 @@ namespace System
         private static void ThrowStringNullOrEmptyException(string? argument, string? paramName)
         {
             ArgumentNullException.ThrowIfNull(argument, paramName);
-            throw new ArgumentException(paramName, "The value cannot be an empty string.");
+            throw new ArgumentException("The value cannot be an empty string.", paramName: paramName);
         }
     }
 }

--- a/src/OpenRiaServices.Client/Framework/Polyfills.cs
+++ b/src/OpenRiaServices.Client/Framework/Polyfills.cs
@@ -28,7 +28,9 @@ namespace System
             public static void ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
             {
                 if (argument is null || argument.Length == 0)
-                    ThrowArgumentNullException(paramName);
+                {
+                    ThrowStringNullOrEmptyException(argument, paramName);
+                }
             }
         }
 
@@ -36,6 +38,13 @@ namespace System
         private static void ThrowArgumentNullException(string? paramName)
         {
             throw new ArgumentNullException(paramName);
+        }
+
+        [DoesNotReturn]
+        private static void ThrowStringNullOrEmptyException(string? argument, string? paramName)
+        {
+            ArgumentNullException.ThrowIfNull(argument, paramName);
+            throw new ArgumentException(paramName, "The value cannot be an empty string.");
         }
     }
 }

--- a/src/OpenRiaServices.Client/Framework/QueryBuilder.cs
+++ b/src/OpenRiaServices.Client/Framework/QueryBuilder.cs
@@ -66,10 +66,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public QueryBuilder<T> OrderBy<TKey>(Expression<Func<T, TKey>> keySelector)
         {
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
+            ArgumentNullException.ThrowIfNull(keySelector);
 
             Func<EntityQuery<T>, EntityQuery<T>> entityQueryReplay = _entityQueryReplay;
             Func<IQueryable<T>, IQueryable<T>> queryableReplay = _queryableReplay;
@@ -102,10 +99,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public QueryBuilder<T> OrderByDescending<TKey>(Expression<Func<T, TKey>> keySelector)
         {
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
+            ArgumentNullException.ThrowIfNull(keySelector);
 
             Func<EntityQuery<T>, EntityQuery<T>> entityQueryReplay = _entityQueryReplay;
             Func<IQueryable<T>, IQueryable<T>> queryableReplay = _queryableReplay;
@@ -138,10 +132,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public QueryBuilder<T> Select(Expression<Func<T, T>> selector)
         {
-            if (selector == null)
-            {
-                throw new ArgumentNullException(nameof(selector));
-            }
+            ArgumentNullException.ThrowIfNull(selector);
 
             Func<EntityQuery<T>, EntityQuery<T>> entityQueryReplay = _entityQueryReplay;
             Func<IQueryable<T>, IQueryable<T>> queryableReplay = _queryableReplay;
@@ -228,10 +219,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public QueryBuilder<T> ThenBy<TKey>(Expression<Func<T, TKey>> keySelector)
         {
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
+            ArgumentNullException.ThrowIfNull(keySelector);
 
             Func<EntityQuery<T>, EntityQuery<T>> entityQueryReplay = _entityQueryReplay;
             Func<IQueryable<T>, IQueryable<T>> queryableReplay = _queryableReplay;
@@ -264,10 +252,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public QueryBuilder<T> ThenByDescending<TKey>(Expression<Func<T, TKey>> keySelector)
         {
-            if (keySelector == null)
-            {
-                throw new ArgumentNullException(nameof(keySelector));
-            }
+            ArgumentNullException.ThrowIfNull(keySelector);
 
             Func<EntityQuery<T>, EntityQuery<T>> entityQueryReplay = _entityQueryReplay;
             Func<IQueryable<T>, IQueryable<T>> queryableReplay = _queryableReplay;
@@ -299,10 +284,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public QueryBuilder<T> Where(Expression<Func<T, bool>> predicate)
         {
-            if (predicate == null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
+            ArgumentNullException.ThrowIfNull(predicate);
 
             Func<EntityQuery<T>, EntityQuery<T>> entityQueryReplay = _entityQueryReplay;
             Func<IQueryable<T>, IQueryable<T>> queryableReplay = _queryableReplay;
@@ -338,10 +320,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public EntityQuery<T> ApplyTo(EntityQuery<T> entityQuery)
         {
-            if (entityQuery == null)
-            {
-                throw new ArgumentNullException(nameof(entityQuery));
-            }
+            ArgumentNullException.ThrowIfNull(entityQuery);
 
             entityQuery.IncludeTotalCount = RequestTotalItemCount;
             if (_entityQueryReplay != null)
@@ -361,10 +340,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public IEnumerable<T> ApplyTo(IEnumerable<T> enumerable)
         {
-            if (enumerable == null)
-            {
-                throw new ArgumentNullException(nameof(enumerable));
-            }
+            ArgumentNullException.ThrowIfNull(enumerable);
 
             return ApplyTo(enumerable.AsQueryable());
         }
@@ -379,10 +355,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public IQueryable<T> ApplyTo(IQueryable<T> queryable)
         {
-            if (queryable == null)
-            {
-                throw new ArgumentNullException(nameof(queryable));
-            }
+            ArgumentNullException.ThrowIfNull(queryable);
 
             if (_queryableReplay != null)
             {
@@ -401,10 +374,7 @@ namespace OpenRiaServices.Client
         /// </exception>
         public ObservableCollection<T> ApplyTo(ObservableCollection<T> collection)
         {
-            if (collection == null)
-            {
-                throw new ArgumentNullException(nameof(collection));
-            }
+            ArgumentNullException.ThrowIfNull(collection);
 
             return new ObservableCollection<T>(ApplyTo((IEnumerable<T>)collection));
         }

--- a/src/OpenRiaServices.Client/Framework/QueryCompletedResult.cs
+++ b/src/OpenRiaServices.Client/Framework/QueryCompletedResult.cs
@@ -25,18 +25,9 @@ namespace OpenRiaServices.Client
         /// <param name="validationErrors">A collection of validation errors.</param>
         public QueryCompletedResult(IEnumerable<Entity> entities, IEnumerable<Entity> includedEntities, int totalCount, IEnumerable<ValidationResult> validationErrors)
         {
-            if (entities == null)
-            {
-                throw new ArgumentNullException(nameof(entities));
-            }
-            if (includedEntities == null)
-            {
-                throw new ArgumentNullException(nameof(includedEntities));
-            }
-            if (validationErrors == null)
-            {
-                throw new ArgumentNullException(nameof(validationErrors));
-            }
+            ArgumentNullException.ThrowIfNull(entities);
+            ArgumentNullException.ThrowIfNull(includedEntities);
+            ArgumentNullException.ThrowIfNull(validationErrors);
 
             this._entities = entities.ToList().AsReadOnly();
             this._includedEntities = includedEntities.ToList().AsReadOnly();

--- a/src/OpenRiaServices.Client/Framework/SubmitCompletedResult.cs
+++ b/src/OpenRiaServices.Client/Framework/SubmitCompletedResult.cs
@@ -21,14 +21,8 @@ namespace OpenRiaServices.Client
         /// DomainService for the submit operation.</param>
         public SubmitCompletedResult(EntityChangeSet changeSet, IEnumerable<ChangeSetEntry> operationResults)
         {
-            if (changeSet == null)
-            {
-                throw new ArgumentNullException(nameof(changeSet));
-            }
-            if (operationResults == null)
-            {
-                throw new ArgumentNullException(nameof(operationResults));
-            }
+            ArgumentNullException.ThrowIfNull(changeSet);
+            ArgumentNullException.ThrowIfNull(operationResults);
 
             this._changeSet = changeSet;
             this._operationResults =new ReadOnlyCollection<ChangeSetEntry>(operationResults.ToList());

--- a/src/OpenRiaServices.Client/Framework/SubmitOperation.cs
+++ b/src/OpenRiaServices.Client/Framework/SubmitOperation.cs
@@ -29,10 +29,7 @@ namespace OpenRiaServices.Client
             Task<SubmitResult> sumitResultTask, CancellationTokenSource? cancellationTokenSource)
             : base(userState, cancellationTokenSource)
         {
-            if (changeSet == null)
-            {
-                throw new ArgumentNullException(nameof(changeSet));
-            }
+            ArgumentNullException.ThrowIfNull(changeSet);
 
             this._completeAction = completeAction;
             this._changeSet = changeSet;

--- a/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationResultCollection.cs
@@ -197,10 +197,7 @@ namespace OpenRiaServices.Client
         /// <param name="item">The item to be added.</param>
         public void Add(ValidationResult item)
         {
-            if (item == null)
-            {
-                throw new ArgumentNullException(nameof(item));
-            }
+            ArgumentNullException.ThrowIfNull(item);
 
             IEnumerable<string?> propertiesAffected = item.MemberNames;
 
@@ -319,10 +316,7 @@ namespace OpenRiaServices.Client
         /// <returns><c>true</c> if the removal was successful, otherwise <c>false</c>.</returns>
         public bool Remove(ValidationResult item)
         {
-            if (item == null)
-            {
-                throw new ArgumentNullException(nameof(item));
-            }
+            ArgumentNullException.ThrowIfNull(item);
 
             IEnumerable<string?> propertiesAffected = item.MemberNames;
 

--- a/src/OpenRiaServices.Client/Framework/ValidationResultInfo.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationResultInfo.cs
@@ -38,15 +38,9 @@ namespace OpenRiaServices.Client
         /// <param name="sourceMemberNames">A collection of the names of the members the error originated from.</param>
         public ValidationResultInfo(string message, IEnumerable<string> sourceMemberNames)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
+            ArgumentNullException.ThrowIfNull(message);
 
-            if (sourceMemberNames == null)
-            {
-                throw new ArgumentNullException(nameof(sourceMemberNames));
-            }
+            ArgumentNullException.ThrowIfNull(sourceMemberNames);
 
             this._message = message;
             this._sourceMemberNames = sourceMemberNames;
@@ -62,15 +56,9 @@ namespace OpenRiaServices.Client
         /// <param name="sourceMemberNames">A collection of the names of the members the error originated from.</param>
         public ValidationResultInfo(string message, int errorCode, string stackTrace, IEnumerable<string> sourceMemberNames)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
+            ArgumentNullException.ThrowIfNull(message);
 
-            if (sourceMemberNames == null)
-            {
-                throw new ArgumentNullException(nameof(sourceMemberNames));
-            }
+            ArgumentNullException.ThrowIfNull(sourceMemberNames);
 
             this._message = message;
             this._errorCode = errorCode;

--- a/src/OpenRiaServices.Client/Framework/ValidationUtilities.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationUtilities.cs
@@ -32,10 +32,7 @@ namespace OpenRiaServices.Client
         /// <returns>A new validation context.</returns>
         internal static ValidationContext CreateValidationContext(object instance, ValidationContext? parentContext)
         {
-            if (instance == null)
-            {
-                throw new ArgumentNullException(nameof(instance));
-            }
+            ArgumentNullException.ThrowIfNull(instance);
 
             ValidationContext context = new ValidationContext(instance, parentContext, parentContext != null ? parentContext.Items : null);
             return context;
@@ -609,10 +606,7 @@ namespace OpenRiaServices.Client
                 throw new ArgumentNullException(nameof(methodName));
             }
 
-            if (validationContext == null)
-            {
-                throw new ArgumentNullException(nameof(validationContext));
-            }
+            ArgumentNullException.ThrowIfNull(validationContext);
 
             if (validationContext.ObjectInstance == null)
             {

--- a/src/OpenRiaServices.Client/Framework/ValidationUtilities.cs
+++ b/src/OpenRiaServices.Client/Framework/ValidationUtilities.cs
@@ -601,10 +601,7 @@ namespace OpenRiaServices.Client
             ValidationContext validationContext, object[] parameters,
             List<ValidationResult> validationResults, bool performTypeValidation)
         {
-            if (string.IsNullOrEmpty(methodName))
-            {
-                throw new ArgumentNullException(nameof(methodName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(methodName);
 
             ArgumentNullException.ThrowIfNull(validationContext);
 

--- a/src/OpenRiaServices.Client/Test/Client.Test/Authentication/WebContextBaseTest.cs
+++ b/src/OpenRiaServices.Client/Test/Client.Test/Authentication/WebContextBaseTest.cs
@@ -238,7 +238,7 @@ namespace OpenRiaServices.Client.Authentication.Test
 
             ExceptionHelper.ExpectArgumentNullException(
                 () => context.RaisePropertyChangedMock(null), "propertyName");
-            ExceptionHelper.ExpectArgumentNullException(
+            ExceptionHelper.ExpectEmptyStringArgumentException(
                 () => context.RaisePropertyChangedMock(string.Empty), "propertyName");
 
             propertyName = "Property 1";

--- a/src/OpenRiaServices.EntityFramework/Framework/DbContextExtensions.cs
+++ b/src/OpenRiaServices.EntityFramework/Framework/DbContextExtensions.cs
@@ -23,22 +23,10 @@ namespace OpenRiaServices.EntityFramework
         /// <param name="dbContext">The corresponding <see cref="DbContext"/></param>
         public static void AttachAsModified<T>(this IDbSet<T> dbSet, T current, T original, DbContext dbContext) where T : class
         {
-            if (dbSet == null)
-            {
-                throw new ArgumentNullException(nameof(dbSet));
-            }
-            if (current == null)
-            {
-                throw new ArgumentNullException(nameof(current));
-            }
-            if (original == null)
-            {
-                throw new ArgumentNullException(nameof(original));
-            }
-            if (dbContext == null)
-            {
-                throw new ArgumentNullException(nameof(dbContext));
-            }
+            ArgumentNullException.ThrowIfNull(dbSet);
+            ArgumentNullException.ThrowIfNull(current);
+            ArgumentNullException.ThrowIfNull(original);
+            ArgumentNullException.ThrowIfNull(dbContext);
 
             DbEntityEntry<T> entityEntry = dbContext.Entry(current);
             if (entityEntry.State == EntityState.Detached)
@@ -72,18 +60,9 @@ namespace OpenRiaServices.EntityFramework
         /// <param name="dbContext">The coresponding <see cref="DbContext"/></param>
         public static void AttachAsModified<T>(this IDbSet<T> dbSet, T entity, DbContext dbContext) where T : class
         {
-            if (dbSet == null)
-            {
-                throw new ArgumentNullException(nameof(dbSet));
-            }
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
-            if (dbContext == null)
-            {
-                throw new ArgumentNullException(nameof(dbContext));
-            }
+            ArgumentNullException.ThrowIfNull(dbSet);
+            ArgumentNullException.ThrowIfNull(entity);
+            ArgumentNullException.ThrowIfNull(dbContext);
 
             DbEntityEntry<T> entityEntry = dbContext.Entry(entity);
             if (entityEntry.State == EntityState.Detached)

--- a/src/OpenRiaServices.EntityFramework/Framework/DbDomainServiceDescriptionProviderAttribute.cs
+++ b/src/OpenRiaServices.EntityFramework/Framework/DbDomainServiceDescriptionProviderAttribute.cs
@@ -72,10 +72,7 @@ namespace OpenRiaServices.EntityFramework
         /// <returns>The description provider.</returns>
         public override DomainServiceDescriptionProvider CreateProvider(Type domainServiceType, DomainServiceDescriptionProvider parent)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             if (_dbContextType == null)
             {

--- a/src/OpenRiaServices.EntityFramework/Framework/LinqToEntitiesDomainServiceDescriptionProviderAttribute.cs
+++ b/src/OpenRiaServices.EntityFramework/Framework/LinqToEntitiesDomainServiceDescriptionProviderAttribute.cs
@@ -59,10 +59,7 @@ namespace OpenRiaServices.EntityFramework
         /// <returns>The description provider.</returns>
         public override DomainServiceDescriptionProvider CreateProvider(Type domainServiceType, DomainServiceDescriptionProvider parent)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             if (this._objectContextType == null)
             {

--- a/src/OpenRiaServices.EntityFramework/Framework/LinqToEntitiesTypeDescriptionContext.cs
+++ b/src/OpenRiaServices.EntityFramework/Framework/LinqToEntitiesTypeDescriptionContext.cs
@@ -29,10 +29,7 @@ namespace OpenRiaServices.EntityFramework
         /// <param name="contextType">The ObjectContext Type</param>
         public LinqToEntitiesTypeDescriptionContext(Type contextType)
         {
-            if (contextType == null)
-            {
-                throw new ArgumentNullException(nameof(contextType));
-            }
+            ArgumentNullException.ThrowIfNull(contextType);
             this._contextType = contextType;
         }
 

--- a/src/OpenRiaServices.EntityFramework/Framework/MetadataWorkspaceUtilities.cs
+++ b/src/OpenRiaServices.EntityFramework/Framework/MetadataWorkspaceUtilities.cs
@@ -217,20 +217,11 @@ namespace System.Data.Mapping
 
             public MetadataWorkspaceInfo(string csdlPath, string mslPath, string ssdlPath)
             {
-                if (csdlPath == null)
-                {
-                    throw new ArgumentNullException(nameof(csdlPath));
-                }
+                ArgumentNullException.ThrowIfNull(csdlPath);
 
-                if (mslPath == null)
-                {
-                    throw new ArgumentNullException(nameof(mslPath));
-                }
+                ArgumentNullException.ThrowIfNull(mslPath);
 
-                if (ssdlPath == null)
-                {
-                    throw new ArgumentNullException(nameof(ssdlPath));
-                }
+                ArgumentNullException.ThrowIfNull(ssdlPath);
 
                 this.Csdl = csdlPath;
                 this.Msl = mslPath;

--- a/src/OpenRiaServices.EntityFramework/Framework/ObjectContextExtensions.cs
+++ b/src/OpenRiaServices.EntityFramework/Framework/ObjectContextExtensions.cs
@@ -22,18 +22,9 @@ namespace OpenRiaServices.EntityFramework
         /// <param name="original">The original entity state</param>
         public static void AttachAsModified<T>(this ObjectSet<T> objectSet, T current, T original) where T : class
         {
-            if (objectSet == null)
-            {
-                throw new ArgumentNullException(nameof(objectSet));
-            }
-            if (current == null)
-            {
-                throw new ArgumentNullException(nameof(current));
-            }
-            if (original == null)
-            {
-                throw new ArgumentNullException(nameof(original));
-            }
+            ArgumentNullException.ThrowIfNull(objectSet);
+            ArgumentNullException.ThrowIfNull(current);
+            ArgumentNullException.ThrowIfNull(original);
 
             // Attach the entity if it is not already attached, or if it is already
             // attached, transition to Modified
@@ -67,14 +58,8 @@ namespace OpenRiaServices.EntityFramework
         /// <param name="entity">The current entity state</param>
         public static void AttachAsModified<T>(this ObjectSet<T> objectSet, T entity) where T : class
         {
-            if (objectSet == null)
-            {
-                throw new ArgumentNullException(nameof(objectSet));
-            }
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(objectSet);
+            ArgumentNullException.ThrowIfNull(entity);
 
             ObjectContext context = objectSet.Context;
             EntityState currState = ObjectContextUtilities.GetEntityState(context, entity);

--- a/src/OpenRiaServices.EntityFramework/Framework/ObjectContextUtilities.cs
+++ b/src/OpenRiaServices.EntityFramework/Framework/ObjectContextUtilities.cs
@@ -46,14 +46,8 @@ using ConcurrencyMode = System.Data.Metadata.Edm.ConcurrencyMode;
         /// is not mapped.</returns>
         public static StructuralType GetEdmType(MetadataWorkspace workspace, Type clrType)
         {
-            if (workspace == null)
-            {
-                throw new ArgumentNullException(nameof(workspace));
-            }
-            if (clrType == null)
-            {
-                throw new ArgumentNullException(nameof(clrType));
-            }
+            ArgumentNullException.ThrowIfNull(workspace);
+            ArgumentNullException.ThrowIfNull(clrType);
 
             if (clrType.IsPrimitive || clrType == typeof(object))
             {
@@ -100,14 +94,8 @@ using ConcurrencyMode = System.Data.Metadata.Edm.ConcurrencyMode;
         /// <returns>The current <see cref="EntityState"/> of the specified entity</returns>
         public static EntityState GetEntityState(ObjectContext context, object entity)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(entity);
 
             ObjectStateEntry stateEntry = null;
             if (!context.ObjectStateManager.TryGetObjectStateEntry(entity, out stateEntry))

--- a/src/OpenRiaServices.EntityFramework/Framework/OpenRiaServices.EntityFramework.csproj
+++ b/src/OpenRiaServices.EntityFramework/Framework/OpenRiaServices.EntityFramework.csproj
@@ -12,6 +12,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\ExceptionHandlingUtility.cs" Link="ExceptionHandlingUtility.cs" />
     <Compile Update="DbResource.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/OpenRiaServices.Hosting.Local/Framework/DomainServiceProxy.cs
+++ b/src/OpenRiaServices.Hosting.Local/Framework/DomainServiceProxy.cs
@@ -123,10 +123,7 @@ namespace OpenRiaServices.Hosting.Local
             where TDomainServiceContract : IDisposable
             where TDomainService : DomainService
         {
-            if (domainServiceContext == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceContext));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceContext);
 
             // Get or create the proxy type
             Type proxyType = DomainServiceProxy.GetProxyType<TDomainServiceContract, TDomainService>();
@@ -245,20 +242,11 @@ namespace OpenRiaServices.Hosting.Local
         public static void AssociateOriginal<TEntity>(object domainServiceProxy, TEntity current, TEntity original)
             where TEntity : new()
         {
-            if (domainServiceProxy == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceProxy));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceProxy);
 
-            if (current == null)
-            {
-                throw new ArgumentNullException(nameof(current));
-            }
+            ArgumentNullException.ThrowIfNull(current);
 
-            if (original == null)
-            {
-                throw new ArgumentNullException(nameof(original));
-            }
+            ArgumentNullException.ThrowIfNull(original);
 
             PropertyInfo currentOriginalProp = domainServiceProxy.GetType().GetProperty("CurrentOriginalEntityMap", BindingFlags.Public | BindingFlags.Instance);
 
@@ -296,10 +284,7 @@ namespace OpenRiaServices.Hosting.Local
             /// <param name="httpContextBase">The <see cref="HttpContextBase"/>.</param>
             public HttpContextBaseServiceProvider(HttpContextBase httpContextBase)
             {
-                if (httpContextBase == null)
-                {
-                    throw new ArgumentNullException(nameof(httpContextBase));
-                }
+                ArgumentNullException.ThrowIfNull(httpContextBase);
 
                 this._httpContextBase = httpContextBase;
             }
@@ -312,10 +297,7 @@ namespace OpenRiaServices.Hosting.Local
             /// service object of type serviceType.</returns>
             public object GetService(Type serviceType)
             {
-                if (serviceType == null)
-                {
-                    throw new ArgumentNullException(nameof(serviceType));
-                }
+                ArgumentNullException.ThrowIfNull(serviceType);
 
                 if (serviceType == typeof(IPrincipal))
                 {

--- a/src/OpenRiaServices.Hosting.Local/Framework/Internal/DomainServiceProxyGenerator.cs
+++ b/src/OpenRiaServices.Hosting.Local/Framework/Internal/DomainServiceProxyGenerator.cs
@@ -66,15 +66,9 @@ namespace OpenRiaServices.Hosting.Local
         /// <returns>Returns a <see cref="DomainService"/> proxy type.</returns>
         public static Type Generate(Type domainServiceContract, Type domainService)
         {
-            if (domainServiceContract == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceContract));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceContract);
 
-            if (domainService == null)
-            {
-                throw new ArgumentNullException(nameof(domainService));
-            }
+            ArgumentNullException.ThrowIfNull(domainService);
 
             // Verify 'domainServiceContract' is actually a public interface.
             if (!domainServiceContract.IsInterface || (!domainServiceContract.IsPublic && !domainServiceContract.IsNestedPublic))

--- a/src/OpenRiaServices.Hosting.Local/Framework/OpenRiaServices.Hosting.Local.csproj
+++ b/src/OpenRiaServices.Hosting.Local/Framework/OpenRiaServices.Hosting.Local.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\OpenRiaServices.Server\Framework\OpenRiaServices.Server.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Condition=" '$(RunCodeAnalysis)' != 'true' " Remove="GlobalSuppressions.cs" />
     <Compile Update="Resource.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/OpenRiaServices.Hosting.Local/Framework/OperationException.cs
+++ b/src/OpenRiaServices.Hosting.Local/Framework/OperationException.cs
@@ -59,10 +59,7 @@ namespace OpenRiaServices.Hosting.Local
         internal OperationException(string message, ValidationResultInfo operationError)
             : this(message, new[] { operationError })
         {
-            if (operationError == null)
-            {
-                throw new ArgumentNullException(nameof(operationError));
-            }
+            ArgumentNullException.ThrowIfNull(operationError);
         }
 
         /// <summary>
@@ -74,10 +71,7 @@ namespace OpenRiaServices.Hosting.Local
         internal OperationException(string message, IEnumerable<ValidationResultInfo> operationErrors)
             : base(message)
         {
-            if (operationErrors == null)
-            {
-                throw new ArgumentNullException(nameof(operationErrors));
-            }
+            ArgumentNullException.ThrowIfNull(operationErrors);
 
             this._data.OperationErrors = operationErrors.ToArray();
 

--- a/src/OpenRiaServices.Hosting.Local/Framework/OperationException.cs
+++ b/src/OpenRiaServices.Hosting.Local/Framework/OperationException.cs
@@ -59,7 +59,10 @@ namespace OpenRiaServices.Hosting.Local
         internal OperationException(string message, ValidationResultInfo operationError)
             : this(message, new[] { operationError })
         {
-            ArgumentNullException.ThrowIfNull(operationError);
+            if (operationError == null)
+            {
+                throw new ArgumentNullException(nameof(operationError));
+            }
         }
 
         /// <summary>
@@ -71,7 +74,10 @@ namespace OpenRiaServices.Hosting.Local
         internal OperationException(string message, IEnumerable<ValidationResultInfo> operationErrors)
             : base(message)
         {
-            ArgumentNullException.ThrowIfNull(operationErrors);
+            if (operationErrors == null)
+            {
+                throw new ArgumentNullException(nameof(operationErrors));
+            }
 
             this._data.OperationErrors = operationErrors.ToArray();
 

--- a/src/OpenRiaServices.Hosting.Wcf.Endpoint/Framework/WCF/Tracing/InMemoryTraceListener.cs
+++ b/src/OpenRiaServices.Hosting.Wcf.Endpoint/Framework/WCF/Tracing/InMemoryTraceListener.cs
@@ -57,10 +57,7 @@ namespace OpenRiaServices.Hosting.Wcf.Tracing
         /// <param name="message">Message to trace.</param>
         public override void Write(string message)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
+            ArgumentNullException.ThrowIfNull(message);
 
             currentEntry = currentEntry == null ? message : currentEntry + message;
         }

--- a/src/OpenRiaServices.Hosting.Wcf.Endpoint/Framework/WCF/Tracing/TracingDomainServiceEndpointFactory.cs
+++ b/src/OpenRiaServices.Hosting.Wcf.Endpoint/Framework/WCF/Tracing/TracingDomainServiceEndpointFactory.cs
@@ -36,10 +36,7 @@ namespace OpenRiaServices.Hosting.Wcf.Tracing
         /// <returns>The collection of endpoints.</returns>
         public override IEnumerable<ServiceEndpoint> CreateEndpoints(DomainServiceDescription description, DomainServiceHost serviceHost, ContractDescription contractDescription)
         {
-            if (serviceHost == null)
-            {
-                throw new ArgumentNullException(nameof(serviceHost));
-            }
+            ArgumentNullException.ThrowIfNull(serviceHost);
 
             if (this.Parameters["maxEntries"] != null)
             {
@@ -96,10 +93,7 @@ namespace OpenRiaServices.Hosting.Wcf.Tracing
 
             public void ApplyDispatchBehavior(ServiceEndpoint endpoint, EndpointDispatcher endpointDispatcher)
             {
-                if (endpointDispatcher == null)
-                {
-                    throw new ArgumentNullException(nameof(endpointDispatcher));
-                }
+                ArgumentNullException.ThrowIfNull(endpointDispatcher);
 
                 endpointDispatcher.DispatchRuntime.SynchronizationContext = null;
                 endpointDispatcher.DispatchRuntime.ConcurrencyMode = ConcurrencyMode.Single;

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Linq/DynamicQueryable.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Linq/DynamicQueryable.cs
@@ -23,10 +23,8 @@ namespace System.Linq.Dynamic
     {
         public static IQueryable Where(this IQueryable source, string predicate, QueryResolver queryResolver)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-            if (predicate == null)
-                throw new ArgumentNullException(nameof(predicate));
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(predicate);
             LambdaExpression lambda = DynamicExpression.ParseLambda(source.ElementType, typeof(bool), predicate, queryResolver);
             return source.Provider.CreateQuery(
                 Expression.Call(
@@ -37,10 +35,8 @@ namespace System.Linq.Dynamic
 
         public static IQueryable OrderBy(this IQueryable source, string ordering, QueryResolver queryResolver)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
-            if (ordering == null)
-                throw new ArgumentNullException(nameof(ordering));
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(ordering);
             ParameterExpression[] parameters = new ParameterExpression[] {
                 Expression.Parameter(source.ElementType, "") };
             ExpressionParser parser = new ExpressionParser(parameters, ordering, queryResolver);
@@ -62,8 +58,7 @@ namespace System.Linq.Dynamic
 
         public static IQueryable Take(this IQueryable source, int count)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
             return source.Provider.CreateQuery(
                 Expression.Call(
                     typeof(Queryable), "Take",
@@ -73,8 +68,7 @@ namespace System.Linq.Dynamic
 
         public static IQueryable Skip(this IQueryable source, int count)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            ArgumentNullException.ThrowIfNull(source);
             return source.Provider.CreateQuery(
                 Expression.Call(
                     typeof(Queryable), "Skip",
@@ -377,8 +371,7 @@ namespace System.Linq.Dynamic
 
         public ExpressionParser(ParameterExpression[] parameters, string expression, QueryResolver queryResolver)
         {
-            if (expression == null)
-                throw new ArgumentNullException(nameof(expression));
+            ArgumentNullException.ThrowIfNull(expression);
 
             this._queryResolver = queryResolver;
             if (parameters != null)

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Linq/QueryDeserializer.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Linq/QueryDeserializer.cs
@@ -62,10 +62,7 @@ namespace System.Linq.Dynamic
 
             private PostProcessor(DomainServiceDescription domainServiceDescription)
             {
-                if (domainServiceDescription == null)
-                {
-                    throw new ArgumentNullException(nameof(domainServiceDescription));
-                }
+                ArgumentNullException.ThrowIfNull(domainServiceDescription);
 
                 this.domainServiceDescription = domainServiceDescription;
             }

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/DomainServiceEndpointFactory.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/DomainServiceEndpointFactory.cs
@@ -43,10 +43,7 @@ namespace OpenRiaServices.Hosting.Wcf
             }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value);
 
                 this._name = value;
             }

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/DomainServiceHost.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/DomainServiceHost.cs
@@ -35,15 +35,8 @@ namespace OpenRiaServices.Hosting.Wcf
         /// </param>
         public DomainServiceHost(Type domainServiceType, params Uri[] baseAddresses)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
-
-            if (baseAddresses == null)
-            {
-                throw new ArgumentNullException(nameof(baseAddresses));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
+            ArgumentNullException.ThrowIfNull(baseAddresses);
 
             EnableClientAccessAttribute att = (EnableClientAccessAttribute)TypeDescriptor.GetAttributes(domainServiceType)[typeof(EnableClientAccessAttribute)];
 
@@ -71,10 +64,7 @@ namespace OpenRiaServices.Hosting.Wcf
         [Obsolete("Resolve services from DomainService.ServiceContext instead")]
         public object GetService(Type serviceType)
         {
-            if (serviceType == null)
-            {
-                throw new ArgumentNullException(nameof(serviceType));
-            }
+            ArgumentNullException.ThrowIfNull(serviceType);
 
             if (serviceType == typeof(IPrincipal))
             {

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/MessageEncoders/PoxBinaryMessageEncodingBindingElement.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/MessageEncoders/PoxBinaryMessageEncodingBindingElement.cs
@@ -77,10 +77,7 @@ namespace OpenRiaServices.Client.Web
 
         public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             context.BindingParameters.Add(this);
             return context.BuildInnerChannelFactory<TChannel>();
@@ -88,10 +85,7 @@ namespace OpenRiaServices.Client.Web
 
         public override bool CanBuildChannelFactory<TChannel>(BindingContext context)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return context.CanBuildInnerChannelFactory<TChannel>();
         }
@@ -126,10 +120,7 @@ namespace OpenRiaServices.Client.Web
 
             public PoxBinaryMessageEncoderFactory(XmlDictionaryReaderQuotas readerQuotas)
             {
-                if (readerQuotas == null)
-                {
-                    throw new ArgumentNullException(nameof(readerQuotas));
-                }
+                ArgumentNullException.ThrowIfNull(readerQuotas);
                 this._readerQuotas = readerQuotas;
             }
 
@@ -165,14 +156,8 @@ namespace OpenRiaServices.Client.Web
 
             public PoxBinaryMessageEncoder(MessageVersion messageVersion, XmlDictionaryReaderQuotas readerQuotas)
             {
-                if (messageVersion == null)
-                {
-                    throw new ArgumentNullException(nameof(messageVersion));
-                }
-                if (readerQuotas == null)
-                {
-                    throw new ArgumentNullException(nameof(readerQuotas));
-                }
+                ArgumentNullException.ThrowIfNull(messageVersion);
+                ArgumentNullException.ThrowIfNull(readerQuotas);
                 this._readerQuotas = readerQuotas;
                 this._messageVersion = messageVersion;
             }
@@ -203,10 +188,7 @@ namespace OpenRiaServices.Client.Web
 
             public override Message ReadMessage(ArraySegment<byte> buffer, BufferManager bufferManager, string contentType)
             {
-                if (bufferManager == null)
-                {
-                    throw new ArgumentNullException(nameof(bufferManager));
-                }
+                ArgumentNullException.ThrowIfNull(bufferManager);
 
                 ThrowIfIncorrectContentType(contentType);
 #if !SILVERLIGHT
@@ -219,10 +201,7 @@ namespace OpenRiaServices.Client.Web
 
             public override Message ReadMessage(Stream stream, int maxSizeOfHeaders, string contentType)
             {
-                if (stream == null)
-                {
-                    throw new ArgumentNullException(nameof(stream));
-                }
+                ArgumentNullException.ThrowIfNull(stream);
 
                 ThrowIfIncorrectContentType(contentType);
 
@@ -235,11 +214,9 @@ namespace OpenRiaServices.Client.Web
 
             public override ArraySegment<byte> WriteMessage(Message message, int maxMessageSize, BufferManager bufferManager, int messageOffset)
             {
-                if (message == null)
-                    throw new ArgumentNullException(nameof(message));
+                ArgumentNullException.ThrowIfNull(message);
 
-                if (bufferManager == null)
-                    throw new ArgumentNullException(nameof(bufferManager));
+                ArgumentNullException.ThrowIfNull(bufferManager);
 
                 if (maxMessageSize < 0)
                     throw new ArgumentOutOfRangeException(nameof(maxMessageSize));
@@ -251,15 +228,9 @@ namespace OpenRiaServices.Client.Web
 
             public override void WriteMessage(Message message, Stream stream)
             {
-                if (message == null)
-                {
-                    throw new ArgumentNullException(nameof(message));
-                }
+                ArgumentNullException.ThrowIfNull(message);
 
-                if (stream == null)
-                {
-                    throw new ArgumentNullException(nameof(stream));
-                }
+                ArgumentNullException.ThrowIfNull(stream);
 
                 this.ThrowIfInvalidMessageVersion(message);
 
@@ -650,10 +621,7 @@ namespace OpenRiaServices.Client.Web
                     /// <exception cref="ObjectDisposedException" />
                     public override void WriteMessage(Stream stream)
                     {
-                        if (stream == null)
-                        {
-                            throw new ArgumentNullException(nameof(stream));
-                        }
+                        ArgumentNullException.ThrowIfNull(stream);
 
                         lock (this.ThisLock)
                         {

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/MessageEncoders/PoxBinaryMessageEncodingBindingElement.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/MessageEncoders/PoxBinaryMessageEncodingBindingElement.cs
@@ -53,14 +53,8 @@ namespace OpenRiaServices.Client.Web
             }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-                else
-                {
-                    value.CopyTo(this._readerQuotas);
-                }
+                ArgumentNullException.ThrowIfNull(value);
+                value.CopyTo(this._readerQuotas);
             }
         }
 #endif
@@ -93,20 +87,14 @@ namespace OpenRiaServices.Client.Web
 #if NETFRAMEWORK
         public override IChannelListener<TChannel> BuildChannelListener<TChannel>(BindingContext context)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
             context.BindingParameters.Add(this);
             return context.BuildInnerChannelListener<TChannel>();
         }
 
         public override bool CanBuildChannelListener<TChannel>(BindingContext context)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             return context.CanBuildInnerChannelListener<TChannel>();
         }

--- a/src/OpenRiaServices.LinqToSql/Framework/DataContextExtensions.cs
+++ b/src/OpenRiaServices.LinqToSql/Framework/DataContextExtensions.cs
@@ -16,10 +16,7 @@ namespace OpenRiaServices.LinqToSql
         /// <returns>True if the entity is currently attached, false otherwise</returns>
         public static bool IsAttached(this ITable table, object entity)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
 
             // Only way currently to determine if an entity is attached
             // is to see if original state is null

--- a/src/OpenRiaServices.LinqToSql/Framework/LinqToSqlDomainServiceDescriptionProviderAttribute.cs
+++ b/src/OpenRiaServices.LinqToSql/Framework/LinqToSqlDomainServiceDescriptionProviderAttribute.cs
@@ -54,10 +54,7 @@ namespace OpenRiaServices.LinqToSql
         /// <returns>The description provider.</returns>
         public override DomainServiceDescriptionProvider CreateProvider(Type domainServiceType, DomainServiceDescriptionProvider parent)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             if (this._dataContextType == null)
             {

--- a/src/OpenRiaServices.LinqToSql/Framework/LinqToSqlTypeDescriptionContext.cs
+++ b/src/OpenRiaServices.LinqToSql/Framework/LinqToSqlTypeDescriptionContext.cs
@@ -23,10 +23,7 @@ namespace OpenRiaServices.LinqToSql
         /// <param name="dataContextType">The DataContext type</param>
         public LinqToSqlTypeDescriptionContext(Type dataContextType)
         {
-            if (dataContextType == null)
-            {
-                throw new ArgumentNullException(nameof(dataContextType));
-            }
+            ArgumentNullException.ThrowIfNull(dataContextType);
 
             System.Data.Linq.DataContext dataContext = null;
             try

--- a/src/OpenRiaServices.LinqToSql/Framework/OpenRiaServices.LinqToSql.csproj
+++ b/src/OpenRiaServices.LinqToSql/Framework/OpenRiaServices.LinqToSql.csproj
@@ -10,6 +10,7 @@
     <Reference Include="System.Data.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Include="..\..\OpenRiaServices.EntityFramework\Framework\MetadataPropertyDescriptorWrapper.cs" Link="MetadataPropertyDescriptorWrapper.cs" />
     <Compile Include="..\..\OpenRiaServices.EntityFramework\Framework\TypeDescriptionContextBase.cs" Link="TypeDescriptionContextBase.cs" />
     <Compile Include="..\..\OpenRiaServices.EntityFramework\Framework\TypeDescriptorBase.cs" Link="TypeDescriptorBase.cs" />

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/DbContextEFCoreExtensions.cs
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/DbContextEFCoreExtensions.cs
@@ -23,22 +23,10 @@ namespace OpenRiaServices.Server.EntityFrameworkCore
         /// <param name="dbContext">The corresponding <see cref="DbContext"/></param>
         public static void AttachAsModified<T>(this DbSet<T> dbSet, T current, T original, DbContext dbContext) where T : class
         {
-            if (dbSet == null)
-            {
-                throw new ArgumentNullException(nameof(dbSet));
-            }
-            if (current == null)
-            {
-                throw new ArgumentNullException(nameof(current));
-            }
-            if (original == null)
-            {
-                throw new ArgumentNullException(nameof(original));
-            }
-            if (dbContext == null)
-            {
-                throw new ArgumentNullException(nameof(dbContext));
-            }
+            ArgumentNullException.ThrowIfNull(dbSet);
+            ArgumentNullException.ThrowIfNull(current);
+            ArgumentNullException.ThrowIfNull(original);
+            ArgumentNullException.ThrowIfNull(dbContext);
 
             EntityEntry<T> entityEntry = dbContext.Entry(current);
             if (entityEntry.State == EntityState.Detached)
@@ -72,18 +60,9 @@ namespace OpenRiaServices.Server.EntityFrameworkCore
         /// <param name="dbContext">The coresponding <see cref="DbContext"/></param>
         public static void AttachAsModified<T>(this DbSet<T> dbSet, T entity, DbContext dbContext) where T : class
         {
-            if (dbSet == null)
-            {
-                throw new ArgumentNullException(nameof(dbSet));
-            }
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
-            if (dbContext == null)
-            {
-                throw new ArgumentNullException(nameof(dbContext));
-            }
+            ArgumentNullException.ThrowIfNull(dbSet);
+            ArgumentNullException.ThrowIfNull(entity);
+            ArgumentNullException.ThrowIfNull(dbContext);
 
             EntityEntry<T> entityEntry = dbContext.Entry(entity);
             if (entityEntry.State == EntityState.Detached)

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/EFCoreTypeDescriptionContext.cs
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/EFCoreTypeDescriptionContext.cs
@@ -29,10 +29,7 @@ namespace OpenRiaServices.Server.EntityFrameworkCore
         /// <param name="contextType">The ObjectContext Type</param>
         public EFCoreTypeDescriptionContext(Type contextType)
         {
-            if (contextType == null)
-            {
-                throw new ArgumentNullException(nameof(contextType));
-            }
+            ArgumentNullException.ThrowIfNull(contextType);
             _contextType = contextType;
         }
 

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'=='net472'" Version="3.1.24" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'=='net472'" Version="3.1.24" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)'=='net472'" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)'=='net472'" Version="5.2.2" />
     
     <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'=='net8.0'" Version="8.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'=='net8.0'" Version="8.0.*" />

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'=='net472'" Version="3.1.24" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'=='net472'" Version="3.1.24" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)'=='net472'" Version="5.2.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)'=='net472'" Version="7.0.1" />
     
     <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(TargetFramework)'=='net8.0'" Version="8.0.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(TargetFramework)'=='net8.0'" Version="8.0.*" />
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\..\OpenRiaServices.Server\Framework\OpenRiaServices.Server.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\ExceptionHandlingUtility.cs" Link="ExceptionHandlingUtility.cs" />
     <Compile Include="..\..\OpenRiaServices.EntityFramework\Framework\DbDomainService.cs" Link="DbDomainService.cs" />
     <Compile Include="..\..\OpenRiaServices.EntityFramework\Framework\DbDomainServiceDescriptionProviderAttribute.cs" Link="DbDomainService.cs" />

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Test/DbContextModel/EFCoreModels.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Test/DbContextModel/EFCoreModels.csproj
@@ -7,7 +7,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.32" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)'=='net472'" Version="5.2.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)'=='net472'" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Test/DbContextModel/EFCoreModels.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Test/DbContextModel/EFCoreModels.csproj
@@ -7,7 +7,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.32" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)'=='net472'" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(TargetFramework)'=='net472'" Version="5.2.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/DomainServiceTestHost.cs
@@ -107,14 +107,8 @@ namespace OpenRiaServices.Server.UnitTesting
         /// <exception cref="ArgumentNullException">is thrown when <paramref name="user"/> is <c>null</c></exception>
         private DomainServiceTestHost(IDomainServiceFactory factory, IServiceProvider serviceProvider, IPrincipal user)
         {
-            if (serviceProvider == null)
-            {
-                throw new ArgumentNullException(nameof(serviceProvider));
-            }
-            if (user == null)
-            {
-                throw new ArgumentNullException(nameof(user));
-            }
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+            ArgumentNullException.ThrowIfNull(user);
 
             this._factory = factory;
             this._serviceProvider = serviceProvider;
@@ -139,10 +133,7 @@ namespace OpenRiaServices.Server.UnitTesting
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value);
                 this._factory = value;
             }
         }
@@ -165,10 +156,7 @@ namespace OpenRiaServices.Server.UnitTesting
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value);
                 this._serviceProvider = value;
             }
         }
@@ -182,10 +170,7 @@ namespace OpenRiaServices.Server.UnitTesting
             get => _user;
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value);
                 this._user = value;
             }
         }
@@ -1171,10 +1156,7 @@ namespace OpenRiaServices.Server.UnitTesting
 
             public DomainServiceFactory(Func<TDomainService> createDomainService)
             {
-                if (createDomainService == null)
-                {
-                    throw new ArgumentNullException(nameof(createDomainService));
-                }
+                ArgumentNullException.ThrowIfNull(createDomainService);
                 this._createDomainService = createDomainService;
             }
 

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/OpenRiaServices.Server.UnitTesting.csproj
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/OpenRiaServices.Server.UnitTesting.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Update="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/OpenRiaServices.Server.UnitTesting/Framework/OperationContext.cs
+++ b/src/OpenRiaServices.Server.UnitTesting/Framework/OperationContext.cs
@@ -10,18 +10,9 @@ namespace OpenRiaServices.Server.UnitTesting
 
         public OperationContext(DomainServiceContext domainServiceContext, DomainService domainService, DomainServiceDescription domainServiceDescription)
         {
-            if (domainServiceContext == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceContext));
-            }
-            if (domainService == null)
-            {
-                throw new ArgumentNullException(nameof(domainService));
-            }
-            if (domainServiceDescription == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceDescription));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceContext);
+            ArgumentNullException.ThrowIfNull(domainService);
+            ArgumentNullException.ThrowIfNull(domainServiceDescription);
 
             this._domainServiceContext = domainServiceContext;
             this._domainService = domainService;

--- a/src/OpenRiaServices.Server/Framework/Authentication/AuthenticationCodeProcessor.cs
+++ b/src/OpenRiaServices.Server/Framework/Authentication/AuthenticationCodeProcessor.cs
@@ -249,10 +249,7 @@ namespace OpenRiaServices.Server.Authentication
         /// <returns>A collection of comment statements that matches the input resource</returns>
         internal static CodeCommentStatementCollection GetDocComments(string resourceComment)
         {
-            if (resourceComment == null)
-            {
-                throw new ArgumentNullException(nameof(resourceComment));
-            }
+            ArgumentNullException.ThrowIfNull(resourceComment);
 
             var commentCollection = new CodeCommentStatementCollection();
             foreach (string comment in resourceComment.Split(new string[] { Environment.NewLine }, StringSplitOptions.None))

--- a/src/OpenRiaServices.Server/Framework/Data/AuthorizationAttribute.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/AuthorizationAttribute.cs
@@ -42,14 +42,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </returns>
         public AuthorizationResult Authorize(IPrincipal principal, AuthorizationContext authorizationContext)
         {
-            if (principal == null)
-            {
-                throw new ArgumentNullException(nameof(principal));
-            }
-            if (authorizationContext == null)
-            {
-                throw new ArgumentNullException(nameof(authorizationContext));
-            }
+            ArgumentNullException.ThrowIfNull(principal);
+            ArgumentNullException.ThrowIfNull(authorizationContext);
             return this.IsAuthorized(principal, authorizationContext);
         }
 

--- a/src/OpenRiaServices.Server/Framework/Data/AuthorizationContext.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/AuthorizationContext.cs
@@ -103,10 +103,7 @@ namespace System.ComponentModel.DataAnnotations
         public AuthorizationContext(object? instance, string operation, string operationType, AuthorizationContext authorizationContext)
             : this((IServiceProvider) authorizationContext)
         {
-            if (authorizationContext == null)
-            {
-                throw new ArgumentNullException(nameof(authorizationContext));
-            }
+            ArgumentNullException.ThrowIfNull(authorizationContext);
 
             // We use the _items field rather than the property to preserve the lazy instantiation semantics if it's null
             this.Setup(instance, operation, operationType, authorizationContext._items);

--- a/src/OpenRiaServices.Server/Framework/Data/AuthorizationContext.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/AuthorizationContext.cs
@@ -231,17 +231,11 @@ namespace System.ComponentModel.DataAnnotations
             this._instance = instance;
 
             // Operation is required
-            if (string.IsNullOrEmpty(operation))
-            {
-                throw new ArgumentNullException(nameof(operation));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(operation);
             this._operation = operation;
 
             // OperationType is required
-            if (string.IsNullOrEmpty(operationType))
-            {
-                throw new ArgumentNullException(nameof(operationType));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(operationType);
             this._operationType = operationType;
 
             // Snapshot the dictionary if provided, else create lazily on demand

--- a/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
@@ -29,10 +29,7 @@ namespace OpenRiaServices.Server
         /// <exception cref="ArgumentNullException">if <paramref name="changeSetEntries"/> is null.</exception>
         public ChangeSet(IEnumerable<ChangeSetEntry> changeSetEntries)
         {
-            if (changeSetEntries == null)
-            {
-                throw new ArgumentNullException(nameof(changeSetEntries));
-            }
+            ArgumentNullException.ThrowIfNull(changeSetEntries);
 
             // ensure the changeset is valid
             ValidateChangeSetEntries(changeSetEntries);
@@ -245,15 +242,9 @@ namespace OpenRiaServices.Server
         /// the <see cref="ChangeSet"/>'s <see cref="ChangeSetEntry"/> items.</exception>
         public void Replace<TEntity>(TEntity clientEntity, TEntity returnedEntity) where TEntity : class
         {
-            if (clientEntity == null)
-            {
-                throw new ArgumentNullException(nameof(clientEntity));
-            }
+            ArgumentNullException.ThrowIfNull(clientEntity);
 
-            if (returnedEntity == null)
-            {
-                throw new ArgumentNullException(nameof(returnedEntity));
-            }
+            ArgumentNullException.ThrowIfNull(returnedEntity);
 
             Type clientEntityType = clientEntity.GetType();
             Type returnedEntityType = returnedEntity.GetType();
@@ -289,10 +280,7 @@ namespace OpenRiaServices.Server
         /// <exception cref="ArgumentException">if <paramref name="clientEntity"/> is not in the change set.</exception>
         public TEntity GetOriginal<TEntity>(TEntity clientEntity) where TEntity : class
         {
-            if (clientEntity == null)
-            {
-                throw new ArgumentNullException(nameof(clientEntity));
-            }
+            ArgumentNullException.ThrowIfNull(clientEntity);
 
             ChangeSetEntry entry = this._changeSetEntries.FirstOrDefault(p => object.ReferenceEquals(p.Entity, clientEntity));
             if (entry == null)
@@ -317,10 +305,7 @@ namespace OpenRiaServices.Server
         /// <returns>The <see cref="ChangeOperation"/> for the specified object.</returns>
         public ChangeOperation GetChangeOperation(object entity)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
 
             // Rather than error for objects not in the changeset,
             // we need to return 'None', since this method can be
@@ -368,14 +353,8 @@ namespace OpenRiaServices.Server
 
         private IEnumerable GetAssociatedChangesInternal(object entity, LambdaExpression expression, ChangeOperation? operationType)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
-            if (expression == null)
-            {
-                throw new ArgumentNullException(nameof(expression));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
+            ArgumentNullException.ThrowIfNull(expression);
 
             this.VerifyExistsInChangeset(entity);
 
@@ -628,20 +607,11 @@ namespace OpenRiaServices.Server
             where TEntity : class
             where TStoreEntity : class
         {
-            if (clientEntity == null)
-            {
-                throw new ArgumentNullException(nameof(clientEntity));
-            }
+            ArgumentNullException.ThrowIfNull(clientEntity);
 
-            if (storeEntity == null)
-            {
-                throw new ArgumentNullException(nameof(storeEntity));
-            }
+            ArgumentNullException.ThrowIfNull(storeEntity);
 
-            if (storeToClientTransform == null)
-            {
-                throw new ArgumentNullException(nameof(storeToClientTransform));
-            }
+            ArgumentNullException.ThrowIfNull(storeToClientTransform);
 
             // Verify the provided client entity exists in our changeset
             this.VerifyExistsInChangeset(clientEntity);
@@ -732,15 +702,9 @@ namespace OpenRiaServices.Server
             /// <param name="entityTransform">The entity transform.</param>
             public AssociatedEntityInfo(object clientEntity, Action entityTransform)
             {
-                if (clientEntity == null)
-                {
-                    throw new ArgumentNullException(nameof(clientEntity));
-                }
+                ArgumentNullException.ThrowIfNull(clientEntity);
 
-                if (entityTransform == null)
-                {
-                    throw new ArgumentNullException(nameof(entityTransform));
-                }
+                ArgumentNullException.ThrowIfNull(entityTransform);
 
                 this._clientEntity = clientEntity;
                 this._entityTransform = entityTransform;

--- a/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ChangeSet.cs
@@ -641,10 +641,7 @@ namespace OpenRiaServices.Server
         public IEnumerable<TEntity> GetAssociatedEntities<TEntity, TStoreEntity>(TStoreEntity storeEntity)
             where TEntity : class
         {
-            if (storeEntity == null)
-            {
-                throw new ArgumentNullException(nameof(storeEntity));
-            }
+            ArgumentNullException.ThrowIfNull(storeEntity);
 
             List<AssociatedEntityInfo> associatedModels = null;
             if (this.AssociatedStoreEntities.TryGetValue(storeEntity, out associatedModels))

--- a/src/OpenRiaServices.Server/Framework/Data/ChangeSetEntry.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ChangeSetEntry.cs
@@ -39,10 +39,7 @@ namespace OpenRiaServices.Server
         /// <param name="operation">The operation to be performed</param>
         public ChangeSetEntry(int id, object entity, object originalEntity, DomainOperation operation)
         {
-            if (entity == null)
-            {
-                throw new ArgumentNullException(nameof(entity));
-            }
+            ArgumentNullException.ThrowIfNull(entity);
 
             this._id = id;
             this._entity = entity;

--- a/src/OpenRiaServices.Server/Framework/Data/CodeProcessor.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/CodeProcessor.cs
@@ -23,10 +23,7 @@ namespace OpenRiaServices.Server
         /// <param name="codeDomProvider">The <see cref="CodeDomProvider"/> used during <see cref="DomainService"/> code generation.</param>
         protected CodeProcessor(CodeDomProvider codeDomProvider)
         {
-            if (codeDomProvider == null)
-            {
-                throw new ArgumentNullException(nameof(codeDomProvider));
-            }
+            ArgumentNullException.ThrowIfNull(codeDomProvider);
 
             this._codeDomProvider = codeDomProvider;
         }

--- a/src/OpenRiaServices.Server/Framework/Data/DomainOperationEntry.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainOperationEntry.cs
@@ -38,10 +38,7 @@ namespace OpenRiaServices.Server
         /// <param name="attributes">The method level attributes for the operation</param>  
         protected DomainOperationEntry(Type domainServiceType, string name, DomainOperation operation, Type returnType, IEnumerable<DomainOperationParameter> parameters, AttributeCollection attributes)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
             ArgumentNullException.ThrowIfNull(returnType);
             ArgumentNullException.ThrowIfNull(parameters);
             ArgumentNullException.ThrowIfNull(attributes);

--- a/src/OpenRiaServices.Server/Framework/Data/DomainOperationEntry.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainOperationEntry.cs
@@ -38,11 +38,11 @@ namespace OpenRiaServices.Server
         /// <param name="attributes">The method level attributes for the operation</param>  
         protected DomainOperationEntry(Type domainServiceType, string name, DomainOperation operation, Type returnType, IEnumerable<DomainOperationParameter> parameters, AttributeCollection attributes)
         {
+            ArgumentNullException.ThrowIfNull(domainServiceType);
             ArgumentException.ThrowIfNullOrEmpty(name);
             ArgumentNullException.ThrowIfNull(returnType);
             ArgumentNullException.ThrowIfNull(parameters);
             ArgumentNullException.ThrowIfNull(attributes);
-            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             if (operation == DomainOperation.None)
             {

--- a/src/OpenRiaServices.Server/Framework/Data/DomainOperationEntry.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainOperationEntry.cs
@@ -42,22 +42,10 @@ namespace OpenRiaServices.Server
             {
                 throw new ArgumentNullException(nameof(name));
             }
-            if (returnType == null)
-            {
-                throw new ArgumentNullException(nameof(returnType));
-            }
-            if (parameters == null)
-            {
-                throw new ArgumentNullException(nameof(parameters));
-            }
-            if (attributes == null)
-            {
-                throw new ArgumentNullException(nameof(attributes));
-            }
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(returnType);
+            ArgumentNullException.ThrowIfNull(parameters);
+            ArgumentNullException.ThrowIfNull(attributes);
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             if (operation == DomainOperation.None)
             {

--- a/src/OpenRiaServices.Server/Framework/Data/DomainOperationParameter.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainOperationParameter.cs
@@ -21,10 +21,7 @@ namespace OpenRiaServices.Server
         /// <param name="attributes">The set of attributes for the parameter</param>
         public DomainOperationParameter(string name, Type parameterType, AttributeCollection attributes)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             ArgumentNullException.ThrowIfNull(parameterType);
 

--- a/src/OpenRiaServices.Server/Framework/Data/DomainOperationParameter.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainOperationParameter.cs
@@ -26,15 +26,9 @@ namespace OpenRiaServices.Server
                 throw new ArgumentNullException(nameof(name));
             }
 
-            if (parameterType == null)
-            {
-                throw new ArgumentNullException(nameof(parameterType));
-            }
+            ArgumentNullException.ThrowIfNull(parameterType);
 
-            if (attributes == null)
-            {
-                throw new ArgumentNullException(nameof(attributes));
-            }
+            ArgumentNullException.ThrowIfNull(attributes);
 
             Name = name;
             ParameterType = parameterType;

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -146,10 +146,7 @@ namespace OpenRiaServices.Server
         /// </returns>
         public AuthorizationResult IsAuthorized(DomainOperationEntry domainOperationEntry, object? entity)
         {
-            if (domainOperationEntry == null)
-            {
-                throw new ArgumentNullException(nameof(domainOperationEntry));
-            }
+            ArgumentNullException.ThrowIfNull(domainOperationEntry);
 
             // A null entity is not permitted in a Submit.
             // Queries are always null.
@@ -239,10 +236,7 @@ namespace OpenRiaServices.Server
         /// instance. Overrides must call the base method.</param>
         public virtual void Initialize(DomainServiceContext context)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             if (this._serviceContext != null)
             {
@@ -270,10 +264,7 @@ namespace OpenRiaServices.Server
 
             try
             {
-                if (queryDescription == null)
-                {
-                    throw new ArgumentNullException(nameof(queryDescription));
-                }
+                ArgumentNullException.ThrowIfNull(queryDescription);
 
                 this.EnsureInitialized();
                 this.CheckOperationType(DomainOperationType.Query);
@@ -421,10 +412,7 @@ namespace OpenRiaServices.Server
         {
             try
             {
-                if (invokeDescription == null)
-                {
-                    throw new ArgumentNullException(nameof(invokeDescription));
-                }
+                ArgumentNullException.ThrowIfNull(invokeDescription);
 
                 this.EnsureInitialized();
                 this.CheckOperationType(DomainOperationType.Invoke);
@@ -499,10 +487,7 @@ namespace OpenRiaServices.Server
         {
             try
             {
-                if (changeSet == null)
-                {
-                    throw new ArgumentNullException(nameof(changeSet));
-                }
+                ArgumentNullException.ThrowIfNull(changeSet);
                 this._changeSet = changeSet;
 
                 this.EnsureInitialized();
@@ -582,7 +567,7 @@ namespace OpenRiaServices.Server
             {
                 if (attribute is RequiresAuthenticationAttribute)
                 {
-                    AuthorizationResult result = attribute.Authorize(principal, authorizationContext!);
+                    AuthorizationResult result = attribute.Authorize(principal, authorizationContext);
                     if (result != AuthorizationResult.Allowed)
                     {
                         return result;
@@ -596,7 +581,7 @@ namespace OpenRiaServices.Server
             {
                 if (!(attribute is RequiresAuthenticationAttribute))
                 {
-                    AuthorizationResult result = attribute.Authorize(principal, authorizationContext!);
+                    AuthorizationResult result = attribute.Authorize(principal, authorizationContext);
                     if (result != AuthorizationResult.Allowed)
                     {
                         return result;
@@ -1333,10 +1318,7 @@ namespace OpenRiaServices.Server
             /// <param name="domainService">A <see cref="DomainService"/> instance to release.</param>
             public void ReleaseDomainService(DomainService domainService)
             {
-                if (domainService == null)
-                {
-                    throw new ArgumentNullException(nameof(domainService));
-                }
+                ArgumentNullException.ThrowIfNull(domainService);
                 domainService.Dispose();
             }
         }

--- a/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescription.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescription.cs
@@ -48,10 +48,7 @@ namespace OpenRiaServices.Server
         /// <param name="domainServiceType">The Type of the DomainService</param>
         internal DomainServiceDescription(Type domainServiceType)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             this._domainServiceType = domainServiceType;
             this._createSerializationType = (Type type) => this.CreateSerializationType(type);
@@ -63,10 +60,7 @@ namespace OpenRiaServices.Server
         /// <param name="baseDescription">The base <see cref="DomainServiceDescription"/></param>
         internal DomainServiceDescription(DomainServiceDescription baseDescription)
         {
-            if (baseDescription == null)
-            {
-                throw new ArgumentNullException(nameof(baseDescription));
-            }
+            ArgumentNullException.ThrowIfNull(baseDescription);
 
             this._domainServiceType = baseDescription._domainServiceType;
             this._attributes = baseDescription._attributes;
@@ -201,10 +195,7 @@ namespace OpenRiaServices.Server
         {
             this.CheckInvalidUpdate();
 
-            if (operation == null)
-            {
-                throw new ArgumentNullException(nameof(operation));
-            }
+            ArgumentNullException.ThrowIfNull(operation);
 
             if (operation.DomainServiceType != this.DomainServiceType)
             {
@@ -267,10 +258,7 @@ namespace OpenRiaServices.Server
         {
             this.EnsureInitialized();
 
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
             if (string.IsNullOrEmpty(methodName))
             {
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resource.DomainOperationEntry_ArgumentCannotBeNullOrEmpty, "methodName"));
@@ -304,10 +292,7 @@ namespace OpenRiaServices.Server
         {
             this.EnsureInitialized();
 
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
 
             Dictionary<string, DomainOperationEntry> entityCustomMethods = null;
             if (this._customMethods.TryGetValue(entityType, out entityCustomMethods))
@@ -329,10 +314,7 @@ namespace OpenRiaServices.Server
         {
             this.EnsureInitialized();
 
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
             if ((operation != DomainOperation.Insert) &&
                 (operation != DomainOperation.Update) &&
                 (operation != DomainOperation.Delete))
@@ -367,10 +349,7 @@ namespace OpenRiaServices.Server
         {
             this.EnsureInitialized();
 
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
 
             List<PropertyDescriptor> assocList = null;
             if (this._compositionMap.TryGetValue(entityType, out assocList))
@@ -431,10 +410,7 @@ namespace OpenRiaServices.Server
         /// has no base types.</returns>
         public Type GetRootEntityType(Type entityType)
         {
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
 
             EnsureInitialized();
             Type rootType = null;
@@ -464,10 +440,7 @@ namespace OpenRiaServices.Server
         /// <paramref name="entityType"/> had no visible base types.</returns>
         public Type GetEntityBaseType(Type entityType)
         {
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
 
             EnsureInitialized();
             Type baseType = entityType.BaseType;
@@ -489,10 +462,7 @@ namespace OpenRiaServices.Server
         /// <returns>The description for the specified <see cref="DomainService"/> type</returns>
         public static DomainServiceDescription GetDescription(Type domainServiceType)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             if (domainServiceType.IsAbstract
                 || domainServiceType.IsGenericType
@@ -1929,10 +1899,7 @@ namespace OpenRiaServices.Server
         /// <returns><c>True</c> if the operation is supported, <c>false</c> otherwise.</returns>
         public bool IsOperationSupported(Type entityType, DomainOperation operationType)
         {
-            if (entityType == null)
-            {
-                throw new ArgumentNullException(nameof(entityType));
-            }
+            ArgumentNullException.ThrowIfNull(entityType);
 
             if (operationType != DomainOperation.Insert &&
                 operationType != DomainOperation.Update &&

--- a/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescriptionProvider.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescriptionProvider.cs
@@ -26,10 +26,7 @@ namespace OpenRiaServices.Server
         /// <param name="parent">The existing parent description provider. May be null.</param>
         protected DomainServiceDescriptionProvider(Type domainServiceType, DomainServiceDescriptionProvider parent)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             this._domainServiceType = domainServiceType;
             this._parentDescriptionProvider = parent;
@@ -77,14 +74,8 @@ namespace OpenRiaServices.Server
         /// <returns>The <see cref="TypeDescriptor"/> for the specified Type.</returns>
         public virtual ICustomTypeDescriptor GetTypeDescriptor(Type type, ICustomTypeDescriptor parent)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
-            if (parent == null)
-            {
-                throw new ArgumentNullException(nameof(parent));
-            }
+            ArgumentNullException.ThrowIfNull(type);
+            ArgumentNullException.ThrowIfNull(parent);
 
             if (this._parentDescriptionProvider != null)
             {
@@ -106,10 +97,7 @@ namespace OpenRiaServices.Server
         /// <c>false</c> otherwise.</returns>
         public virtual bool LookupIsEntityType(Type type)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
+            ArgumentNullException.ThrowIfNull(type);
 
             return false;
         }
@@ -123,10 +111,7 @@ namespace OpenRiaServices.Server
         /// <returns>The operation attributes.</returns>
         public virtual AttributeCollection GetOperationAttributes(DomainOperationEntry operation)
         {
-            if (operation == null)
-            {
-                throw new ArgumentNullException(nameof(operation));
-            }
+            ArgumentNullException.ThrowIfNull(operation);
 
             if (this._parentDescriptionProvider != null)
             {
@@ -145,10 +130,7 @@ namespace OpenRiaServices.Server
         /// <returns>Returns <c>true</c> if the <see cref="Type"/> is an entity, <c>false</c> otherwise.</returns>
         protected internal bool IsEntityType(Type type)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
+            ArgumentNullException.ThrowIfNull(type);
 
             if (this._isEntityTypeFunc != null)
             {
@@ -184,10 +166,7 @@ namespace OpenRiaServices.Server
         /// <returns>A new description based on the base description.</returns>
         protected DomainServiceDescription CreateDescription(DomainServiceDescription baseDescription)
         {
-            if (baseDescription == null)
-            {
-                throw new ArgumentNullException(nameof(baseDescription));
-            }
+            ArgumentNullException.ThrowIfNull(baseDescription);
             return new DomainServiceDescription(baseDescription);
         }
     }   

--- a/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescriptionProviderAttribute.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainServiceDescriptionProviderAttribute.cs
@@ -18,10 +18,7 @@ namespace OpenRiaServices.Server
         /// <param name="domainServiceDescriptionProviderType">The <see cref="DomainServiceDescriptionProvider"/> type</param>
         public DomainServiceDescriptionProviderAttribute(Type domainServiceDescriptionProviderType)
         {
-            if (domainServiceDescriptionProviderType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceDescriptionProviderType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceDescriptionProviderType);
 
             this._domainServiceDescriptionProviderType = domainServiceDescriptionProviderType;
         }
@@ -57,10 +54,7 @@ namespace OpenRiaServices.Server
         /// <returns>The description provider</returns>
         public virtual DomainServiceDescriptionProvider CreateProvider(Type domainServiceType, DomainServiceDescriptionProvider parent)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
             if (!typeof(DomainService).IsAssignableFrom(domainServiceType))
             {

--- a/src/OpenRiaServices.Server/Framework/Data/DomainTypeDescriptionProvider.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainTypeDescriptionProvider.cs
@@ -18,10 +18,7 @@ namespace OpenRiaServices.Server
         public DomainTypeDescriptionProvider(Type type, DomainServiceDescriptionProvider descriptionProvider)
             : base(TypeDescriptor.GetProvider(type))
         {
-            if (descriptionProvider == null)
-            {
-                throw new ArgumentNullException(nameof(descriptionProvider));
-            }
+            ArgumentNullException.ThrowIfNull(descriptionProvider);
 
             this._type = type;
             this._descriptionProvider = descriptionProvider;

--- a/src/OpenRiaServices.Server/Framework/Data/InvokeDescription.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/InvokeDescription.cs
@@ -18,10 +18,7 @@ namespace OpenRiaServices.Server
         /// <param name="parameterValues">The parameter values for the method if it requires any.</param>
         public InvokeDescription(DomainOperationEntry domainOperationEntry, object[] parameterValues)
         {
-            if (domainOperationEntry == null)
-            {
-                throw new ArgumentNullException(nameof(domainOperationEntry));
-            }
+            ArgumentNullException.ThrowIfNull(domainOperationEntry);
 
             this._domainOperationEntry = domainOperationEntry;
             this._parameterValues = parameterValues;

--- a/src/OpenRiaServices.Server/Framework/Data/QueryDescription.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/QueryDescription.cs
@@ -22,10 +22,7 @@ namespace OpenRiaServices.Server
         /// <param name="domainOperationEntry">The query operation to be processed</param>
         public QueryDescription(DomainOperationEntry domainOperationEntry)
         {
-            if (domainOperationEntry == null)
-            {
-                throw new ArgumentNullException(nameof(domainOperationEntry));
-            }
+            ArgumentNullException.ThrowIfNull(domainOperationEntry);
             if (domainOperationEntry.Operation != DomainOperation.Query)
             {
                 throw new ArgumentOutOfRangeException(nameof(domainOperationEntry));
@@ -42,10 +39,7 @@ namespace OpenRiaServices.Server
         /// <param name="parameterValues">Parameter values for the method if it requires any</param>
         public QueryDescription(DomainOperationEntry domainOperationEntry, object[] parameterValues) : this(domainOperationEntry)
         {
-            if (parameterValues == null)
-            {
-                throw new ArgumentNullException(nameof(parameterValues));
-            }
+            ArgumentNullException.ThrowIfNull(parameterValues);
 
             this._parameterValues = parameterValues;
         }

--- a/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ReflectionDomainServiceDescriptionProvider.cs
@@ -400,10 +400,7 @@ namespace OpenRiaServices.Server
             public ReflectionDomainOperationEntry(Type domainServiceType, MethodInfo methodInfo, DomainOperation operation)
                 : base(domainServiceType, methodInfo.Name, operation, methodInfo.ReturnType, GetMethodParameters(methodInfo), GetAttributeCollection(methodInfo))
             {
-                if (methodInfo == null)
-                {
-                    throw new ArgumentNullException(nameof(methodInfo));
-                }
+                ArgumentNullException.ThrowIfNull(methodInfo);
 
                 // Generic methods aren’t supported, and will be caught during DomainServiceDescription validation.
                 if (!methodInfo.IsGenericMethodDefinition)

--- a/src/OpenRiaServices.Server/Framework/Data/ServiceInvokeResult.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ServiceInvokeResult.cs
@@ -29,8 +29,7 @@ namespace OpenRiaServices.Server
         /// <param name="validationErrors">the validation errors, should <c>never</c> be modified after beeing passed in</param>
         public ServiceInvokeResult(IReadOnlyCollection<ValidationResult> validationErrors)
         {
-            if (validationErrors == null)
-                throw new ArgumentNullException(nameof(validationErrors));
+            ArgumentNullException.ThrowIfNull(validationErrors);
             if (validationErrors.Count == 0)
                 throw new ArgumentException(Resource.ValidationErrorsCannotBeEmpty, nameof(validationErrors));
 

--- a/src/OpenRiaServices.Server/Framework/Data/ServiceQueryResult.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/ServiceQueryResult.cs
@@ -29,8 +29,7 @@ namespace OpenRiaServices.Server
         /// <param name="validationErrors">the validation errors, should <c>never</c> be modified after beeing passed in</param>
         public ServiceQueryResult(IReadOnlyCollection<ValidationResult> validationErrors)
         {
-            if (validationErrors == null)
-                throw new ArgumentNullException(nameof(validationErrors));
+            ArgumentNullException.ThrowIfNull(validationErrors);
             if (validationErrors.Count == 0)
                 throw new ArgumentException(Resource.ValidationErrorsCannotBeEmpty, nameof(validationErrors));
 

--- a/src/OpenRiaServices.Server/Test/AuthorizationContextTests.cs
+++ b/src/OpenRiaServices.Server/Test/AuthorizationContextTests.cs
@@ -53,11 +53,11 @@ namespace OpenRiaServices.Server.Test
         {
             // Operation param cannot be null or empty
             ExceptionHelper.ExpectArgumentNullExceptionStandard(() => new AuthorizationContext(/*instance*/ null, /*operation*/ null, "operationType", /*serviceProvider*/ null, items: null), "operation");
-            ExceptionHelper.ExpectArgumentNullExceptionStandard(() => new AuthorizationContext(/*instance*/ null, /*operation*/ string.Empty, "operationType", /*serviceProvider*/ null, items: null), "operation");
+            ExceptionHelper.ExpectEmptyStringArgumentException(() => new AuthorizationContext(/*instance*/ null, /*operation*/ string.Empty, "operationType", /*serviceProvider*/ null, items: null), "operation");
 
             // Operation param cannot be null or empty
             ExceptionHelper.ExpectArgumentNullExceptionStandard(() => new AuthorizationContext(/*instance*/ null, "operation", /*operationType*/ null, /*serviceProvider*/ null, items: null), "operationType");
-            ExceptionHelper.ExpectArgumentNullExceptionStandard(() => new AuthorizationContext(/*instance*/ null, "operation", /*operationType*/ string.Empty, /*serviceProvider*/ null, items: null), "operationType");
+            ExceptionHelper.ExpectEmptyStringArgumentException(() => new AuthorizationContext(/*instance*/ null, "operation", /*operationType*/ string.Empty, /*serviceProvider*/ null, items: null), "operationType");
 
             string instance = "mockEntity";   // type is only required to be object
             string operation = "testOp";

--- a/src/OpenRiaServices.Tools.CodeGenTask/OpenRiaServices.Tools.CodeGenTask.csproj
+++ b/src/OpenRiaServices.Tools.CodeGenTask/OpenRiaServices.Tools.CodeGenTask.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\OpenRiaServices.Tools\Framework\OpenRiaServices.Tools.csproj" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.10.12" />
-    <PackageReference Include="System.CommandLine" Version="2.0.5" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/AttributeGenerationHelpers/AttributeGeneratorHelper.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/AttributeGenerationHelpers/AttributeGeneratorHelper.cs
@@ -195,10 +195,7 @@ namespace OpenRiaServices.Tools.TextTemplate
 
         private static ICustomAttributeBuilder GetCustomAttributeBuilder(Type attributeType)
         {
-            if (attributeType == null)
-            {
-                throw new ArgumentNullException(nameof(attributeType));
-            }
+            ArgumentNullException.ThrowIfNull(attributeType);
 
             ICustomAttributeBuilder cab = null;
 

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/OpenRiaServices.Tools.TextTemplate.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/OpenRiaServices.Tools.TextTemplate.csproj
@@ -10,6 +10,7 @@
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Include="..\..\OpenRiaServices.Tools\Framework\SharedCodeGenUtilities.cs" Link="Utilities\SharedCodeGenUtilities.cs" />
     <Compile Include="..\..\OpenRiaServices.Tools\Framework\MetadataPipeline\AttributeBuilderException.cs" Link="CSharpGenerators\AttributeGenerationHelpers\AttributeBuilderException.cs" />
     <Compile Include="..\..\OpenRiaServices.Tools\Framework\MetadataPipeline\AttributeDeclaration.cs" Link="CSharpGenerators\AttributeGenerationHelpers\AttributeDeclaration.cs" />

--- a/src/OpenRiaServices.Tools/Framework/ClientCodeGenerationOptions.cs
+++ b/src/OpenRiaServices.Tools/Framework/ClientCodeGenerationOptions.cs
@@ -27,10 +27,7 @@ namespace OpenRiaServices.Tools
             }
             set
             {
-                if (string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentNullException(nameof(value), Resource.Null_Language_Property);
-                }
+                ArgumentException.ThrowIfNullOrEmpty(value);
                 this._language = value;
             }
         }

--- a/src/OpenRiaServices.Tools/Framework/ClientProxyFixupCodeDomVisitor.cs
+++ b/src/OpenRiaServices.Tools/Framework/ClientProxyFixupCodeDomVisitor.cs
@@ -20,10 +20,7 @@ namespace OpenRiaServices.Tools
         /// <param name="options">The current <see cref="ClientCodeGenerationOptions"/> options.</param>
         public ClientProxyFixupCodeDomVisitor(ClientCodeGenerationOptions options)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
+            ArgumentNullException.ThrowIfNull(options);
 
             this._options = options;
             this._isCSharp = (this._options.Language == "C#");

--- a/src/OpenRiaServices.Tools/Framework/CodeDomClientCodeGenerator.cs
+++ b/src/OpenRiaServices.Tools/Framework/CodeDomClientCodeGenerator.cs
@@ -71,20 +71,11 @@ namespace OpenRiaServices.Tools
 
         internal void Initialize(ICodeGenerationHost host, IEnumerable<DomainServiceDescription> descriptions, ClientCodeGenerationOptions options)
         {
-            if (host == null)
-            {
-                throw new ArgumentNullException(nameof(host));
-            }
+            ArgumentNullException.ThrowIfNull(host);
 
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
+            ArgumentNullException.ThrowIfNull(options);
 
-            if (descriptions == null)
-            {
-                throw new ArgumentNullException(nameof(descriptions));
-            }
+            ArgumentNullException.ThrowIfNull(descriptions);
 
             // Initialize all the instance variables
             this._host = host;
@@ -551,10 +542,7 @@ namespace OpenRiaServices.Tools
         private static void ValidateOptions(ClientCodeGenerationOptions clientProxyCodeGenerationOptions)
         {
             // A null is not acceptable
-            if (clientProxyCodeGenerationOptions == null)
-            {
-                throw new ArgumentNullException(nameof(clientProxyCodeGenerationOptions));
-            }
+            ArgumentNullException.ThrowIfNull(clientProxyCodeGenerationOptions);
 
             // The language property may not be null.
             if (String.IsNullOrEmpty(clientProxyCodeGenerationOptions.Language))

--- a/src/OpenRiaServices.Tools/Framework/CodeDomVisitor.cs
+++ b/src/OpenRiaServices.Tools/Framework/CodeDomVisitor.cs
@@ -15,10 +15,7 @@ namespace OpenRiaServices.Tools
         /// <param name="codeCompileUnit">The <see cref="CodeCompileUnit"/> to visit.</param>
         public void Visit(CodeCompileUnit codeCompileUnit)
         {
-            if (codeCompileUnit == null)
-            {
-                throw new ArgumentNullException(nameof(codeCompileUnit));
-            }
+            ArgumentNullException.ThrowIfNull(codeCompileUnit);
 
             this.VisitBase(codeCompileUnit);
         }

--- a/src/OpenRiaServices.Tools/Framework/CodeGenUtilities.cs
+++ b/src/OpenRiaServices.Tools/Framework/CodeGenUtilities.cs
@@ -803,10 +803,7 @@ namespace OpenRiaServices.Tools
         /// <returns>A collection of comment statements that matches the input resource</returns>
         internal static CodeCommentStatementCollection GetDocComments(string resourceComment, bool isCSharp)
         {
-            if (resourceComment == null)
-            {
-                throw new ArgumentNullException(nameof(resourceComment));
-            }
+            ArgumentNullException.ThrowIfNull(resourceComment);
 
             CodeCommentStatementCollection commentCollection = new CodeCommentStatementCollection();
             foreach (string comment in resourceComment.Split(new string[] { Environment.NewLine }, StringSplitOptions.None))

--- a/src/OpenRiaServices.Tools/Framework/CodeGenUtilities.cs
+++ b/src/OpenRiaServices.Tools/Framework/CodeGenUtilities.cs
@@ -476,10 +476,7 @@ namespace OpenRiaServices.Tools
         /// <returns>A string representing the safe type name.</returns>
         private static string GetSafeTypeName(string typeFullName, string containingNamespace, bool userType)
         {
-            if (string.IsNullOrEmpty(typeFullName))
-            {
-                throw new ArgumentNullException(nameof(typeFullName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(typeFullName);
 
             string typeName = typeFullName;
             string typeNamespace = string.Empty;
@@ -825,10 +822,7 @@ namespace OpenRiaServices.Tools
         /// reference error.</returns>
         private static bool RegisterTypeName(string typeNamespace, string typeName, string containingNamespace)
         {
-            if (string.IsNullOrEmpty(typeName))
-            {
-                throw new ArgumentNullException(nameof(typeName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(typeName);
 
             if (isVisualBasic || (containingNamespace == null))
             {

--- a/src/OpenRiaServices.Tools/Framework/DomainServiceCatalog.cs
+++ b/src/OpenRiaServices.Tools/Framework/DomainServiceCatalog.cs
@@ -27,15 +27,9 @@ namespace OpenRiaServices.Tools
         /// <exception cref="ArgumentNullException"> is thrown if <paramref name="assembliesToLoad"/> or <paramref name="logger"/> is null.</exception>
         public DomainServiceCatalog(IEnumerable<string> assembliesToLoad, ILogger logger)
         {
-            if (assembliesToLoad == null)
-            {
-                throw new ArgumentNullException(nameof(assembliesToLoad));
-            }
+            ArgumentNullException.ThrowIfNull(assembliesToLoad);
 
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+            ArgumentNullException.ThrowIfNull(logger);
 
             this._logger = logger;
 
@@ -54,15 +48,9 @@ namespace OpenRiaServices.Tools
         /// <exception cref="ArgumentNullException"> is thrown if <paramref name="domainServiceType"/> or <paramref name="logger"/> is null.</exception>
         public DomainServiceCatalog(Type domainServiceType, ILogger logger)
         {
-            if (domainServiceType == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceType));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceType);
 
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+            ArgumentNullException.ThrowIfNull(logger);
 
             this._logger = logger;
 
@@ -77,15 +65,9 @@ namespace OpenRiaServices.Tools
         /// <exception cref="ArgumentNullException"> is thrown if <paramref name="domainServiceTypes"/> or <paramref name="logger"/> is null.</exception>
         public DomainServiceCatalog(IEnumerable<Type> domainServiceTypes, ILogger logger)
         {
-            if (domainServiceTypes == null)
-            {
-                throw new ArgumentNullException(nameof(domainServiceTypes));
-            }
+            ArgumentNullException.ThrowIfNull(domainServiceTypes);
 
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+            ArgumentNullException.ThrowIfNull(logger);
 
             this._logger = logger;
 

--- a/src/OpenRiaServices.Tools/Framework/EndpointRoutePattern.cs
+++ b/src/OpenRiaServices.Tools/Framework/EndpointRoutePattern.cs
@@ -5,7 +5,7 @@
 namespace OpenRiaServices.Tools
 {
     /// <summary>
-    /// IMPORTANT: THIS IS AN EXACT copy of <see cref="Server.EndpointRoutePattern"/> where all values are identical.
+    /// IMPORTANT: THIS IS AN EXACT copy of <c>Server.EndpointRoutePattern</c> where all values are identical.
     /// We don't use the server version in the options because we don't want to load in the Server assembly until a bit later
     /// after the options are created.
     /// </summary>

--- a/src/OpenRiaServices.Tools/Framework/LinkedServerProjectCache.cs
+++ b/src/OpenRiaServices.Tools/Framework/LinkedServerProjectCache.cs
@@ -33,15 +33,9 @@ namespace OpenRiaServices.Tools
         /// <param name="projectFileReader">Instance to use to read the project files.</param>
         internal LinkedServerProjectCache(string rootProjectPath, string historyFilePath, ILogger logger, ProjectFileReader projectFileReader)
         {
-            if (string.IsNullOrEmpty(rootProjectPath))
-            {
-                throw new ArgumentNullException(nameof(rootProjectPath));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(rootProjectPath);
 
-            if (string.IsNullOrEmpty(historyFilePath))
-            {
-                throw new ArgumentNullException(nameof(historyFilePath));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(historyFilePath);
 
             ArgumentNullException.ThrowIfNull(logger);
 
@@ -112,20 +106,14 @@ namespace OpenRiaServices.Tools
         {
             get
             {
-                if (string.IsNullOrEmpty(projectPath))
-                {
-                    throw new ArgumentNullException(nameof(projectPath));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(projectPath);
                 string result = null;
                 this.LinkedServerProjectsByProject.TryGetValue(projectPath, out result);
                 return result;
             }
             set
             {
-                if (string.IsNullOrEmpty(projectPath))
-                {
-                    throw new ArgumentNullException(nameof(projectPath));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(projectPath);
                 this.LinkedServerProjectsByProject[projectPath] = value;
                 this.IsFileCacheCurrent = false;
             }

--- a/src/OpenRiaServices.Tools/Framework/LinkedServerProjectCache.cs
+++ b/src/OpenRiaServices.Tools/Framework/LinkedServerProjectCache.cs
@@ -43,15 +43,9 @@ namespace OpenRiaServices.Tools
                 throw new ArgumentNullException(nameof(historyFilePath));
             }
 
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+            ArgumentNullException.ThrowIfNull(logger);
 
-            if (projectFileReader == null)
-            {
-                throw new ArgumentNullException(nameof(projectFileReader));
-            }
+            ArgumentNullException.ThrowIfNull(projectFileReader);
 
             this._rootProjectPath = rootProjectPath;
             this._historyFilePath = historyFilePath;

--- a/src/OpenRiaServices.Tools/Framework/MetadataPipeline/AttributeDeclaration.cs
+++ b/src/OpenRiaServices.Tools/Framework/MetadataPipeline/AttributeDeclaration.cs
@@ -23,10 +23,7 @@ namespace OpenRiaServices.Tools
         /// <param name="attributeType">The <see cref="Attribute"/> <see cref="Type"/> to represent. Cannot be null.</param>
         public AttributeDeclaration(Type attributeType)
         {
-            if (attributeType == null)
-            {
-                throw new ArgumentNullException(nameof(attributeType));
-            }
+            ArgumentNullException.ThrowIfNull(attributeType);
 
             this._attributeType = attributeType;
             this._errors = new List<string>();

--- a/src/OpenRiaServices.Tools/Framework/MetadataPipeline/CustomAttributeGenerator.cs
+++ b/src/OpenRiaServices.Tools/Framework/MetadataPipeline/CustomAttributeGenerator.cs
@@ -313,10 +313,7 @@ namespace OpenRiaServices.Tools
         /// <returns>The custom attribute builder for it.</returns>
         private static ICustomAttributeBuilder GetCustomAttributeBuilder(Type attributeType)
         {
-            if (attributeType == null)
-            {
-                throw new ArgumentNullException(nameof(attributeType));
-            }
+            ArgumentNullException.ThrowIfNull(attributeType);
 
             ICustomAttributeBuilder cab = null;
 

--- a/src/OpenRiaServices.Tools/Framework/MetadataPipeline/StandardCustomAttributeBuilder.cs
+++ b/src/OpenRiaServices.Tools/Framework/MetadataPipeline/StandardCustomAttributeBuilder.cs
@@ -23,10 +23,7 @@ namespace OpenRiaServices.Tools
         /// <returns>A <see cref="AttributeDeclaration"/> representing the <paramref name="attribute"/>.</returns>
         public virtual AttributeDeclaration GetAttributeDeclaration(Attribute attribute)
         {
-            if (attribute == null)
-            {
-                throw new ArgumentNullException(nameof(attribute));
-            }
+            ArgumentNullException.ThrowIfNull(attribute);
 
             Type attributeType = attribute.GetType();
             AttributeDeclaration attributeDeclaration = new AttributeDeclaration(attributeType);

--- a/src/OpenRiaServices.Tools/Framework/OpenRiaServices.Tools.csproj
+++ b/src/OpenRiaServices.Tools/Framework/OpenRiaServices.Tools.csproj
@@ -65,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\OpenRiaServices.Client\Framework\BinaryTypeUtility.cs" Link="BinaryTypeUtility.cs" />
+    <Compile Include="..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\TypeUtility.cs" Link="TypeUtility.cs" />
     <Compile Include="..\..\OpenRiaServices.Server\Framework\SerializationUtility.cs" Link="SerializationUtility.cs" />
     <Compile Include="..\..\OpenRiaServices.Client\Framework\ExceptionHandlingUtility.cs" Link="ExceptionHandlingUtility.cs" />

--- a/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
+++ b/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
@@ -76,10 +76,7 @@ namespace OpenRiaServices.Tools
         /// <returns>The project instance or null if it does not exist</returns>
         internal Project LoadProject(string projectPath)
         {
-            if (string.IsNullOrEmpty(projectPath))
-            {
-                throw new ArgumentNullException(nameof(projectPath));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(projectPath);
 
             if (!File.Exists(projectPath))
             {

--- a/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
+++ b/src/OpenRiaServices.Tools/Framework/ProjectFileReader.cs
@@ -24,10 +24,7 @@ namespace OpenRiaServices.Tools
         /// <param name="logger">The <see cref="ILogger"/> to use for warnings and errors.</param>
         internal ProjectFileReader(ILogger logger)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+            ArgumentNullException.ThrowIfNull(logger);
 
             this._logger = logger;
         }

--- a/src/OpenRiaServices.Tools/Framework/ProjectSourceFileCache.cs
+++ b/src/OpenRiaServices.Tools/Framework/ProjectSourceFileCache.cs
@@ -49,15 +49,9 @@ namespace OpenRiaServices.Tools
                 throw new ArgumentNullException(nameof(historyFilePath));
             }
 
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+            ArgumentNullException.ThrowIfNull(logger);
 
-            if (projectFileReader == null)
-            {
-                throw new ArgumentNullException(nameof(projectFileReader));
-            }
+            ArgumentNullException.ThrowIfNull(projectFileReader);
 
             this._rootProjectPath = rootProjectPath;
             this._historyFilePath = historyFilePath;

--- a/src/OpenRiaServices.Tools/Framework/ProjectSourceFileCache.cs
+++ b/src/OpenRiaServices.Tools/Framework/ProjectSourceFileCache.cs
@@ -39,15 +39,9 @@ namespace OpenRiaServices.Tools
         /// <param name="projectFileReader">Instance to use to read the project files.</param>
         internal ProjectSourceFileCache(string rootProjectPath, string historyFilePath, ILogger logger, ProjectFileReader projectFileReader)
         {
-            if (string.IsNullOrEmpty(rootProjectPath))
-            {
-                throw new ArgumentNullException(nameof(rootProjectPath));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(rootProjectPath);
 
-            if (string.IsNullOrEmpty(historyFilePath))
-            {
-                throw new ArgumentNullException(nameof(historyFilePath));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(historyFilePath);
 
             ArgumentNullException.ThrowIfNull(logger);
 
@@ -115,20 +109,14 @@ namespace OpenRiaServices.Tools
         {
             get
             {
-                if (string.IsNullOrEmpty(projectPath))
-                {
-                    throw new ArgumentNullException(nameof(projectPath));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(projectPath);
                 IEnumerable<string> result = null;
                 this.SourceFilesByProject.TryGetValue(projectPath, out result);
                 return result;
             }
             set
             {
-                if (string.IsNullOrEmpty(projectPath))
-                {
-                    throw new ArgumentNullException(nameof(projectPath));
-                }
+                ArgumentException.ThrowIfNullOrEmpty(projectPath);
                 this.IsFileCacheCurrent = false;
                 this.SourceFilesByProject[projectPath] = value;
             }
@@ -162,10 +150,7 @@ namespace OpenRiaServices.Tools
         /// </returns>
         internal IEnumerable<string> GetSourceFilesInProject(string projectPath)
         {
-            if (string.IsNullOrEmpty(projectPath))
-            {
-                throw new ArgumentNullException(nameof(projectPath));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(projectPath);
             IEnumerable<string> files = null;
             this.GetOrLoadSourceFilesByProject().TryGetValue(projectPath, out files);
             return files;

--- a/src/OpenRiaServices.Tools/Framework/RiaClientFilesTask.cs
+++ b/src/OpenRiaServices.Tools/Framework/RiaClientFilesTask.cs
@@ -695,10 +695,7 @@ namespace OpenRiaServices.Tools
         /// <returns>The input <paramref name="path"/> without any trailing slashes</returns>
         internal static string NormalizeFolderPath(string path)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
+            ArgumentNullException.ThrowIfNull(path);
 
             // Empty paths are not accepted by Path.GetFullPath
             if (path.Length > 0)

--- a/src/OpenRiaServices.Tools/Framework/SharedTypes/SharedAssemblies.cs
+++ b/src/OpenRiaServices.Tools/Framework/SharedTypes/SharedAssemblies.cs
@@ -27,10 +27,7 @@ namespace OpenRiaServices.Tools.SharedTypes
         /// <param name="logger">Optional logger to use to report errors or warnings</param>
         public SharedAssemblies(IEnumerable<string> assemblyFileNames, IEnumerable<string> assemblySearchPaths, ILogger logger)
         {
-            if (assemblyFileNames == null)
-            {
-                throw new ArgumentNullException(nameof(assemblyFileNames));
-            }
+            ArgumentNullException.ThrowIfNull(assemblyFileNames);
             _logger = logger;
             _sharedTypeByName = new Dictionary<string, TypeInfo>(StringComparer.Ordinal);
             _resolver = new CustomAssemblyResolver(assemblySearchPaths ?? Enumerable.Empty<string>());

--- a/src/OpenRiaServices.Tools/Framework/SharedTypes/SourceFileLocationService.cs
+++ b/src/OpenRiaServices.Tools/Framework/SharedTypes/SourceFileLocationService.cs
@@ -60,10 +60,7 @@
         /// </returns>
         public IEnumerable<string> GetFilesForType(Type type)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
+            ArgumentNullException.ThrowIfNull(type);
 
             //  Get the list of members for this type
             IEnumerable<MemberInfo> memberInfos = this.GetMembersForType(type);
@@ -84,10 +81,7 @@
         /// <returns>The full path of the source file or null if it cannot be determined.</returns>
         public string GetFileForMember(MemberInfo memberInfo)
         {
-            if (memberInfo == null)
-            {
-                throw new ArgumentNullException(nameof(memberInfo));
-            }
+            ArgumentNullException.ThrowIfNull(memberInfo);
 
             // Either load the members or retrieve them from the cache.
             // In either case, this memberInfo should be in the cache after the call.

--- a/src/OpenRiaServices.Tools/Framework/ValidateDomainServicesTask.cs
+++ b/src/OpenRiaServices.Tools/Framework/ValidateDomainServicesTask.cs
@@ -183,10 +183,7 @@ namespace OpenRiaServices.Tools
 
             public TaskLoggingHelperLoggingService(TaskLoggingHelper log)
             {
-                if (log == null)
-                {
-                    throw new ArgumentNullException(nameof(log));
-                }
+                ArgumentNullException.ThrowIfNull(log);
 
                 this._log = log;
             }

--- a/src/OpenRiaServices.Tools/Framework/Validation/DomainServiceValidator.cs
+++ b/src/OpenRiaServices.Tools/Framework/Validation/DomainServiceValidator.cs
@@ -17,14 +17,8 @@ namespace OpenRiaServices.Tools.Validation
     {
         public void Validate(string[] assemblies, ILoggingService logger)
         {
-            if (assemblies == null)
-            {
-                throw new ArgumentNullException(nameof(assemblies));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+            ArgumentNullException.ThrowIfNull(assemblies);
+            ArgumentNullException.ThrowIfNull(logger);
 
             // Just creating an instance of the DomainServiceCatalog will locate all the DomainServices in the specified
             // assemblies and use their corresponding DomainServiceDescriptions to identify and report errors. These

--- a/src/OpenRiaServices.Tools/Test/ClientCodeGenerationOptionsTests.cs
+++ b/src/OpenRiaServices.Tools/Test/ClientCodeGenerationOptionsTests.cs
@@ -33,8 +33,8 @@ namespace OpenRiaServices.Tools.Test
             Assert.IsFalse(options.UseFullTypeNames);
 
             // Null languge throws
-            ExceptionHelper.ExpectArgumentNullException(() => options.Language = null, Resource.Null_Language_Property, "value");
-            ExceptionHelper.ExpectArgumentNullException(() => options.Language = string.Empty, Resource.Null_Language_Property, "value");
+            ExceptionHelper.ExpectArgumentNullException(() => options.Language = null, "value");
+            ExceptionHelper.ExpectEmptyStringArgumentException(() => options.Language = string.Empty, "value");
 
             // Now test a range of values for each property
             foreach (string language in new string[] { "C#", "VB", "notALanguage" })

--- a/src/OpenRiaServices.Tools/Test/LinkedServerProjectCacheTests.cs
+++ b/src/OpenRiaServices.Tools/Test/LinkedServerProjectCacheTests.cs
@@ -29,11 +29,11 @@ namespace OpenRiaServices.Tools.Test
             {
                 // Null project  file throws
                 ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new LinkedServerProjectCache(null, "breadCrumb", logger, projectFileReader), "rootProjectPath");
-                ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new LinkedServerProjectCache(String.Empty, "breadCrumb", logger, projectFileReader), "rootProjectPath");
+                ExceptionHelper.ExpectEmptyStringArgumentException(() => cache = new LinkedServerProjectCache(string.Empty, "breadCrumb", logger, projectFileReader), "rootProjectPath");
 
                 // Null logger throws
                 ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new LinkedServerProjectCache("proj", null, logger, projectFileReader), "historyFilePath");
-                ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new LinkedServerProjectCache("proj", String.Empty, logger, projectFileReader), "historyFilePath");
+                ExceptionHelper.ExpectEmptyStringArgumentException(() => cache = new LinkedServerProjectCache("proj", string.Empty, logger, projectFileReader), "historyFilePath");
 
                 // Null logger throws
                 ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new LinkedServerProjectCache("proj", "breadCrumb", null, projectFileReader), "logger");
@@ -65,12 +65,12 @@ namespace OpenRiaServices.Tools.Test
 
                     // Null indexer parameter throws on sets
                     ExceptionHelper.ExpectArgumentNullExceptionStandard((() => cache[null] = "x"), "projectPath");
-                    ExceptionHelper.ExpectArgumentNullExceptionStandard((() => cache[string.Empty] = "x"), "projectPath");
+                    ExceptionHelper.ExpectEmptyStringArgumentException((() => cache[string.Empty] = "x"), "projectPath");
 
                     // Null indexer parameter throws on gets
                     string unused;
                     ExceptionHelper.ExpectArgumentNullExceptionStandard((() => unused = cache[null]), "projectPath");
-                    ExceptionHelper.ExpectArgumentNullExceptionStandard((() => unused = cache[string.Empty]), "projectPath");
+                    ExceptionHelper.ExpectEmptyStringArgumentException((() => unused = cache[string.Empty]), "projectPath");
 
                     // Indexer setter can be called with valid values
                     cache["proj1"] = "proj1.Web";

--- a/src/OpenRiaServices.Tools/Test/ProjectSourceFileCacheTests.cs
+++ b/src/OpenRiaServices.Tools/Test/ProjectSourceFileCacheTests.cs
@@ -30,11 +30,11 @@ namespace OpenRiaServices.Tools.Test
             {
                 // Null/empty server project throws
                 ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new ProjectSourceFileCache(null, "breadCrumb", logger, projectFileReader), "rootProjectPath");
-                ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new ProjectSourceFileCache(string.Empty, "breadCrumb", logger, projectFileReader), "rootProjectPath");
+                ExceptionHelper.ExpectEmptyStringArgumentException(() => cache = new ProjectSourceFileCache(string.Empty, "breadCrumb", logger, projectFileReader), "rootProjectPath");
 
                 // Null/empty bread crumb file throws
                 ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new ProjectSourceFileCache("proj", null, logger, projectFileReader), "historyFilePath");
-                ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new ProjectSourceFileCache("proj", string.Empty, logger, projectFileReader), "historyFilePath");
+                ExceptionHelper.ExpectEmptyStringArgumentException(() => cache = new ProjectSourceFileCache("proj", string.Empty, logger, projectFileReader), "historyFilePath");
 
                 // Null logger throws
                 ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache = new ProjectSourceFileCache("proj", "breadCrumb", null, projectFileReader), "logger");
@@ -92,11 +92,11 @@ namespace OpenRiaServices.Tools.Test
 
                 // ArgNull exception on null/empty index setter
                 ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache[null] = new string[] { "a" }, "projectPath");
-                ExceptionHelper.ExpectArgumentNullExceptionStandard(() => cache[string.Empty] = new string[] { "a" }, "projectPath");
+                ExceptionHelper.ExpectEmptyStringArgumentException(() => cache[string.Empty] = new string[] { "a" }, "projectPath");
 
                 // ArgNull exception on null/empty index getter
                 ExceptionHelper.ExpectArgumentNullExceptionStandard(() => files = cache[null], "projectPath");
-                ExceptionHelper.ExpectArgumentNullExceptionStandard(() => files = cache[string.Empty], "projectPath");
+                ExceptionHelper.ExpectEmptyStringArgumentException(() => files = cache[string.Empty], "projectPath");
             }
         }
 

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
@@ -267,5 +267,11 @@ namespace OpenRiaServices.Client.Test
             Assert.AreEqual(message, e.Message);
             return e;
         }
+
+        internal static void ExpectEmptyStringArgumentException(Action value, string paramName)
+        {
+            var ex = Assert.ThrowsExactly<ArgumentException>(value);
+            Assert.AreEqual(paramName, ex.ParamName);
+        }
     }
 }

--- a/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.Test/ExceptionHelper.cs
@@ -253,10 +253,7 @@ namespace OpenRiaServices.Client.Test
         {
             WebException e = ExpectExceptionHelper<WebException>(del);
 
-#if !SILVERLIGHT // Message is set to "" in Silverlight in some cases
             Assert.AreEqual(message, e.Message);
-#endif
-
             Assert.AreEqual(webExceptionStatus, e.Status);
             return e;
         }
@@ -268,10 +265,11 @@ namespace OpenRiaServices.Client.Test
             return e;
         }
 
-        internal static void ExpectEmptyStringArgumentException(Action value, string paramName)
+        public static void ExpectEmptyStringArgumentException(Action value, string paramName)
         {
             var ex = Assert.ThrowsExactly<ArgumentException>(value);
             Assert.AreEqual(paramName, ex.ParamName);
+            Assert.Contains("The value cannot be an empty string.", ex.Message);
         }
     }
 }

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/CrossDomainServiceQueryTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/CrossDomainServiceQueryTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Silverlight.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestDomainServices.LTS;
 using OpenRiaServices.Silverlight.Testing;
+using System.Threading.Tasks;
 
 namespace OpenRiaServices.Client.Test
 {
@@ -15,9 +16,7 @@ namespace OpenRiaServices.Client.Test
     /// Note: we're using the same generated client for both EF and LTS tests, varying only the
     /// provider string that the tests use.
     /// </summary>
-#if !SILVERLIGHT
     [TestClass]
-#endif
     public abstract class CrossDomainServiceQueryTests : DomainContextTestBase<Catalog>
     {
         public CrossDomainServiceQueryTests(Uri serviceUri, ProviderType providerType)
@@ -436,38 +435,17 @@ namespace OpenRiaServices.Client.Test
         }
 
         [TestMethod]
-        [Asynchronous]
-        public void TestLoad_CustomTotalCount()
+        public async Task TestLoad_CustomTotalCount()
         {
             Catalog catalog = CreateDomainContext();
-            int totalCountWithoutPaging = 0;
             var query = catalog.GetProductsWithCustomTotalCountQuery();
 
-            Load(query);
+            var loadResult = await catalog.LoadAsync(query);
+            catalog.Products.Clear();
 
-            EnqueueConditional(delegate
-            {
-                return IsLoadComplete;
-            });
-            EnqueueCallback(delegate
-            {
-                totalCountWithoutPaging = LoadOperation.TotalEntityCount;
-                catalog.Products.Clear();
-            });
-            EnqueueCallback(delegate
-            {
-                Load(query.OrderBy(p => p.ProductID).Skip(2).Take(4));
-            });
-            EnqueueConditional(delegate
-            {
-                return IsLoadComplete;
-            });
-            EnqueueCallback(delegate
-            {
-                Assert.AreEqual(totalCountWithoutPaging, LoadOperation.TotalEntityCount);
-                Assert.HasCount(4, LoadOperation.Entities);
-            });
-            EnqueueTestComplete();
+            var loadWithPagingResult = await catalog.LoadAsync(query.OrderBy(p => p.ProductID).Skip(2).Take(3));
+            Assert.AreEqual(loadResult.TotalEntityCount, loadWithPagingResult.TotalEntityCount);
+            Assert.HasCount(3, loadWithPagingResult.Entities);
         }
 
         [TestMethod]

--- a/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/EntityQueryTests.cs
+++ b/src/Test/OpenRiaservices.EndToEnd.Wcf.Test/Data/EntityQueryTests.cs
@@ -195,7 +195,7 @@ namespace OpenRiaServices.Client.Test
                 EntityQuery<City> citiesQuery = new EntityQuery<City>(_testClient, null, parameters, false, true);
             }, "queryName");
 
-            ExceptionHelper.ExpectArgumentNullException(delegate
+            ExceptionHelper.ExpectEmptyStringArgumentException(delegate
             {
                 EntityQuery<City> citiesQuery = new EntityQuery<City>(_testClient, string.Empty, parameters, false, true);
             }, "queryName");

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicContext.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicContext.cs
@@ -332,10 +332,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         /// <param name="namespaceName">The namespace to use for the generated code.  It cannot be empty.</param>
         protected void GenerateBusinessLogicClass(CodeGenContext codeGenContext, string className, string namespaceName)
         {
-            if (codeGenContext == null)
-            {
-                throw new ArgumentNullException("codeGenContext");
-            }
+            ArgumentNullException.ThrowIfNull(codeGenContext);
             ArgumentException.ThrowIfNullOrEmpty(className);
             ArgumentException.ThrowIfNullOrEmpty(namespaceName);
 

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicContext.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicContext.cs
@@ -336,14 +336,8 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
             {
                 throw new ArgumentNullException("codeGenContext");
             }
-            if (string.IsNullOrEmpty(className))
-            {
-                throw new ArgumentNullException("className");
-            }
-            if (string.IsNullOrEmpty(namespaceName))
-            {
-                throw new ArgumentNullException("namespaceName");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(className);
+            ArgumentException.ThrowIfNullOrEmpty(namespaceName);
 
             // namespace XXX { }
             CodeNamespace ns = codeGenContext.GetOrGenNamespace(namespaceName);

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicModel.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicModel.cs
@@ -42,10 +42,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         /// <param name="logger">Callback to invoke to report errors during processing.</param>
         public BusinessLogicModel(Action<string> logger)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException("logger");
-            }
+            ArgumentNullException.ThrowIfNull(logger);
             this._logger = logger;
         }
 

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicViewModel.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicViewModel.cs
@@ -48,16 +48,9 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         public BusinessLogicViewModel(string projectDirectory, string className, string language, string rootNamespace, string assemblyName, IEnumerable<Type> contextTypes, IVsHelp help)
         {
             ArgumentException.ThrowIfNullOrEmpty(projectDirectory);
-
             ArgumentException.ThrowIfNullOrEmpty(className);
-
             ArgumentException.ThrowIfNullOrEmpty(language);
-
-            if (contextTypes == null)
-            {
-                throw new ArgumentNullException("contextTypes");
-            }
-
+            ArgumentNullException.ThrowIfNull(contextTypes);
             ArgumentException.ThrowIfNullOrEmpty(assemblyName);
 
             this._projectDirectory = projectDirectory;

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicViewModel.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicViewModel.cs
@@ -47,30 +47,18 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         /// <param name="help">The help object used to display help on pressing F1.</param>
         public BusinessLogicViewModel(string projectDirectory, string className, string language, string rootNamespace, string assemblyName, IEnumerable<Type> contextTypes, IVsHelp help)
         {
-            if (string.IsNullOrEmpty(projectDirectory))
-            {
-                throw new ArgumentNullException("projectDirectory");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(projectDirectory);
 
-            if (string.IsNullOrEmpty(className))
-            {
-                throw new ArgumentNullException("className");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(className);
 
-            if (string.IsNullOrEmpty(language))
-            {
-                throw new ArgumentNullException("language");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(language);
 
             if (contextTypes == null)
             {
                 throw new ArgumentNullException("contextTypes");
             }
 
-            if (string.IsNullOrEmpty(assemblyName))
-            {
-                throw new ArgumentNullException("assemblyName");
-            }
+            ArgumentException.ThrowIfNullOrEmpty(assemblyName);
 
             this._projectDirectory = projectDirectory;
             this._className = className;

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicViewModel.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/BusinessLogicViewModel.cs
@@ -50,8 +50,8 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
             ArgumentException.ThrowIfNullOrEmpty(projectDirectory);
             ArgumentException.ThrowIfNullOrEmpty(className);
             ArgumentException.ThrowIfNullOrEmpty(language);
-            ArgumentNullException.ThrowIfNull(contextTypes);
             ArgumentException.ThrowIfNullOrEmpty(assemblyName);
+            ArgumentNullException.ThrowIfNull(contextTypes);
 
             this._projectDirectory = projectDirectory;
             this._className = className;

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/DomainServiceFixupCodeDomVisitor.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/DomainServiceFixupCodeDomVisitor.cs
@@ -21,10 +21,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         /// <param name="context">The current <see cref="CodeGenContext"/> context.</param>
         public DomainServiceFixupCodeDomVisitor(CodeGenContext context)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException("context");
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
             this._context = context;
         }

--- a/src/VisualStudio/Tools/Framework/DomainServiceWizard/GeneratedCode.cs
+++ b/src/VisualStudio/Tools/Framework/DomainServiceWizard/GeneratedCode.cs
@@ -29,14 +29,8 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         public GeneratedCode(string sourceCode, IEnumerable<string> references)
         {
             // Empty is allowed, null is not
-            if (sourceCode == null)
-            {
-                throw new ArgumentNullException("sourceCode");
-            }
-            if (references == null)
-            {
-                throw new ArgumentNullException("references");
-            }
+            ArgumentNullException.ThrowIfNull(sourceCode);
+            ArgumentNullException.ThrowIfNull(references);
             this._sourceCode = sourceCode;
             this._references = references;
         }

--- a/src/VisualStudio/Tools/Framework/OpenRiaServices.VisualStudio.DomainServices.Tools.csproj
+++ b/src/VisualStudio/Tools/Framework/OpenRiaServices.VisualStudio.DomainServices.Tools.csproj
@@ -61,6 +61,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\..\OpenRiaServices.Client\Framework\Polyfills.cs" Link="Polyfills.cs" />
     <Compile Include="..\..\..\OpenRiaServices.Tools\Framework\CodeDomVisitor.cs" Link="DomainServiceWizard\CodeDomVisitor.cs" />
     <Compile Include="..\..\..\OpenRiaServices.Tools\Framework\DbContextUtilities.cs" Link="DomainServiceWizard\DbContextUtilities.cs" />
     <Compile Include="..\..\..\OpenRiaServices.Client\Framework\TypeUtility.cs" Link="DomainServiceWizard\TypeUtility.cs" />

--- a/src/VisualStudio/Tools/Framework/WebConfigUtil.cs
+++ b/src/VisualStudio/Tools/Framework/WebConfigUtil.cs
@@ -42,10 +42,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools
         /// <param name="configuration">The configuration to use.</param>
         public WebConfigUtil(System.Configuration.Configuration configuration)
         {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException("configuration");
-            }
+            ArgumentNullException.ThrowIfNull(configuration);
             this._configuration = configuration;
         }
 

--- a/src/VisualStudio/Tools/Test/DomainServiceWizard/BusinessLogicClassViewModelTests.cs
+++ b/src/VisualStudio/Tools/Test/DomainServiceWizard/BusinessLogicClassViewModelTests.cs
@@ -183,7 +183,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools.Test
                 BusinessLogicViewModel model = new BusinessLogicViewModel(null, "FooClass", "C#", "ARootNamespace", "AnAssemblyName", Array.Empty<Type>(), /* IVsHelp object */ null);
             }, "projectDirectory");
 
-            ExceptionHelper.ExpectArgumentNullExceptionStandard(delegate
+            ExceptionHelper.ExpectEmptyStringArgumentException(delegate
             {
                 BusinessLogicViewModel model = new BusinessLogicViewModel(string.Empty, "FooClass", "C#", "ARootNamespace", "AnAssemblyName", Array.Empty<Type>(), /* IVsHelp object */ null);
             }, "projectDirectory");
@@ -194,7 +194,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools.Test
                 BusinessLogicViewModel model = new BusinessLogicViewModel("FooFolder", null, "C#", "ARootNamespace", "AnAssemblyName", Array.Empty<Type>(), /* IVsHelp object */ null);
             }, "className");
 
-            ExceptionHelper.ExpectArgumentNullExceptionStandard(delegate
+            ExceptionHelper.ExpectEmptyStringArgumentException(delegate
             {
                 BusinessLogicViewModel model = new BusinessLogicViewModel("FooFolder", string.Empty, "C#", "ARootNamespace", "AnAssemblyName", Array.Empty<Type>(), /* IVsHelp object */ null);
             }, "className");
@@ -205,7 +205,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools.Test
                 BusinessLogicViewModel model = new BusinessLogicViewModel("FooFolder", "AClassName", null, "ARootNamespace", "AnAssemblyName", Array.Empty<Type>(), /* IVsHelp object */ null);
             }, "language");
 
-            ExceptionHelper.ExpectArgumentNullExceptionStandard(delegate
+            ExceptionHelper.ExpectEmptyStringArgumentException(delegate
             {
                 BusinessLogicViewModel model = new BusinessLogicViewModel("FooFolder", "AClassName", string.Empty, "ARootNamespace", "AnAssemblyName", Array.Empty<Type>(), /* IVsHelp object */ null);
             }, "language");
@@ -216,7 +216,7 @@ namespace OpenRiaServices.VisualStudio.DomainServices.Tools.Test
                 BusinessLogicViewModel model = new BusinessLogicViewModel("FooFolder", "AClassName", "C#", "ARootNamespace", null, Array.Empty<Type>(), /* IVsHelp object */ null);
             }, "assemblyName");
 
-            ExceptionHelper.ExpectArgumentNullExceptionStandard(delegate
+            ExceptionHelper.ExpectEmptyStringArgumentException(delegate
             {
                 BusinessLogicViewModel model = new BusinessLogicViewModel("FooFolder", "AClassName", "C#", "ARootNamespace", "", Array.Empty<Type>(), /* IVsHelp object */ null);
             }, "assemblyName");


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized argument validation across the codebase for more consistent behavior and maintenance.

* **Breaking Changes**
  * Removed .NET Standard 2.0 target; supported targets are .NET 4.7.2, .NET 8.0, and .NET 8.0-Windows.
  * Validation semantics changed: empty-string inputs now produce distinct empty-string argument errors (may affect callers expecting prior exceptions).

* **Chores**
  * Updated System.CommandLine package version.
  * Consolidated shared polyfills/utilities into projects and added a changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->