### PR TITLE
Improve surrogate (serialization) performance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ See [AspNetCore README](src/OpenRiaServices.Hosting.AspNetCore/Framework/README.
   * Non-side-effect operations now accept `GET`, `POST`, and `QUERY` requests (previously `GET` and `POST` only)
   * Side-effect operations remain `POST`-only
 
+# 5.9.0
+
 ## Client (`OpenRiaServices.Client.DomainClients.Http`)
 
 * Added `MaxQueryStringLength` setting to `HttpDomainClientFactory` (default `2048`)
@@ -29,6 +31,9 @@ DomainContext.DomainClientFactory = new BinaryHttpDomainClientFactory(baseUri, h
 };
 ```
 
+## Server
+
+* Improve performance for creating surrogate types, by reducing number of lookups (affect serialization performance)
 
 # EF Core 4.1.0
 

--- a/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/DomainServiceSerializationSurrogate.cs
+++ b/src/OpenRiaServices.Hosting.Wcf/Framework/Wcf/DomainServiceSerializationSurrogate.cs
@@ -1,9 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Reflection;
 using System.Runtime.Serialization;
-using System.Security;
 using OpenRiaServices.Server;
 
 #nullable disable
@@ -17,9 +15,9 @@ namespace OpenRiaServices.Hosting.Wcf
         : IDataContractSurrogate
 #endif
     {
-        private readonly DomainServiceDescription description;
-        private readonly Dictionary<Type, (Type surrogateType, Func<object, object> surrogateFactory)> exposedTypeToSurrogateMap;
-        private readonly HashSet<Type> surrogateTypes;
+        private readonly DomainServiceDescription _description;
+        private readonly ConcurrentDictionary<Type, (Type surrogateType, Func<object, object> surrogateFactory)> _exposedTypeToSurrogateMap;
+        private readonly HashSet<Type> _surrogateTypes;
 
         /// <summary>
         /// Default constructor.
@@ -27,29 +25,26 @@ namespace OpenRiaServices.Hosting.Wcf
         /// <param name="description">A description of the <see cref="DomainService"/> this type creates surrogates for.</param>
         public DomainServiceSerializationSurrogate(DomainServiceDescription description)
         {
-            this.description = description;
-            this.surrogateTypes = new HashSet<Type>();
-            this.exposedTypeToSurrogateMap = new Dictionary<Type, (Type, Func<object, object>)>();
+            this._description = description;
+            _surrogateTypes = new HashSet<Type>();
+            _exposedTypeToSurrogateMap = new ConcurrentDictionary<Type, (Type, Func<object, object>)>();
 
             // Cache the list of entity types and surrogate types.
             HashSet<Type> exposedTypes = new HashSet<Type>(description.EntityTypes);
 
             // Because complex types and entities cannot share an inheritance relationship, we can add them to the same surrogate set.
-            foreach (Type complexType in description.ComplexTypes)
-            {
-                exposedTypes.Add(complexType);
-            }
+            exposedTypes.UnionWith(description.ComplexTypes);
 
             foreach (Type exposedType in exposedTypes)
             {
                 Type surrogateType = DataContractSurrogateGenerator.GetSurrogateType(exposedTypes, exposedType);
-                Func<object, object> surrogateFactory = (Func<object, object>)DynamicMethodUtility.GetFactoryMethod(surrogateType.GetConstructor(new Type[] { exposedType }), typeof(Func<object, object>));
-                exposedTypeToSurrogateMap.Add(exposedType, (surrogateType, surrogateFactory));
-                surrogateTypes.Add(surrogateType);
+                Func<object, object> surrogateFactory = (Func<object, object>)DynamicMethodUtility.GetFactoryMethod(surrogateType.GetConstructor([exposedType]), typeof(Func<object, object>));
+                _exposedTypeToSurrogateMap.TryAdd(exposedType, (surrogateType, surrogateFactory));
+                _surrogateTypes.Add(surrogateType);
             }
         }
 
-        public IReadOnlyCollection<Type> SurrogateTypes => this.surrogateTypes;
+        public IReadOnlyCollection<Type> SurrogateTypes => this._surrogateTypes;
 
 #if ASPNET_CORE
         public Type GetSurrogateType(Type type)
@@ -57,7 +52,7 @@ namespace OpenRiaServices.Hosting.Wcf
         public Type GetDataContractType(Type type)
 #endif
         {
-            if (this.exposedTypeToSurrogateMap.TryGetValue(type, out var surrogateInfo))
+            if (this._exposedTypeToSurrogateMap.TryGetValue(type, out var surrogateInfo))
             {
                 return surrogateInfo.surrogateType;
             }
@@ -66,7 +61,7 @@ namespace OpenRiaServices.Hosting.Wcf
 
         public object GetDeserializedObject(object obj, Type targetType)
         {
-            if (this.surrogateTypes.Contains(obj.GetType()))
+            if (this._surrogateTypes.Contains(obj.GetType()))
             {
                 return ((ICloneable)obj).Clone();
             }
@@ -74,20 +69,45 @@ namespace OpenRiaServices.Hosting.Wcf
             return obj;
         }
 
+        // Fast path to get deserialized object when we know the type is a surrogate, to avoid the dictionary lookup in GetDeserializedObject.
+        internal object GetDeserializedObjectFast(object obj)
+        {
+            return ((ICloneable)obj).Clone();
+        }
+
         public object GetObjectToSerialize(object obj, Type targetType)
         {
-            Type exposedType = this.description.GetSerializationType(obj.GetType());
-
-            if (exposedType != null && (exposedType != targetType))
+            Type type = obj.GetType();
+            if (type == targetType)
             {
-                if (this.exposedTypeToSurrogateMap.TryGetValue(exposedType, out var surrogateInfo))
-                {
-                    // Return a new instance of the surrogate.
-                    return surrogateInfo.surrogateFactory(obj);
-                }
+                return obj;
             }
 
-            return obj;
+            // Fast path for then type is exactly a known type
+            var (_, surrogateFactory) = this._exposedTypeToSurrogateMap.GetOrAdd(type, static (key, This) =>
+            {
+                // If the type is not found, check the inheritance heirarchy for a known type.
+                // This ensures that the method works if the type is a proxy type generated by an ORM, for example.
+                Type exposedType = This._description.GetSerializationType(key);
+                if (This._exposedTypeToSurrogateMap.TryGetValue(exposedType, out var surrogateInfo))
+                {
+                    // Return a new instance of the surrogate.
+                    return surrogateInfo;
+                }
+                return default;
+            }, this);
+
+
+            return surrogateFactory?.Invoke(obj) ?? obj;
+        }
+
+        public Func<object, object> TryGetSurrogateFactory(Type type)
+        {
+            if (this._exposedTypeToSurrogateMap.TryGetValue(type, out var surrogateInfo))
+            {
+                return surrogateInfo.surrogateFactory;
+            }
+            return null;
         }
 
 #if !ASPNET_CORE


### PR DESCRIPTION
This pull request focuses on improving the performance of surrogate type creation in the WCF server serialization logic, which should positively impact serialization performance. The main changes involve optimizing how surrogate types and their factories are stored and accessed, as well as simplifying some of the logic for handling these types.

Documentation updates:

* Updated the changelog to document the performance improvements for surrogate type creation and serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Significantly enhanced server-side serialization and deserialization performance through improved surrogate type caching mechanisms and streamlined lookup strategies
  * Optimized surrogate type creation and resolution processes, reducing lookup overhead and delivering faster data serialization operations with improved system responsiveness

* **Release**
  * Version 5.9.0 now available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->