### PR TITLE
EFCore: Set AllowEmptyStrings=true on client for non nullable string properties

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# EF Core 4.1.0
+
+* Generate `[Required(AllowEmptyStrings=true)]` instead of `[Required]` on client for non nullable string properties
+
 # 5.8.0
 
 This release gives some ❤️ to AvaloniaUI and other frameworks which use IList for data binding.

--- a/src/OpenRiaServices.Client/Framework/InvokeResult.cs
+++ b/src/OpenRiaServices.Client/Framework/InvokeResult.cs
@@ -11,6 +11,9 @@ namespace OpenRiaServices.Client
     /// </summary>
     interface IInvokeResult
     {
+        /// <summary>
+        /// Get the value returned by the Invoke operation, if any.  If the Invoke operation does not return a value, this will be null.
+        /// </summary>
         object? Value { get; }
     }
 
@@ -27,15 +30,13 @@ namespace OpenRiaServices.Client
     /// </summary>
     public class InvokeResult<T> : InvokeResult, IInvokeResult
     {
-        private readonly T _value;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InvokeResult{T}"/> class.
         /// </summary>
         /// <param name="value">The value.</param>
         public InvokeResult(T value)
         {
-            _value = value;
+            Value = value;
         }
 
         /// <summary>
@@ -44,16 +45,16 @@ namespace OpenRiaServices.Client
         /// <value>
         /// The value.
         /// </value>
-        public T? Value => _value;
+        public T Value { get; }
 
-        object? IInvokeResult.Value => _value;
+        object? IInvokeResult.Value => Value;
 
         /// <summary>
         /// Implicit conversion to <typeparamref name="T"/> so that <see cref="Value"/> does not need to be used
         /// in most cases.
         /// </summary>
         /// <param name="invokeResult"></param>
-        public static implicit operator T?(InvokeResult<T> invokeResult)
+        public static implicit operator T(InvokeResult<T> invokeResult)
         {
             return invokeResult.Value;
         }

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/EFCoreTypeDescriptor.cs
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/EFCoreTypeDescriptor.cs
@@ -184,7 +184,7 @@ namespace OpenRiaServices.Server.EntityFrameworkCore
                     && !databaseGenerated
                     && pd.Attributes[typeof(RequiredAttribute)] == null)
                 {
-                    attributes.Add(new RequiredAttribute());
+                    attributes.Add(new RequiredAttribute() { AllowEmptyStrings = (property.ClrType == typeof(string)) });
                 }
 
                 bool isStringType = pd.PropertyType == typeof(string) || pd.PropertyType == typeof(char[]);

