### PR TITLE
Ensure ChangeSet is always initialized before use

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,10 +16,10 @@ This release gives some ❤️ to AvaloniaUI and other frameworks which use ILis
     * Add `IList<T>` interface to `EntityCollection`
 * Nullability annotations for `EntitySet` and `EntityCollection`
 * Nullability annotations for many parts of the most used public API
-* ChangeSet now throws an `InvalidOperationException` if accessed outside a submit operation, where `ChangeSet` previously returned `null`.
 
 ### Server
 
+* ChangeSet now throws an `InvalidOperationException` if accessed outside a submit operation, where `ChangeSet` previously returned `null`.
 * Added Nullability annotations for a few core types of public API
 
 ### Other

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ This release gives some ❤️ to AvaloniaUI and other frameworks which use ILis
     * Add `IList<T>` interface to `EntityCollection`
 * Nullability annotations for `EntitySet` and `EntityCollection`
 * Nullability annotations for many parts of the most used public API
+* ChangeSet now throws an `InvalidOperationException` if accessed outside of a submit operation, eg. in the cases where `ChangeSet` previously would have returned `null`.
 
 ### Server
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@ This release gives some ❤️ to AvaloniaUI and other frameworks which use ILis
     * Add `IList<T>` interface to `EntityCollection`
 * Nullability annotations for `EntitySet` and `EntityCollection`
 * Nullability annotations for many parts of the most used public API
-* ChangeSet now throws an `InvalidOperationException` if accessed outside of a submit operation, eg. in the cases where `ChangeSet` previously would have returned `null`.
+* ChangeSet now throws an `InvalidOperationException` if accessed outside a submit operation, where `ChangeSet` previously returned `null`.
 
 ### Server
 

--- a/src/OpenRiaServices.Client/Framework/Polyfills.cs
+++ b/src/OpenRiaServices.Client/Framework/Polyfills.cs
@@ -1,5 +1,6 @@
 ﻿#if !NET
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -85,6 +86,22 @@ namespace System.Runtime.CompilerServices
         }
 
         public string ParameterName { get; private set; }
+    }
+}
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Types and Methods attributed with StackTraceHidden will be omitted from the stack trace text shown in StackTrace.ToString()
+    /// and Exception.StackTrace
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Struct, Inherited = false)]
+    public sealed class StackTraceHiddenAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StackTraceHiddenAttribute"/> class.
+        /// </summary>
+        public StackTraceHiddenAttribute() { }
     }
 }
 

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -234,9 +234,7 @@ namespace OpenRiaServices.Server
                 [System.Diagnostics.StackTraceHidden]
                 static void ThrowChangeSetNotInitialized() =>
                     throw new InvalidOperationException(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            Resource.DomainService_ChangeSetNotInitialized));
+                        Resource.DomainService_ChangeSetNotInitialized);
             }
         }
 

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -218,10 +218,11 @@ namespace OpenRiaServices.Server
         /// <summary>
         /// Gets the current <see cref="ChangeSet"/>. Returns null if no change operations are being performed.
         /// </summary>
-        protected ChangeSet? ChangeSet
+        protected ChangeSet ChangeSet
         {
             get
             {
+                EnsureChangeSetInitialized();
                 return this._changeSet;
             }
         }
