### PR TITLE
Update Changelog for MessagePack transport support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,47 @@
+
+# 5.10.0 / AspNetCore 1.6.0 — MessagePack transport preview
+
+## AspNetCore 1.6.0
+
+* Added MessagePack wire-format support (`application/vnd.msgpack`) via [#591](https://github.com/OpenRIAServices/OpenRiaServices/pull/591)
+
+### Enable MessagePack on the server
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddOpenRiaServices()
+    .AddMessagePackSerialization();
+```
+Optionally pass a custom `Nerdbank.MessagePack.MessagePackSerializer` to add converters or a custom comparer provider:
+```csharp
+builder.Services.AddOpenRiaServices()
+    .AddMessagePackSerialization(opt =>
+    {
+        opt.Serializer = new Nerdbank.MessagePack.MessagePackSerializer()
+        {
+            // custom converters / comparer provider
+        };
+    });
+```
+## Client 5.10.0 (`OpenRiaServices.Client.DomainClients.Http`)
+
+* Added `MessagePackHttpDomainClientFactory` — a `DomainClientFactory` that communicates with the server using MessagePack over HTTP
+### Enable MessagePack on the client
+```csharp
+DomainContext.DomainClientFactory =
+    new MessagePackHttpDomainClientFactory(baseUri, httpClientFactory);
+```
+Optionally pass a custom serializer:
+```csharp
+var serializer = new MessagePackSerializer()
+{
+    // custom converters / comparer provider
+};
+DomainContext.DomainClientFactory =
+    new MessagePackHttpDomainClientFactory(baseUri, httpClientFactory, serializer);
+```
+For performance benchmark data see [PR #591](https://github.com/OpenRIAServices/OpenRiaServices/pull/591).
+
 # AspNetCore 1.5.0
 
 * Allow configuring Serializer security settings


### PR DESCRIPTION
Added support for MessagePack serialization in AspNetCore and client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Release notes for v5.10.0 and AspNetCore 1.6.0 documenting new MessagePack serialization support with server and client configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->