--- a/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
+++ b/src/OpenRiaServices.Server.EntityFrameworkCore/Framework/OpenRiaServices.Server.EntityFrameworkCore.csproj
@@ -3,8 +3,8 @@
     <TargetFrameworks>net472;net8.0;net10.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SERVERFX;EFCORE</DefineConstants>
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <VersionPrefix>4.0.0</VersionPrefix>
-    <AssemblyVersion>4.0.0</AssemblyVersion>
+    <VersionPrefix>4.1.0</VersionPrefix>
+    <AssemblyVersion>4.1.0</AssemblyVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EFCore.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EFCore.g.cs
@@ -97,7 +97,7 @@ namespace EFCoreModels.Northwind
         /// Gets or sets the 'CategoryName' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(15)]
         public string CategoryName
         {
@@ -339,7 +339,7 @@ namespace EFCoreModels.Northwind
         /// </summary>
         [ConcurrencyCheck()]
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [RoundtripOriginal()]
         [StringLength(40)]
         public string CompanyName
@@ -450,7 +450,7 @@ namespace EFCoreModels.Northwind
         [DataMember()]
         [Editable(false, AllowInitialValue=true)]
         [Key()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [RoundtripOriginal()]
         [StringLength(15)]
         public string CustomerID
@@ -1736,7 +1736,7 @@ namespace EFCoreModels.Northwind
         /// </summary>
         [ConcurrencyCheck()]
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [RoundtripOriginal()]
         [StringLength(40)]
         public string ProductName
@@ -2219,7 +2219,7 @@ namespace EFCoreModels.Northwind
         /// Gets or sets the 'RegionDescription' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(50)]
         public string RegionDescription
         {
@@ -2421,7 +2421,7 @@ namespace EFCoreModels.Northwind
         /// Gets or sets the 'TerritoryDescription' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(50)]
         public string TerritoryDescription
         {
@@ -2449,7 +2449,7 @@ namespace EFCoreModels.Northwind
         [DataMember()]
         [Editable(false, AllowInitialValue=true)]
         [Key()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [RoundtripOriginal()]
         [StringLength(20)]
         public string TerritoryID

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EFCore.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/EF/Northwind_EFCore.g.vb
@@ -108,7 +108,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets or sets the 'CategoryName' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(15)>  _
         Public Property CategoryName() As String
             Get
@@ -346,7 +346,7 @@ Namespace EFCoreModels.Northwind
         ''' </summary>
         <ConcurrencyCheck(),  _
          DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          RoundtripOriginal(),  _
          StringLength(40)>  _
         Public Property CompanyName() As String
@@ -441,7 +441,7 @@ Namespace EFCoreModels.Northwind
          DataMember(),  _
          Editable(false, AllowInitialValue:=true),  _
          Key(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          RoundtripOriginal(),  _
          StringLength(15)>  _
         Public Property CustomerID() As String
@@ -1629,7 +1629,7 @@ Namespace EFCoreModels.Northwind
         ''' </summary>
         <ConcurrencyCheck(),  _
          DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          RoundtripOriginal(),  _
          StringLength(40)>  _
         Public Property ProductName() As String
@@ -2064,7 +2064,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets or sets the 'RegionDescription' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(50)>  _
         Public Property RegionDescription() As String
             Get
@@ -2246,7 +2246,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets or sets the 'TerritoryDescription' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(50)>  _
         Public Property TerritoryDescription() As String
             Get
@@ -2270,7 +2270,7 @@ Namespace EFCoreModels.Northwind
         <DataMember(),  _
          Editable(false, AllowInitialValue:=true),  _
          Key(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          RoundtripOriginal(),  _
          StringLength(20)>  _
         Public Property TerritoryID() As String

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCoreContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCoreContextScenarios.g.cs
@@ -97,7 +97,7 @@ namespace EFCoreModels.Northwind
         /// Gets or sets the 'CategoryName' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(15)]
         public string CategoryName
         {
@@ -339,7 +339,7 @@ namespace EFCoreModels.Northwind
         /// </summary>
         [ConcurrencyCheck()]
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [RoundtripOriginal()]
         [StringLength(40)]
         public string CompanyName
@@ -450,7 +450,7 @@ namespace EFCoreModels.Northwind
         [DataMember()]
         [Editable(false, AllowInitialValue=true)]
         [Key()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [RoundtripOriginal()]
         [StringLength(15)]
         public string CustomerID
@@ -1736,7 +1736,7 @@ namespace EFCoreModels.Northwind
         /// </summary>
         [ConcurrencyCheck()]
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [RoundtripOriginal()]
         [StringLength(40)]
         public string ProductName
@@ -2219,7 +2219,7 @@ namespace EFCoreModels.Northwind
         /// Gets or sets the 'RegionDescription' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(50)]
         public string RegionDescription
         {
@@ -2421,7 +2421,7 @@ namespace EFCoreModels.Northwind
         /// Gets or sets the 'TerritoryDescription' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(50)]
         public string TerritoryDescription
         {
@@ -2449,7 +2449,7 @@ namespace EFCoreModels.Northwind
         [DataMember()]
         [Editable(false, AllowInitialValue=true)]
         [Key()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [RoundtripOriginal()]
         [StringLength(20)]
         public string TerritoryID

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCoreContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCoreContextScenarios.g.vb
@@ -108,7 +108,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets or sets the 'CategoryName' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(15)>  _
         Public Property CategoryName() As String
             Get
@@ -346,7 +346,7 @@ Namespace EFCoreModels.Northwind
         ''' </summary>
         <ConcurrencyCheck(),  _
          DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          RoundtripOriginal(),  _
          StringLength(40)>  _
         Public Property CompanyName() As String
@@ -441,7 +441,7 @@ Namespace EFCoreModels.Northwind
          DataMember(),  _
          Editable(false, AllowInitialValue:=true),  _
          Key(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          RoundtripOriginal(),  _
          StringLength(15)>  _
         Public Property CustomerID() As String
@@ -1629,7 +1629,7 @@ Namespace EFCoreModels.Northwind
         ''' </summary>
         <ConcurrencyCheck(),  _
          DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          RoundtripOriginal(),  _
          StringLength(40)>  _
         Public Property ProductName() As String
@@ -2064,7 +2064,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets or sets the 'RegionDescription' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(50)>  _
         Public Property RegionDescription() As String
             Get
@@ -2246,7 +2246,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets or sets the 'TerritoryDescription' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(50)>  _
         Public Property TerritoryDescription() As String
             Get
@@ -2270,7 +2270,7 @@ Namespace EFCoreModels.Northwind
         <DataMember(),  _
          Editable(false, AllowInitialValue:=true),  _
          Key(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          RoundtripOriginal(),  _
          StringLength(20)>  _
         Public Property TerritoryID() As String

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCore_ComplexObject.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCore_ComplexObject.g.cs
@@ -59,7 +59,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// Gets or sets the 'AddressLine' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(100)]
         public string AddressLine
         {
@@ -85,7 +85,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// Gets or sets the 'City' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(50)]
         public string City
         {
@@ -171,7 +171,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// Gets or sets the 'HomePhone' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         [StringLength(24)]
         public string HomePhone
         {
@@ -421,7 +421,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// Gets or sets the 'Description' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         public string Description
         {
             get
@@ -481,7 +481,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// Gets or sets the 'Description' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         public string Description
         {
             get
@@ -578,7 +578,7 @@ namespace EFCoreModels.Scenarios.OwnedTypes
         /// Gets or sets the 'Description' value.
         /// </summary>
         [DataMember()]
-        [Required()]
+        [Required(AllowEmptyStrings=true)]
         public string Description
         {
             get

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCore_ComplexObject.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/EFCore_ComplexObject.g.vb
@@ -69,7 +69,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' Gets or sets the 'AddressLine' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(100)>  _
         Public Property AddressLine() As String
             Get
@@ -91,7 +91,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' Gets or sets the 'City' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(50)>  _
         Public Property City() As String
             Get
@@ -174,7 +174,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' Gets or sets the 'HomePhone' value.
         ''' </summary>
         <DataMember(),  _
-         Required(),  _
+         Required(AllowEmptyStrings:=true),  _
          StringLength(24)>  _
         Public Property HomePhone() As String
             Get
@@ -406,7 +406,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' Gets or sets the 'Description' value.
         ''' </summary>
         <DataMember(),  _
-         Required()>  _
+         Required(AllowEmptyStrings:=true)>  _
         Public Property Description() As String
             Get
                 Return Me._description
@@ -467,7 +467,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' Gets or sets the 'Description' value.
         ''' </summary>
         <DataMember(),  _
-         Required()>  _
+         Required(AllowEmptyStrings:=true)>  _
         Public Property Description() As String
             Get
                 Return Me._description
@@ -561,7 +561,7 @@ Namespace EFCoreModels.Scenarios.OwnedTypes
         ''' Gets or sets the 'Description' value.
         ''' </summary>
         <DataMember(),  _
-         Required()>  _
+         Required(AllowEmptyStrings:=true)>  _
         Public Property Description() As String
             Get
                 Return Me._description

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.cs
@@ -86,7 +86,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the 'CategoryName' value.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute()]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings=true)]
         [global::System.ComponentModel.DataAnnotations.StringLengthAttribute(15)]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         public string CategoryName
@@ -328,7 +328,7 @@ namespace EFCoreModels.Northwind
         /// Gets or sets the 'CompanyName' value.
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.ConcurrencyCheckAttribute()]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute()]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings=true)]
         [global::System.ComponentModel.DataAnnotations.RoundtripOriginalAttribute()]
         [global::System.ComponentModel.DataAnnotations.StringLengthAttribute(40)]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
@@ -439,7 +439,7 @@ namespace EFCoreModels.Northwind
         [global::System.ComponentModel.DataAnnotations.ConcurrencyCheckAttribute()]
         [global::System.ComponentModel.DataAnnotations.EditableAttribute(false, AllowInitialValue=true)]
         [global::System.ComponentModel.DataAnnotations.KeyAttribute()]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute()]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings=true)]
         [global::System.ComponentModel.DataAnnotations.RoundtripOriginalAttribute()]
         [global::System.ComponentModel.DataAnnotations.StringLengthAttribute(15)]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
@@ -1725,7 +1725,7 @@ namespace EFCoreModels.Northwind
         /// Gets or sets the 'ProductName' value.
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.ConcurrencyCheckAttribute()]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute()]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings=true)]
         [global::System.ComponentModel.DataAnnotations.RoundtripOriginalAttribute()]
         [global::System.ComponentModel.DataAnnotations.StringLengthAttribute(40)]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
@@ -2208,7 +2208,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the 'RegionDescription' value.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute()]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings=true)]
         [global::System.ComponentModel.DataAnnotations.StringLengthAttribute(50)]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         public string RegionDescription
@@ -2410,7 +2410,7 @@ namespace EFCoreModels.Northwind
         /// <summary>
         /// Gets or sets the 'TerritoryDescription' value.
         /// </summary>
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute()]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings=true)]
         [global::System.ComponentModel.DataAnnotations.StringLengthAttribute(50)]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         public string TerritoryDescription
@@ -2438,7 +2438,7 @@ namespace EFCoreModels.Northwind
         /// </summary>
         [global::System.ComponentModel.DataAnnotations.EditableAttribute(false, AllowInitialValue=true)]
         [global::System.ComponentModel.DataAnnotations.KeyAttribute()]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute()]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings=true)]
         [global::System.ComponentModel.DataAnnotations.RoundtripOriginalAttribute()]
         [global::System.ComponentModel.DataAnnotations.StringLengthAttribute(20)]
         [global::System.Runtime.Serialization.DataMemberAttribute()]

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/EFCoreDbContextScenarios.g.vb
@@ -96,7 +96,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the 'CategoryName' value.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.RequiredAttribute(),  _
+        <Global.System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings:=true),  _
          Global.System.ComponentModel.DataAnnotations.StringLengthAttribute(15),  _
          Global.System.Runtime.Serialization.DataMemberAttribute()>  _
         Public Property CategoryName() As String
@@ -334,7 +334,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets or sets the 'CompanyName' value.
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.ConcurrencyCheckAttribute(),  _
-         Global.System.ComponentModel.DataAnnotations.RequiredAttribute(),  _
+         Global.System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings:=true),  _
          Global.System.ComponentModel.DataAnnotations.RoundtripOriginalAttribute(),  _
          Global.System.ComponentModel.DataAnnotations.StringLengthAttribute(40),  _
          Global.System.Runtime.Serialization.DataMemberAttribute()>  _
@@ -429,7 +429,7 @@ Namespace EFCoreModels.Northwind
         <Global.System.ComponentModel.DataAnnotations.ConcurrencyCheckAttribute(),  _
          Global.System.ComponentModel.DataAnnotations.EditableAttribute(false, AllowInitialValue:=true),  _
          Global.System.ComponentModel.DataAnnotations.KeyAttribute(),  _
-         Global.System.ComponentModel.DataAnnotations.RequiredAttribute(),  _
+         Global.System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings:=true),  _
          Global.System.ComponentModel.DataAnnotations.RoundtripOriginalAttribute(),  _
          Global.System.ComponentModel.DataAnnotations.StringLengthAttribute(15),  _
          Global.System.Runtime.Serialization.DataMemberAttribute()>  _
@@ -1617,7 +1617,7 @@ Namespace EFCoreModels.Northwind
         ''' Gets or sets the 'ProductName' value.
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.ConcurrencyCheckAttribute(),  _
-         Global.System.ComponentModel.DataAnnotations.RequiredAttribute(),  _
+         Global.System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings:=true),  _
          Global.System.ComponentModel.DataAnnotations.RoundtripOriginalAttribute(),  _
          Global.System.ComponentModel.DataAnnotations.StringLengthAttribute(40),  _
          Global.System.Runtime.Serialization.DataMemberAttribute()>  _
@@ -2052,7 +2052,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the 'RegionDescription' value.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.RequiredAttribute(),  _
+        <Global.System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings:=true),  _
          Global.System.ComponentModel.DataAnnotations.StringLengthAttribute(50),  _
          Global.System.Runtime.Serialization.DataMemberAttribute()>  _
         Public Property RegionDescription() As String
@@ -2234,7 +2234,7 @@ Namespace EFCoreModels.Northwind
         ''' <summary>
         ''' Gets or sets the 'TerritoryDescription' value.
         ''' </summary>
-        <Global.System.ComponentModel.DataAnnotations.RequiredAttribute(),  _
+        <Global.System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings:=true),  _
          Global.System.ComponentModel.DataAnnotations.StringLengthAttribute(50),  _
          Global.System.Runtime.Serialization.DataMemberAttribute()>  _
         Public Property TerritoryDescription() As String
@@ -2258,7 +2258,7 @@ Namespace EFCoreModels.Northwind
         ''' </summary>
         <Global.System.ComponentModel.DataAnnotations.EditableAttribute(false, AllowInitialValue:=true),  _
          Global.System.ComponentModel.DataAnnotations.KeyAttribute(),  _
-         Global.System.ComponentModel.DataAnnotations.RequiredAttribute(),  _
+         Global.System.ComponentModel.DataAnnotations.RequiredAttribute(AllowEmptyStrings:=true),  _
          Global.System.ComponentModel.DataAnnotations.RoundtripOriginalAttribute(),  _
          Global.System.ComponentModel.DataAnnotations.StringLengthAttribute(20),  _
          Global.System.Runtime.Serialization.DataMemberAttribute()>  _


### PR DESCRIPTION
* Generate `[Required(AllowEmptyStrings=true)]` instead of `[Required]` on client for non nullable string properties
* It also bumps the package version to 4.1.0. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation for required non-nullable string properties now allows empty strings while still requiring a value, making required string validation more flexible.

* **Chores**
  * Release version updated to 4.1.0.

* **Documentation**
  * Added top-of-file release notes for the 4.1.0 release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenRIAServices/OpenRiaServices/pull/575)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->