@@ -718,7 +719,7 @@ namespace OpenRiaServices.Server
         /// <returns>True if the <see cref="ChangeSet"/> is authorized, false otherwise.</returns>
         protected virtual bool AuthorizeChangeSet()
         {
-            foreach (ChangeSetEntry op in this.ChangeSet!.ChangeSetEntries)
+            foreach (ChangeSetEntry op in this.ChangeSet.ChangeSetEntries)
             {
                 object entity = op.Entity;
 
@@ -751,7 +752,7 @@ namespace OpenRiaServices.Server
         protected virtual ValueTask<bool> ValidateChangeSetAsync(CancellationToken cancellationToken)
         {
             // Perform validation on the each of the operations.
-            var result = ValidateOperations(this.ChangeSet!.ChangeSetEntries, this.ServiceDescription, this.ValidationContext);
+            var result = ValidateOperations(this.ChangeSet.ChangeSetEntries, this.ServiceDescription, this.ValidationContext);
             return new ValueTask<bool>(result);
         }
 
@@ -766,7 +767,7 @@ namespace OpenRiaServices.Server
             await this.InvokeCustomOperations()
                 .ConfigureAwait(false);
 
-            return !this.ChangeSet!.HasError;
+            return !this.ChangeSet.HasError;
         }
 
         /// <summary>
@@ -794,7 +795,7 @@ namespace OpenRiaServices.Server
         private void ResolveOperations()
         {
             // Resolve and set the DomainOperationEntry for each operation in the changeset
-            foreach (ChangeSetEntry changeSetEntry in this.ChangeSet!.ChangeSetEntries)
+            foreach (ChangeSetEntry changeSetEntry in this.ChangeSet.ChangeSetEntries)
             {
                 // resolve the DomainOperationEntry
                 Type entityType = changeSetEntry.Entity.GetType();
@@ -984,7 +985,7 @@ namespace OpenRiaServices.Server
                 if (e.Value != null && e.ValidationResult != null)
                 {
                     IEnumerable<ChangeSetEntry> updateOperations =
-                        this.ChangeSet!.ChangeSetEntries.Where(
+                        this.ChangeSet.ChangeSetEntries.Where(
                             p => p.Operation == DomainOperation.Insert ||
                                  p.Operation == DomainOperation.Update ||
                                  p.Operation == DomainOperation.Delete);
@@ -1003,7 +1004,7 @@ namespace OpenRiaServices.Server
                 }
             }
 
-            return !this.ChangeSet!.HasError;
+            return !this.ChangeSet.HasError;
         }
 
         /// <summary>
@@ -1016,6 +1017,19 @@ namespace OpenRiaServices.Server
             if (this._serviceContext == null)
             {
                 throw new InvalidOperationException(Resource.DomainService_NotInitialized);
+            }
+        }
+
+        /// <summary>
+        /// Ensures the <see cref="ChangeSet"/> has been initialized properly.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">if the <see cref="_changeSet"/> instance hasn't been initialized.</exception>
+        [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_changeSet))]
+        private void EnsureChangeSetInitialized()
+        {
+            if (this._changeSet == null)
+            {
+                throw new InvalidOperationException(Resource.DomainService_ChangeSetNotInitialized);
             }
         }
 
