### PR TITLE
run code generation tests on net10

### DIFF
--- a/src/OpenRiaServices.Client.Web/Framework/OpenRiaServices.Client.Web.csproj
+++ b/src/OpenRiaServices.Client.Web/Framework/OpenRiaServices.Client.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0;net8.0</TargetFrameworks>
     <PackageTags>WCF;RIA;Services;RIAServices;Silverlight;OpenRiaServices</PackageTags>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
+++ b/src/OpenRiaServices.Tools.TextTemplate/Test/OpenRiaServices.Tools.TextTemplate.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>

--- a/src/OpenRiaServices.Tools/Framework/CreateOpenRiaClientFilesTask.cs
+++ b/src/OpenRiaServices.Tools/Framework/CreateOpenRiaClientFilesTask.cs
@@ -752,7 +752,13 @@ namespace OpenRiaServices.Tools
                 "../net8.0/OpenRiaServices.Tools.CodeGenTask.dll"));
 
             if (!File.Exists(path))
-                throw new FileNotFoundException(path);
+            {
+                // try once more but with net10.0, this can happen when running tests
+                path = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(typeof(CreateOpenRiaClientFilesTask).Assembly.Location),
+                "../net10.0/OpenRiaServices.Tools.CodeGenTask.dll"));
+                if (!File.Exists(path))
+                    throw new FileNotFoundException(path);
+            }
 
             using var loggingServer = new CrossProcessLoggingServer();
             var startInfo = new ProcessStartInfo

--- a/src/OpenRiaServices.Tools/Test/ClientClassLib/ClientClassLib.csproj
+++ b/src/OpenRiaServices.Tools/Test/ClientClassLib/ClientClassLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>$(DefineConstants);SILVERLIGHT</DefineConstants>
     <DebugType>pdbonly</DebugType>

--- a/src/OpenRiaServices.Tools/Test/ClientClassLib2/ClientClassLib2.csproj
+++ b/src/OpenRiaServices.Tools/Test/ClientClassLib2/ClientClassLib2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DefineConstants>$(DefineConstants);SILVERLIGHT</DefineConstants>
     <DebugType>pdbonly</DebugType>

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NoWarn>618</NoWarn>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <DefineConstants Condition="'$(TargetFramework)' == 'net472'">$(DefineConstants);HAS_LINQ2SQL</DefineConstants>

--- a/src/OpenRiaServices.Tools/Test/ServerClassLib/ServerClassLib.csproj
+++ b/src/OpenRiaServices.Tools/Test/ServerClassLib/ServerClassLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <!-- We compile with Release settings to test PDB reader,
          though we pretend it is the Debug build just to simplify
          a debug build of the solution


### PR DESCRIPTION
This fix makes the tests run and pass on standard VS 2026 install where dotnet 8 SDK is not installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added .NET 10.0 as a target framework across multiple projects to extend SDK and test support.
  * Updated client-generation tooling to also look for codegen outputs for the newer framework, improving compatibility when generating client proxies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->