@@ -1040,7 +1054,7 @@ namespace OpenRiaServices.Server
         private async Task InvokeCudOperationsAsync()
         {
             object[] parameters = new object[1];
-            foreach (ChangeSetEntry operation in this.ChangeSet!.ChangeSetEntries
+            foreach (ChangeSetEntry operation in this.ChangeSet.ChangeSetEntries
                 .Where(op => op.Operation == DomainOperation.Insert ||
                              op.Operation == DomainOperation.Update ||
                              op.Operation == DomainOperation.Delete))
@@ -1082,7 +1096,7 @@ namespace OpenRiaServices.Server
         /// </summary>
         private async Task InvokeCustomOperations()
         {
-            foreach (ChangeSetEntry operation in this.ChangeSet!.ChangeSetEntries.Where(op => op.EntityActions != null && op.EntityActions.Any()))
+            foreach (ChangeSetEntry operation in this.ChangeSet.ChangeSetEntries.Where(op => op.EntityActions != null && op.EntityActions.Any()))
             {
                 foreach (var entityAction in operation.EntityActions)
                 {

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -224,15 +224,25 @@ namespace OpenRiaServices.Server
         {
             get
             {
-                if (this._changeSet == null)
-                    ThrowChangeSetNotInitialized(this.ServiceContext.OperationType);
+protected ChangeSet ChangeSet
+{
+    get
+    {
+        if (this._changeSet == null)
+            ThrowChangeSetNotInitialized(this._serviceContext?.OperationType);
 
-                return this._changeSet;
+        return this._changeSet;
 
-                [DoesNotReturn]
-                [System.Diagnostics.StackTraceHidden]
-                static void ThrowChangeSetNotInitialized(DomainOperationType serviceOperationType) =>
-                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.DomainService_ChangeSetNotInitialized, serviceOperationType));
+        [DoesNotReturn]
+        [System.Diagnostics.StackTraceHidden]
+        static void ThrowChangeSetNotInitialized(DomainOperationType? serviceOperationType) =>
+            throw new InvalidOperationException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resource.DomainService_ChangeSetNotInitialized,
+                    serviceOperationType?.ToString() ?? "Unknown"));
+    }
+}
             }
         }
 

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -220,31 +220,26 @@ namespace OpenRiaServices.Server
         /// Gets the current <see cref="ChangeSet"/>. Throws if no change operations are being performed.
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if no change operations are being performed.</exception>
+
         protected ChangeSet ChangeSet
         {
             get
             {
-protected ChangeSet ChangeSet
-{
-    get
-    {
-        if (this._changeSet == null)
-            ThrowChangeSetNotInitialized(this._serviceContext?.OperationType);
+                if (this._changeSet == null)
+                    ThrowChangeSetNotInitialized();
 
-        return this._changeSet;
+                return this._changeSet;
 
-        [DoesNotReturn]
-        [System.Diagnostics.StackTraceHidden]
-        static void ThrowChangeSetNotInitialized(DomainOperationType? serviceOperationType) =>
-            throw new InvalidOperationException(
-                string.Format(
-                    CultureInfo.CurrentCulture,
-                    Resource.DomainService_ChangeSetNotInitialized,
-                    serviceOperationType?.ToString() ?? "Unknown"));
-    }
-}
+                [DoesNotReturn]
+                [System.Diagnostics.StackTraceHidden]
+                static void ThrowChangeSetNotInitialized() =>
+                    throw new InvalidOperationException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            Resource.DomainService_ChangeSetNotInitialized));
             }
         }
+
 
         #endregion // Properties
 

--- a/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/DomainService.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -216,14 +217,22 @@ namespace OpenRiaServices.Server
         }
 
         /// <summary>
-        /// Gets the current <see cref="ChangeSet"/>. Returns null if no change operations are being performed.
+        /// Gets the current <see cref="ChangeSet"/>. Throws if no change operations are being performed.
         /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if no change operations are being performed.</exception>
         protected ChangeSet ChangeSet
         {
             get
             {
-                EnsureChangeSetInitialized();
+                if (this._changeSet == null)
+                    ThrowChangeSetNotInitialized(this.ServiceContext.OperationType);
+
                 return this._changeSet;
+
+                [DoesNotReturn]
+                [System.Diagnostics.StackTraceHidden]
+                static void ThrowChangeSetNotInitialized(DomainOperationType serviceOperationType) =>
+                    throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resource.DomainService_ChangeSetNotInitialized, serviceOperationType));
             }
         }
 
@@ -1017,19 +1026,6 @@ namespace OpenRiaServices.Server
             if (this._serviceContext == null)
             {
                 throw new InvalidOperationException(Resource.DomainService_NotInitialized);
-            }
-        }
-
-        /// <summary>
-        /// Ensures the <see cref="ChangeSet"/> has been initialized properly.
-        /// </summary>
-        /// <exception cref="InvalidOperationException">if the <see cref="_changeSet"/> instance hasn't been initialized.</exception>
-        [System.Diagnostics.CodeAnalysis.MemberNotNull(nameof(_changeSet))]
-        private void EnsureChangeSetInitialized()
-        {
-            if (this._changeSet == null)
-            {
-                throw new InvalidOperationException(Resource.DomainService_ChangeSetNotInitialized);
             }
         }
 

--- a/src/OpenRiaServices.Server/Framework/Data/Resource.Designer.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/Resource.Designer.cs
@@ -19,7 +19,7 @@ namespace OpenRiaServices.Server {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resource {
@@ -228,6 +228,15 @@ namespace OpenRiaServices.Server {
         internal static string DomainService_AlreadyInitialized {
             get {
                 return ResourceManager.GetString("DomainService_AlreadyInitialized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ChangeSet has not been initialized..
+        /// </summary>
+        internal static string DomainService_ChangeSetNotInitialized {
+            get {
+                return ResourceManager.GetString("DomainService_ChangeSetNotInitialized", resourceCulture);
             }
         }
         

--- a/src/OpenRiaServices.Server/Framework/Data/Resource.Designer.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/Resource.Designer.cs
@@ -232,7 +232,7 @@ namespace OpenRiaServices.Server {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ChangeSet has not been initialized..
+        ///   Looks up a localized string similar to The ChangeSet of this DomainService is only initialized during a &apos;Submit&apos; operation, so it cannot be accessed during an operation of type &apos;{0}&apos;..
         /// </summary>
         internal static string DomainService_ChangeSetNotInitialized {
             get {

--- a/src/OpenRiaServices.Server/Framework/Data/Resource.Designer.cs
+++ b/src/OpenRiaServices.Server/Framework/Data/Resource.Designer.cs
@@ -232,7 +232,7 @@ namespace OpenRiaServices.Server {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The ChangeSet of this DomainService is only initialized during a &apos;Submit&apos; operation, so it cannot be accessed during an operation of type &apos;{0}&apos;..
+        ///   Looks up a localized string similar to The ChangeSet of this DomainService is only available while processing a &apos;Submit&apos; operation..
         /// </summary>
         internal static string DomainService_ChangeSetNotInitialized {
             get {

--- a/src/OpenRiaServices.Server/Framework/Data/Resource.resx
+++ b/src/OpenRiaServices.Server/Framework/Data/Resource.resx
@@ -214,7 +214,7 @@
     <value>This DomainService has already been initialized.</value>
   </data>
   <data name="DomainService_ChangeSetNotInitialized" xml:space="preserve">
-    <value>ChangeSet has not been initialized.</value>
+    <value>The ChangeSet of this DomainService is only initialized during a 'Submit' operation, so it cannot be accessed during an operation of type '{0}'.</value>
   </data>
   <data name="DomainService_DuplicateCUDMethod" xml:space="preserve">
     <value>The domain operation entry named '{0}' provides redundant functionality. Another method named '{1}' already exists.</value>

--- a/src/OpenRiaServices.Server/Framework/Data/Resource.resx
+++ b/src/OpenRiaServices.Server/Framework/Data/Resource.resx
@@ -214,7 +214,7 @@
     <value>This DomainService has already been initialized.</value>
   </data>
   <data name="DomainService_ChangeSetNotInitialized" xml:space="preserve">
-    <value>The ChangeSet of this DomainService is only initialized during a 'Submit' operation, so it cannot be accessed during an operation of type '{0}'.</value>
+    <value>The ChangeSet of this DomainService is only available while processing a 'Submit' operation.</value>
   </data>
   <data name="DomainService_DuplicateCUDMethod" xml:space="preserve">
     <value>The domain operation entry named '{0}' provides redundant functionality. Another method named '{1}' already exists.</value>

--- a/src/OpenRiaServices.Server/Framework/Data/Resource.resx
+++ b/src/OpenRiaServices.Server/Framework/Data/Resource.resx
@@ -213,6 +213,9 @@
   <data name="DomainService_AlreadyInitialized" xml:space="preserve">
     <value>This DomainService has already been initialized.</value>
   </data>
+  <data name="DomainService_ChangeSetNotInitialized" xml:space="preserve">
+    <value>ChangeSet has not been initialized.</value>
+  </data>
   <data name="DomainService_DuplicateCUDMethod" xml:space="preserve">
     <value>The domain operation entry named '{0}' provides redundant functionality. Another method named '{1}' already exists.</value>
   </data>

--- a/src/OpenRiaServices.Server/Test/DomainServiceTests.cs
+++ b/src/OpenRiaServices.Server/Test/DomainServiceTests.cs
@@ -49,6 +49,60 @@ namespace OpenRiaServices.Server.Test
         }
 
         /// <summary>
+        /// Verify that accessing ChangeSet before SubmitAsync throws InvalidOperationException.
+        /// </summary>
+        [TestMethod]
+        public void ChangeSet_ThrowsBeforeInitialization()
+        {
+            var ds = new ChangeSetAccessorDomainService();
+            DomainServiceContext dsc = new DomainServiceContext(new MockDataService(), new MockUser("mathew"), DomainOperationType.Submit);
+            ds.Initialize(dsc);
+
+            ExceptionHelper.ExpectInvalidOperationException(
+                () => { var _ = ds.GetChangeSet(); },
+                Resource.DomainService_ChangeSetNotInitialized);
+        }
+
+        /// <summary>
+        /// Verify that accessing ChangeSet before Initialize and SubmitAsync throws InvalidOperationException.
+        /// </summary>
+        [TestMethod]
+        public void ChangeSet_ThrowsBeforeInitializationAndSubmit()
+        {
+            var ds = new ChangeSetAccessorDomainService();
+
+            ExceptionHelper.ExpectInvalidOperationException(
+                () => { var _ = ds.GetChangeSet(); },
+                Resource.DomainService_ChangeSetNotInitialized);
+        }
+
+        /// <summary>
+        /// Verify that ChangeSet is accessible during SubmitAsync after initialization.
+        /// </summary>
+        [TestMethod]
+        public async Task ChangeSet_AccessibleAfterSubmitAsync()
+        {
+            var ds = new ChangeSetAccessorDomainService();
+            DomainServiceContext dsc = new DomainServiceContext(new MockDataService(), new MockUser("mathew"), DomainOperationType.Submit);
+            ds.Initialize(dsc);
+
+            City city = new City
+            {
+                Name = "TestCity",
+                CountyName = "TestCounty",
+                StateName = "WA"
+            };
+
+            ChangeSetEntry insertEntry = new ChangeSetEntry(1, city, null, DomainOperation.Insert);
+            ChangeSet cs = new ChangeSet(new[] { insertEntry });
+
+            bool result = await ds.SubmitAsync(cs, CancellationToken.None);
+
+            Assert.IsTrue(result);
+            Assert.IsTrue(ds.ChangeSetWasAccessibleDuringSubmit, "ChangeSet should be accessible during SubmitAsync.");
+        }
+
+        /// <summary>
         /// Verify that both DAL providers support accessing their respective
         /// contexts in the constructor.
         /// </summary>
@@ -2478,6 +2532,26 @@ namespace OpenRiaServices.Server.Test
     {
         [CustomValidation(typeof(AlwaysFailValidator), "Validate")]
         public int IntProp { get; set; }
+    }
+    public class ChangeSetAccessorDomainService : DomainService
+    {
+        public bool ChangeSetWasAccessibleDuringSubmit { get; private set; }
+
+        public ChangeSet GetChangeSet() => ChangeSet;
+
+        [Query]
+        public IQueryable<City> GetCities() => Array.Empty<City>().AsQueryable();
+
+        public void InsertCity(City city)
+        {
+        }
+
+        protected override ValueTask<bool> PersistChangeSetAsync(CancellationToken cancellationToken)
+        {
+            // Verify ChangeSet is accessible during the submit pipeline
+            ChangeSetWasAccessibleDuringSubmit = ChangeSet != null;
+            return new ValueTask<bool>(true);
+        }
     }
     #endregion // Mock DomainService Types
 }

--- a/src/OpenRiaServices.Server/Test/DomainServiceTests.cs
+++ b/src/OpenRiaServices.Server/Test/DomainServiceTests.cs
@@ -7,18 +7,18 @@ using System.Data.Linq;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Cities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenRiaServices.Client.Test;
 using OpenRiaServices.EntityFramework;
 using OpenRiaServices.Hosting.Wcf;
-using System.Xml.Linq;
-using Cities;
 using OpenRiaServices.LinqToSql;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TestDomainServices;
-using System.Threading.Tasks;
-using System.Threading;
-using OpenRiaServices.Server.UnitTesting;
 using OpenRiaServices.Server.EntityFrameworkCore;
+using OpenRiaServices.Server.UnitTesting;
+using TestDomainServices;
 
 namespace OpenRiaServices.Server.Test
 {
@@ -52,10 +52,10 @@ namespace OpenRiaServices.Server.Test
         /// Verify that accessing ChangeSet before SubmitAsync throws InvalidOperationException.
         /// </summary>
         [TestMethod]
-        public void ChangeSet_ThrowsBeforeInitialization()
+        public void ChangeSet_ThrowsBeforeSubmitAsync()
         {
             var ds = new ChangeSetAccessorDomainService();
-            DomainServiceContext dsc = new DomainServiceContext(new MockDataService(), new MockUser("mathew"), DomainOperationType.Submit);
+            DomainServiceContext dsc = new DomainServiceContext(new MockDataService(), new MockUser("mathew"), DomainOperationType.Invoke);
             ds.Initialize(dsc);
 
             ExceptionHelper.ExpectInvalidOperationException(
@@ -222,7 +222,7 @@ namespace OpenRiaServices.Server.Test
             DomainOperationEntry queryOperation = desc.GetQueryMethod("GetCities");
             QueryDescription query = new QueryDescription(queryOperation, Array.Empty<object>(), /* includeTotalCount */ true, Array.Empty<Zip>().AsQueryable().Where(z => z.Code == 98052));
 
-            ExceptionHelper.ExpectArgumentException(() =>  
+            ExceptionHelper.ExpectArgumentException(() =>
                 ds.QueryAsync<City>(query, CancellationToken.None).GetAwaiter().GetResult()
             , "Expression of type 'System.Linq.EnumerableQuery`1[Cities.City]' cannot be used for parameter of type 'System.Linq.IQueryable`1[Cities.Zip]' of method 'System.Linq.IQueryable`1[Cities.Zip] Where[Zip](System.Linq.IQueryable`1[Cities.Zip], System.Linq.Expressions.Expression`1[System.Func`2[Cities.Zip,System.Boolean]])'");
         }
@@ -404,7 +404,7 @@ namespace OpenRiaServices.Server.Test
             ds.Initialize(dsc);
             query = new QueryDescription(queryOperation, new object[] { 50 });
             var queryResult = await ds.QueryAsync<City>(query, CancellationToken.None);
-            
+
             Assert.IsTrue(queryResult.HasValidationErrors, "Should have validation errors");
             Assert.AreEqual(1, queryResult.ValidationErrors.Count());
             Assert.IsNull(ds.LastError);
@@ -618,7 +618,7 @@ namespace OpenRiaServices.Server.Test
             // Ensure metadata (TypeDescriptors) are initialised
             DomainServiceDescription.GetDescription(typeof(TestDomainServices.EF.Northwind));
 
-            var expectedChangedProperties = new []
+            var expectedChangedProperties = new[]
             {
                 "CategoryName",
                 "Description",
@@ -645,7 +645,7 @@ namespace OpenRiaServices.Server.Test
 
             var currentEntry = ctx.ObjectStateManager.GetObjectStateEntry(current);
             string[] actualChangedProperties = currentEntry.GetModifiedProperties().ToArray();
-            
+
             CollectionAssert.AreEquivalent(expectedChangedProperties, actualChangedProperties);
         }
 
@@ -715,7 +715,7 @@ namespace OpenRiaServices.Server.Test
             DbContextExtensions.AttachAsModified(catalog.DbContext.Products, current, original, catalog.DbContext);
 
             var currentEntry = catalog.DbContext.Entry(current);
-            
+
             string[] actualNotChangedProperties = currentEntry.CurrentValues.PropertyNames.Where(p => !currentEntry.Property(p).IsModified).ToArray();
 
             CollectionAssert.AreEquivalent(expectedNotChangedProperties, actualNotChangedProperties);
@@ -2181,7 +2181,8 @@ namespace OpenRiaServices.Server.Test
         public TestDomainService_OverloadTests()
         {
             // initialize with a test user
-            Initialize(new DomainServiceContext(new MockDataService(), new MockUser("mathew") {
+            Initialize(new DomainServiceContext(new MockDataService(), new MockUser("mathew")
+            {
                 IsAuthenticated = true
             }, DomainOperationType.Submit));
         }
@@ -2515,7 +2516,8 @@ namespace OpenRiaServices.Server.Test
         public void UpdateEntity(DomainServiceInsertCustom_Entity entity) { }
         [EntityAction]
         public void UpdateEntityWithInt(DomainServiceInsertCustom_Entity entity,
-            [CustomValidation(typeof(AlwaysFailValidator), "Validate")] int i) { }
+            [CustomValidation(typeof(AlwaysFailValidator), "Validate")] int i)
+        { }
         [EntityAction]
         public void UpdateEntityWithObject(DomainServiceInsertCustom_Entity entity, DomainServiceInsertCustom_Validated_Object obj) { }
         [EntityAction]
@@ -2549,7 +2551,8 @@ namespace OpenRiaServices.Server.Test
         protected override ValueTask<bool> PersistChangeSetAsync(CancellationToken cancellationToken)
         {
             // Verify ChangeSet is accessible during the submit pipeline
-            ChangeSetWasAccessibleDuringSubmit = ChangeSet != null;
+            _ = ChangeSet;
+            ChangeSetWasAccessibleDuringSubmit = true;
             return new ValueTask<bool>(true);
         }
     }

--- a/src/VisualStudio/ItemTemplates/CSharp/AuthenticationDomainService/AuthenticationDomainService.csproj
+++ b/src/VisualStudio/ItemTemplates/CSharp/AuthenticationDomainService/AuthenticationDomainService.csproj
@@ -31,7 +31,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AuthenticationDomainService</RootNamespace>
     <AssemblyName>AuthenticationDomainService</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/VisualStudio/ItemTemplates/CSharp/DomainServiceClass/DomainServiceClass.csproj
+++ b/src/VisualStudio/ItemTemplates/CSharp/DomainServiceClass/DomainServiceClass.csproj
@@ -31,7 +31,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DomainServiceClass</RootNamespace>
     <AssemblyName>DomainServiceClass</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/VisualStudio/Templates/CSharp/BusinessApplication/BusinessApplicationProjectTemplate.csproj
+++ b/src/VisualStudio/Templates/CSharp/BusinessApplication/BusinessApplicationProjectTemplate.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BusinessApplicationProjectTemplate</RootNamespace>
     <AssemblyName>BusinessApplicationProjectTemplate</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/VisualStudio/Templates/CSharp/RIAServicesLibrary/OpenRiaServicesLibrary.csproj
+++ b/src/VisualStudio/Templates/CSharp/RIAServicesLibrary/OpenRiaServicesLibrary.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OpenRiaServicesLibrary</RootNamespace>
     <AssemblyName>OpenRiaServicesLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>


### PR DESCRIPTION
Removed nullable **ChangeSet**, it now throws if **_changeSet** is `null`, and replaced all null-forgiving usages. Added DomainService_ChangeSetNotInitialized resource string used in the thrown exception.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Accessing the ChangeSet outside a submit now throws a clear InvalidOperationException with a localized message, preventing silent null access.

* **Documentation**
  * Changelog updated to note the stricter ChangeSet behavior in the 5.8.0 client release notes.

* **Tests**
  * Added tests verifying ChangeSet access rules during and outside submit processing.

* **Chores**
  * Project templates updated to target .NET Framework 4.8; added a compatibility attribute to improve stack-trace behavior on older targets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenRIAServices/OpenRiaServices/pull/574)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->