### PR TITLE
Update MessagePack NuGet files and improve type handling

### DIFF
--- a/NuGet/OpenRiaServices.Client.Core.nuspec
+++ b/NuGet/OpenRiaServices.Client.Core.nuspec
@@ -18,15 +18,15 @@
     <tags>WCF RIA Services RIAServices Silverlight OpenRiaServices</tags>
     <dependencies>
       <group targetFramework="net472">
-        <dependency id="Nerdbank.MessagePack" version="1.2.4" exclude="Build,Analyzers" />
+        <dependency id="Nerdbank.MessagePack" version="1.2.36" exclude="Build,Analyzers" />
         <dependency id="System.IO.Hashing" version="10.0.9" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Nerdbank.MessagePack" version="1.2.4" exclude="Build,Analyzers" />
+        <dependency id="Nerdbank.MessagePack" version="1.2.36" exclude="Build,Analyzers" />
         <dependency id="System.IO.Hashing" version="10.0.9" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0-windows7.0">
-        <dependency id="Nerdbank.MessagePack" version="1.2.4" exclude="Build,Analyzers" />
+        <dependency id="Nerdbank.MessagePack" version="1.2.36" exclude="Build,Analyzers" />
         <dependency id="System.IO.Hashing" version="10.0.9" exclude="Build,Analyzers" />
       </group>
     </dependencies>
@@ -42,27 +42,12 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-    <!-- netstandard binaries -->	
-	<!--
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.dll" target="lib\netstandard2.0\OpenRiaServices.Client.dll" />
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.pdb" target="lib\netstandard2.0\OpenRiaServices.Client.pdb" />
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.xml" target="lib\netstandard2.0\OpenRiaServices.Client.xml" />
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.Web.dll" target="lib\netstandard2.0\OpenRiaServices.Client.Web.dll" />
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.Web.pdb" target="lib\netstandard2.0\OpenRiaServices.Client.Web.pdb" />
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.Web.xml" target="lib\netstandard2.0\OpenRiaServices.Client.Web.xml" />
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.dll" />
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.pdb" target="lib\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.pdb" />
-    <file src="..\src\bin\Release\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.xml" target="lib\netstandard2.0\OpenRiaServices.Client.DomainClients.Http.xml" />
--->
+
    <!-- Desktop binaries -->
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.dll" target="lib\net472\OpenRiaServices.Client.dll" />
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.pdb" target="lib\net472\OpenRiaServices.Client.pdb" />
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.xml" target="lib\net472\OpenRiaServices.Client.xml" />
-	<!--
-    <file src="..\src\bin\Release\net472\OpenRiaServices.Client.Web.dll" target="lib\net472\OpenRiaServices.Client.Web.dll" />
-    <file src="..\src\bin\Release\net472\OpenRiaServices.Client.Web.pdb" target="lib\net472\OpenRiaServices.Client.Web.pdb" />
-    <file src="..\src\bin\Release\net472\OpenRiaServices.Client.Web.xml" target="lib\net472\OpenRiaServices.Client.Web.xml" />
-	-->
+
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\net472\OpenRiaServices.Client.DomainClients.Http.dll" />
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.DomainClients.Http.pdb" target="lib\net472\OpenRiaServices.Client.DomainClients.Http.pdb" />
     <file src="..\src\bin\Release\net472\OpenRiaServices.Client.DomainClients.Http.xml" target="lib\net472\OpenRiaServices.Client.DomainClients.Http.xml" />
@@ -71,11 +56,7 @@
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.dll" target="lib\net8.0\OpenRiaServices.Client.dll" />
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.pdb" target="lib\net8.0\OpenRiaServices.Client.pdb" />
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.xml" target="lib\net8.0\OpenRiaServices.Client.xml" />
-	<!--
-    <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.Web.dll" target="lib\net8.0\OpenRiaServices.Client.Web.dll" />
-    <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.Web.pdb" target="lib\net8.0\OpenRiaServices.Client.Web.pdb" />
-    <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.Web.xml" target="lib\net8.0\OpenRiaServices.Client.Web.xml" />
-	-->
+
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\net8.0\OpenRiaServices.Client.DomainClients.Http.dll" />
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.DomainClients.Http.pdb" target="lib\net8.0\OpenRiaServices.Client.DomainClients.Http.pdb" />
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.DomainClients.Http.xml" target="lib\net8.0\OpenRiaServices.Client.DomainClients.Http.xml" />
@@ -84,11 +65,7 @@
     <file src="..\src\bin\Release\net8.0-windows\OpenRiaServices.Client.dll" target="lib\net8.0-windows7.0\OpenRiaServices.Client.dll" />
     <file src="..\src\bin\Release\net8.0-windows\OpenRiaServices.Client.pdb" target="lib\net8.0-windows7.0\OpenRiaServices.Client.pdb" />
     <file src="..\src\bin\Release\net8.0-windows\OpenRiaServices.Client.xml" target="lib\net8.0-windows7.0\OpenRiaServices.Client.xml" />
-	<!--
-    <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.Web.dll" target="lib\net8.0-windows7.0\OpenRiaServices.Client.Web.dll" />
-    <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.Web.pdb" target="lib\net8.0-windows7.0\OpenRiaServices.Client.Web.pdb" />
-    <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.Web.xml" target="lib\net8.0-windows7.0\OpenRiaServices.Client.Web.xml" />
-	-->
+
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.DomainClients.Http.dll" target="lib\net8.0-windows7.0\OpenRiaServices.Client.DomainClients.Http.dll" />
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.DomainClients.Http.pdb" target="lib\net8.0-windows7.0\OpenRiaServices.Client.DomainClients.Http.pdb" />
     <file src="..\src\bin\Release\net8.0\OpenRiaServices.Client.DomainClients.Http.xml" target="lib\net8.0-windows7.0\OpenRiaServices.Client.DomainClients.Http.xml" />

--- a/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
+++ b/src/OpenRiaServices.Client.DomainClients.Http/Framework/OpenRiaServices.Client.DomainClients.Http.csproj
@@ -24,7 +24,8 @@
     <ProjectReference Include="..\..\OpenRiaServices.Client\Framework\OpenRiaServices.Client.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.36" />
+    <PackageReference Include="PolyType" Version="1.4.1" />
     <PackageReference Include="System.IO.Hashing" Version="10.0.9" />
   </ItemGroup>
   <ItemGroup>

--- a/src/OpenRiaServices.Client/Framework/OpenRiaServices.Client.csproj
+++ b/src/OpenRiaServices.Client/Framework/OpenRiaServices.Client.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.36" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/MessagePackSerializationProvider.cs
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/AspNetCore/Serialization/MessagePackSerializationProvider.cs
@@ -36,6 +36,7 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
             Wcf.DomainServiceSerializationSurrogate surrogateProvider = new Wcf.DomainServiceSerializationSurrogate(description);
 
             // Create converters to handle surrogates,
+            Dictionary<Type, DerivedTypeUnion> derivedTypeUnions = _serializer.DerivedTypeUnions.ToDictionary(du => du.BaseType);
             List<MessagePackConverter> converters = new();
             foreach (var entityType in description.EntityTypes.Concat(description.ComplexTypes))
             {
@@ -43,6 +44,9 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
                 {
                     converters.Add((MessagePackConverter)
                         Activator.CreateInstance(typeof(SurrogateConverter<,>).MakeGenericType(surrogateType, entityType), args: [description, surrogateProvider])!);
+
+                    // Prevent Nerdbank.MessagePack from adding an additional discriminator.
+                    derivedTypeUnions[entityType] = DerivedTypeUnion.CreateDisabled(entityType);
                 }
             }
 
@@ -52,7 +56,8 @@ namespace OpenRiaServices.Hosting.AspNetCore.Serialization
 
             return _serializer with
             {
-                Converters = [.. _serializer.Converters, .. converters]
+                Converters = [.. _serializer.Converters, .. converters],
+                DerivedTypeUnions = [.. derivedTypeUnions.Values],
             };
         }
     }

--- a/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
+++ b/src/OpenRiaServices.Hosting.AspNetCore/Framework/OpenRiaServices.Hosting.AspNetCore.csproj
@@ -26,7 +26,8 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.4" />
+    <PackageReference Include="Nerdbank.MessagePack" Version="1.2.36" />
+    <PackageReference Include="PolyType" Version="1.4.1" />
     <PackageReference Include="System.IO.Hashing" Version="10.0.9" />
   </ItemGroup>
 

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpComplexObjectGenerator.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpComplexObjectGenerator.cs
@@ -342,15 +342,15 @@ this.Write(")\r\n{\r\n\tthis.OnCreated();\r\n\tbase.OnDeserializing(default(Syst
 
 				foreach (var pd in requiredProperties)
 				{
-					string parameterName = CodeGenUtilities.GetSafeName(pd.Name);
+					string safeName = CodeGenUtilities.GetSafeName(pd.Name);
 
 this.Write("\tthis.");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(pd.Name));
+this.Write(this.ToStringHelper.ToStringWithCulture(safeName));
 
 this.Write(" = ");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(parameterName));
+this.Write(this.ToStringHelper.ToStringWithCulture(safeName));
 
 this.Write(";\r\n");
 

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpComplexObjectGenerator.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpComplexObjectGenerator.cs
@@ -315,28 +315,18 @@ this.Write("()\r\n{\r\n\tthis.OnCreated();\r\n}\r\n");
 
 
 
-        if (!this.IsAbstract)
-        {
-            var properties = TypeDescriptor.GetProperties(this.Type);
-            bool hasRequiredProperty = properties.Cast<PropertyDescriptor>()
-                .Any(p => p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
-                    && ShouldDeclareProperty(p)
-                    && CanGenerateProperty(p));
+		if (!this.IsAbstract)
+		{
+			var requiredProperties = TypeDescriptor.GetProperties(this.Type)
+				.Cast<PropertyDescriptor>()
+				.Where(p => p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
+					&& ShouldDeclareProperty(p)
+					&& CanGenerateProperty(p))
+				.ToList();
 
-            if (hasRequiredProperty)
-            {
-                var pd = properties.Cast<PropertyDescriptor>()
-                    .FirstOrDefault(p => !p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
-                        && ShouldDeclareProperty(p)
-                        && CanGenerateProperty(p));
-
-                if (pd is null)
-                {
-                    this.ClientCodeGenerator.Error($"The type '{this.Type}' has only required properties, cannot generate PolyType compatible constructor");
-                }
-                else
-                {
-                    string parameterName = pd.Name;
+			if (requiredProperties.Count > 0)
+			{
+				string parameterDeclarations = string.Join(", ", requiredProperties.Select(pd => $"{CodeGenUtilities.GetTypeName(pd.PropertyType)} {CodeGenUtilities.GetSafeName(pd.Name)}"));
 
 this.Write("\r\n[PolyType.ConstructorShape]\r\nprivate ");
 
@@ -344,14 +334,17 @@ this.Write(this.ToStringHelper.ToStringWithCulture(typeName));
 
 this.Write("(");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(CodeGenUtilities.GetTypeName(pd.PropertyType)));
+this.Write(this.ToStringHelper.ToStringWithCulture(parameterDeclarations));
 
-this.Write(" ");
+this.Write(")\r\n{\r\n\tthis.OnCreated();\r\n\tbase.OnDeserializing(default(System.Runtime.Serializat" +
+        "ion.StreamingContext));\r\n");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(parameterName));
 
-this.Write(")\r\n{\r\n\tthis.OnCreated();\r\n    base.OnDeserializing(default(System.Runtime.Seriali" +
-        "zation.StreamingContext));\r\n    this.");
+				foreach (var pd in requiredProperties)
+				{
+					string parameterName = CodeGenUtilities.GetSafeName(pd.Name);
+
+this.Write("\tthis.");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(pd.Name));
 
@@ -359,12 +352,16 @@ this.Write(" = ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(parameterName));
 
-this.Write(";\r\n}\r\n");
+this.Write(";\r\n");
 
 
-                }
-            }
-        }
+				}
+
+this.Write("}\r\n");
+
+
+			}
+		}
 	}
 	
 	private void GeneratePropertiesInternal()

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpEntityGenerator.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpEntityGenerator.cs
@@ -423,15 +423,15 @@ this.Write(")\r\n{\r\n\tthis.OnCreated();\r\n\tbase.OnDeserializing(default(Syst
 
 				foreach (var pd in requiredProperties)
 				{
-					string parameterName = CodeGenUtilities.GetSafeName(pd.Name);
+					string safeName = CodeGenUtilities.GetSafeName(pd.Name);
 
 this.Write("\tthis.");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(pd.Name));
+this.Write(this.ToStringHelper.ToStringWithCulture(safeName));
 
 this.Write(" = ");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(parameterName));
+this.Write(this.ToStringHelper.ToStringWithCulture(safeName));
 
 this.Write(";\r\n");
 

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpEntityGenerator.cs
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/CSharpEntityGenerator.cs
@@ -396,28 +396,18 @@ this.Write("()\r\n{\r\n\tthis.OnCreated();\r\n}\r\n");
 
 
 
-        if (!this.IsAbstract)
-        {
-            var properties = TypeDescriptor.GetProperties(this.Type);
-            bool hasRequiredProperty = properties.Cast<PropertyDescriptor>()
-                .Any(p => p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
-                    && ShouldDeclareProperty(p)
-                    && CanGenerateProperty(p));
+		if (!this.IsAbstract)
+		{
+			var requiredProperties = TypeDescriptor.GetProperties(this.Type)
+				.Cast<PropertyDescriptor>()
+				.Where(p => p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
+					&& ShouldDeclareProperty(p)
+					&& CanGenerateProperty(p))
+				.ToList();
 
-            if (hasRequiredProperty)
-            {
-                var pd = properties.Cast<PropertyDescriptor>()
-                    .FirstOrDefault(p => !p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
-                        && ShouldDeclareProperty(p)
-                        && CanGenerateProperty(p));
-
-                if (pd is null)
-                {
-                    this.ClientCodeGenerator.Error($"The type '{this.Type}' has only required properties, cannot generate PolyType compatible constructor");
-                }
-                else
-                {
-                    string parameterName = pd.Name;
+			if (requiredProperties.Count > 0)
+			{
+				string parameterDeclarations = string.Join(", ", requiredProperties.Select(pd => $"{CodeGenUtilities.GetTypeName(pd.PropertyType)} {CodeGenUtilities.GetSafeName(pd.Name)}"));
 
 this.Write("\r\n[PolyType.ConstructorShape]\r\nprivate ");
 
@@ -425,14 +415,17 @@ this.Write(this.ToStringHelper.ToStringWithCulture(typeName));
 
 this.Write("(");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(CodeGenUtilities.GetTypeName(pd.PropertyType)));
+this.Write(this.ToStringHelper.ToStringWithCulture(parameterDeclarations));
 
-this.Write(" ");
+this.Write(")\r\n{\r\n\tthis.OnCreated();\r\n\tbase.OnDeserializing(default(System.Runtime.Serializat" +
+        "ion.StreamingContext));\r\n");
 
-this.Write(this.ToStringHelper.ToStringWithCulture(parameterName));
 
-this.Write(")\r\n{\r\n\tthis.OnCreated();\r\n    base.OnDeserializing(default(System.Runtime.Seriali" +
-        "zation.StreamingContext));\r\n    this.");
+				foreach (var pd in requiredProperties)
+				{
+					string parameterName = CodeGenUtilities.GetSafeName(pd.Name);
+
+this.Write("\tthis.");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(pd.Name));
 
@@ -440,12 +433,16 @@ this.Write(" = ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(parameterName));
 
-this.Write(";\r\n}\r\n");
+this.Write(";\r\n");
 
 
-                }
-            }
-        }
+				}
+
+this.Write("}\r\n");
+
+
+			}
+		}
 	}
 	
 	private void GeneratePropertiesInternal()

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/Templates/DataContractGeneratorTemplate.ttinclude
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/Templates/DataContractGeneratorTemplate.ttinclude
@@ -88,9 +88,9 @@ private <#= typeName #>(<#= parameterDeclarations #>)
 <#+
 				foreach (var pd in requiredProperties)
 				{
-					string parameterName = CodeGenUtilities.GetSafeName(pd.Name);
+					string safeName = CodeGenUtilities.GetSafeName(pd.Name);
 #>
-	this.<#= pd.Name #> = <#= parameterName #>;
+	this.<#= safeName #> = <#= safeName #>;
 <#+
 				}
 #>

--- a/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/Templates/DataContractGeneratorTemplate.ttinclude
+++ b/src/OpenRiaServices.Tools.TextTemplate/Framework/CSharpGenerators/Templates/DataContractGeneratorTemplate.ttinclude
@@ -66,41 +66,38 @@ namespace <#= this.Type.Namespace #>
 }
 <#+
 
-        if (!this.IsAbstract)
-        {
-            var properties = TypeDescriptor.GetProperties(this.Type);
-            bool hasRequiredProperty = properties.Cast<PropertyDescriptor>()
-                .Any(p => p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
-                    && ShouldDeclareProperty(p)
-                    && CanGenerateProperty(p));
+		if (!this.IsAbstract)
+		{
+			var requiredProperties = TypeDescriptor.GetProperties(this.Type)
+				.Cast<PropertyDescriptor>()
+				.Where(p => p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
+					&& ShouldDeclareProperty(p)
+					&& CanGenerateProperty(p))
+				.ToList();
 
-            if (hasRequiredProperty)
-            {
-                var pd = properties.Cast<PropertyDescriptor>()
-                    .FirstOrDefault(p => !p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
-                        && ShouldDeclareProperty(p)
-                        && CanGenerateProperty(p));
-
-                if (pd is null)
-                {
-                    this.ClientCodeGenerator.Error($"The type '{this.Type}' has only required properties, cannot generate PolyType compatible constructor");
-                }
-                else
-                {
-                    string parameterName = pd.Name;
+			if (requiredProperties.Count > 0)
+			{
+				string parameterDeclarations = string.Join(", ", requiredProperties.Select(pd => $"{CodeGenUtilities.GetTypeName(pd.PropertyType)} {CodeGenUtilities.GetSafeName(pd.Name)}"));
 #>
 
 [PolyType.ConstructorShape]
-private <#= typeName #>(<#= CodeGenUtilities.GetTypeName(pd.PropertyType) #> <#= parameterName #>)
+private <#= typeName #>(<#= parameterDeclarations #>)
 {
 	this.OnCreated();
-    base.OnDeserializing(default(System.Runtime.Serialization.StreamingContext));
-    this.<#= pd.Name #> = <#= parameterName #>;
+	base.OnDeserializing(default(System.Runtime.Serialization.StreamingContext));
+<#+
+				foreach (var pd in requiredProperties)
+				{
+					string parameterName = CodeGenUtilities.GetSafeName(pd.Name);
+#>
+	this.<#= pd.Name #> = <#= parameterName #>;
+<#+
+				}
+#>
 }
 <#+
-                }
-            }
-        }
+			}
+		}
 	}
 	
 	private void GeneratePropertiesInternal()

--- a/src/OpenRiaServices.Tools/Framework/DataContractProxyGenerator.cs
+++ b/src/OpenRiaServices.Tools/Framework/DataContractProxyGenerator.cs
@@ -213,58 +213,52 @@ namespace OpenRiaServices.Tools
 
         private void GeneratePolyTypeDeserializationConstructor()
         {
-            var properties = TypeDescriptor.GetProperties(this.Type);
-            bool hasRequiredProperty = properties.Cast<PropertyDescriptor>()
-                .Any(p => p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
+            var requiredProperties = TypeDescriptor.GetProperties(this.Type)
+                .Cast<PropertyDescriptor>()
+                .Where(p => p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
                     && ShouldDeclareProperty(p)
-                    && CanGenerateProperty(p));
+                    && CanGenerateProperty(p))
+                .ToList();
 
-            if (hasRequiredProperty)
+            if (requiredProperties.Count > 0)
             {
-                var pd = properties.Cast<PropertyDescriptor>()
-                    .FirstOrDefault(p => !p.Attributes.OfType<DataMemberAttribute>().Any(a => a.IsRequired)
-                        && ShouldDeclareProperty(p)
-                        && CanGenerateProperty(p));
-                if (pd != null)
+                var deserializingConstructor = new CodeConstructor();
+                deserializingConstructor.Attributes = MemberAttributes.Private;
+
+                // [ConstructorShape]
+                deserializingConstructor.CustomAttributes.Add(new CodeAttributeDeclaration("PolyType.ConstructorShapeAttribute"));
+
+                foreach (var pd in requiredProperties)
                 {
-                    var deserializingConstructor = new CodeConstructor();
-                    deserializingConstructor.Attributes = MemberAttributes.Private;
-
-                    // [ConstructorShape]
-                    deserializingConstructor.CustomAttributes.Add(new CodeAttributeDeclaration("PolyType.ConstructorShapeAttribute"));
-
-                    // Add constructor parameter from selected property descriptor
-                    string parameterName = pd.Name;
                     deserializingConstructor.Parameters.Add(
                         new CodeParameterDeclarationExpression(
                             CodeGenUtilities.GetTypeReference(pd.PropertyType, this.ClientProxyGenerator, this.ProxyClass),
-                            parameterName));
+                            pd.Name));
+                }
 
-                    // add default ctor doc comments
-                    string comment = "Deserialization ctor for MessagePack support, when any Property is required";
-                    deserializingConstructor.Comments.AddRange(CodeGenUtilities.GenerateSummaryCodeComment(comment, this.ClientProxyGenerator.IsCSharp));
+                // add default ctor doc comments
+                string comment = "Deserialization ctor for MessagePack support, when any Property is required";
+                deserializingConstructor.Comments.AddRange(CodeGenUtilities.GenerateSummaryCodeComment(comment, this.ClientProxyGenerator.IsCSharp));
 
-                    // add call to default OnCreated method
-                    deserializingConstructor.Statements.Add(this.NotificationMethodGen.OnCreatedMethodInvokeExpression);
+                // add call to default OnCreated method
+                deserializingConstructor.Statements.Add(this.NotificationMethodGen.OnCreatedMethodInvokeExpression);
 
-                    // Generate: base.OnDeserializing(default);
-                    deserializingConstructor.Statements.Add(
-                        new CodeMethodInvokeExpression(
-                            new CodeMethodReferenceExpression(new CodeBaseReferenceExpression(), "OnDeserializing"),
-                            new CodeDefaultValueExpression(new CodeTypeReference(typeof(StreamingContext)))));
+                // Generate: base.OnDeserializing(default);
+                deserializingConstructor.Statements.Add(
+                    new CodeMethodInvokeExpression(
+                        new CodeMethodReferenceExpression(new CodeBaseReferenceExpression(), "OnDeserializing"),
+                        new CodeDefaultValueExpression(new CodeTypeReference(typeof(StreamingContext)))));
 
+                foreach (var pd in requiredProperties)
+                {
                     // Set property from constructor parameter: this.<pd.Name> = <parameter>;
                     deserializingConstructor.Statements.Add(
                         new CodeAssignStatement(
                             new CodePropertyReferenceExpression(new CodeThisReferenceExpression(), pd.Name),
-                            new CodeArgumentReferenceExpression(parameterName)));
+                            new CodeArgumentReferenceExpression(pd.Name)));
+                }
 
-                    this.ProxyClass.Members.Add(deserializingConstructor);
-                }
-                else
-                {
-                    throw new InvalidOperationException($"The type '{this.Type}' has only required properties, cannot generate PolyType compatible constructor");
-                }
+                this.ProxyClass.Members.Add(deserializingConstructor);
             }
         }
 

--- a/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
+++ b/src/OpenRiaServices.Tools/Test/OpenRiaServices.Tools.Test.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.11.48" PrivateAssets="All" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.11.48" PrivateAssets="All" ExcludeAssets="Runtime" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.*" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.cs
@@ -496,11 +496,11 @@ namespace TestDomainServices
         /// Deserialization ctor for MessagePack support, when any Property is required
         /// </summary>
         [PolyType.ConstructorShapeAttribute()]
-        private MockReport(int CustomerId)
+        private MockReport(string ReportTitle)
         {
             this.OnCreated();
             base.OnDeserializing(default(System.Runtime.Serialization.StreamingContext));
-            this.CustomerId = CustomerId;
+            this.ReportTitle = ReportTitle;
         }
         
         /// <summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.vb
@@ -25,65 +25,65 @@ Imports System.Runtime.Serialization
 Imports System.Threading.Tasks
 
 Namespace TestDomainServices
-
+    
     ''' <summary>
     ''' The 'MockCustomer' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
     Partial Public NotInheritable Class MockCustomer
         Inherits Entity
-
+        
         Private _city As EntityRef(Of Global.Cities.City)
-
+        
         Private _cityName As String
-
+        
         Private _customerId As Integer
-
+        
         Private _previousResidences As EntityCollection(Of Global.Cities.City)
-
+        
         Private _stateName As String
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
-        Partial Private Sub OnCityNameChanging(ByVal value As String)
+        Private Partial Sub OnCityNameChanging(ByVal value As String)
         End Sub
-        Partial Private Sub OnCityNameChanged()
+        Private Partial Sub OnCityNameChanged()
         End Sub
-        Partial Private Sub OnCustomerIdChanging(ByVal value As Integer)
+        Private Partial Sub OnCustomerIdChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnCustomerIdChanged()
+        Private Partial Sub OnCustomerIdChanged()
         End Sub
-        Partial Private Sub OnStateNameChanging(ByVal value As String)
+        Private Partial Sub OnStateNameChanging(ByVal value As String)
         End Sub
-        Partial Private Sub OnStateNameChanged()
+        Private Partial Sub OnStateNameChanged()
         End Sub
-        Partial Private Sub OnMockCustomerCustomMethodInvoking(ByVal expectedStateName As String, ByVal expectedOriginalStateName As String)
+        Private Partial Sub OnMockCustomerCustomMethodInvoking(ByVal expectedStateName As String, ByVal expectedOriginalStateName As String)
         End Sub
-        Partial Private Sub OnMockCustomerCustomMethodInvoked()
+        Private Partial Sub OnMockCustomerCustomMethodInvoked()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockCustomer"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="City"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_City", New String() {"CityName", "StateName"}, New String() {"Name", "StateName"}, IsForeignKey:=True),
-         ExternalReference()>
+        <EntityAssociation("Customer_City", New String() {"CityName", "StateName"}, New String() {"Name", "StateName"}, IsForeignKey:=true),  _
+         ExternalReference()>  _
         Public Property City() As Global.Cities.City
             Get
                 If (Me._city Is Nothing) Then
@@ -93,11 +93,11 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As Global.Cities.City = Me.City
-                If (Object.Equals(previous, Value) = False) Then
-                    Me.ValidateProperty("City", Value)
-                    If (Not (Value) Is Nothing) Then
-                        Me.CityName = Value.Name
-                        Me.StateName = Value.StateName
+                If (Object.Equals(previous, value) = false) Then
+                    Me.ValidateProperty("City", value)
+                    If (Not (value) Is Nothing) Then
+                        Me.CityName = value.Name
+                        Me.StateName = value.StateName
                     Else
                         Me.CityName = CType(Nothing, String)
                         Me.StateName = CType(Nothing, String)
@@ -105,56 +105,56 @@ Namespace TestDomainServices
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'CityName' value.
         ''' </summary>
-        <DataMember(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         RoundtripOriginal()>  _
         Public Property CityName() As String
             Get
                 Return Me._cityName
             End Get
             Set
-                If (String.Equals(Me._cityName, Value) = False) Then
-                    Me.OnCityNameChanging(Value)
+                If (String.Equals(Me._cityName, value) = false) Then
+                    Me.OnCityNameChanging(value)
                     Me.RaiseDataMemberChanging("CityName")
-                    Me.ValidateProperty("CityName", Value)
-                    Me._cityName = Value
+                    Me.ValidateProperty("CityName", value)
+                    Me._cityName = value
                     Me.RaiseDataMemberChanged("CityName")
-                    Me.OnCityNameChanged()
+                    Me.OnCityNameChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'CustomerId' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False, AllowInitialValue:=True),
-         Key(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         Editable(false, AllowInitialValue:=true),  _
+         Key(),  _
+         RoundtripOriginal()>  _
         Public Property CustomerId() As Integer
             Get
                 Return Me._customerId
             End Get
             Set
-                If ((Me._customerId = Value) _
-                            = False) Then
-                    Me.OnCustomerIdChanging(Value)
-                    Me.ValidateProperty("CustomerId", Value)
-                    Me._customerId = Value
+                If ((Me._customerId = value)  _
+                            = false) Then
+                    Me.OnCustomerIdChanging(value)
+                    Me.ValidateProperty("CustomerId", value)
+                    Me._customerId = value
                     Me.RaisePropertyChanged("CustomerId")
-                    Me.OnCustomerIdChanged()
+                    Me.OnCustomerIdChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets the collection of associated <see cref="City"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_PreviousResidences", "StateName", "StateName"),
-         ExternalReference()>
+        <EntityAssociation("Customer_PreviousResidences", "StateName", "StateName"),  _
+         ExternalReference()>  _
         Public ReadOnly Property PreviousResidences() As EntityCollection(Of Global.Cities.City)
             Get
                 If (Me._previousResidences Is Nothing) Then
@@ -163,56 +163,56 @@ Namespace TestDomainServices
                 Return Me._previousResidences
             End Get
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'StateName' value.
         ''' </summary>
-        <DataMember(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         RoundtripOriginal()>  _
         Public Property StateName() As String
             Get
                 Return Me._stateName
             End Get
             Set
-                If (String.Equals(Me._stateName, Value) = False) Then
-                    Me.OnStateNameChanging(Value)
+                If (String.Equals(Me._stateName, value) = false) Then
+                    Me.OnStateNameChanging(value)
                     Me.RaiseDataMemberChanging("StateName")
-                    Me.ValidateProperty("StateName", Value)
-                    Me._stateName = Value
+                    Me.ValidateProperty("StateName", value)
+                    Me._stateName = value
                     Me.RaiseDataMemberChanged("StateName")
-                    Me.OnStateNameChanged()
+                    Me.OnStateNameChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets a value indicating whether the 'MockCustomerCustomMethod' action has been invoked on this entity.
         ''' </summary>
-        <Display(AutoGenerateField:=False)>
+        <Display(AutoGenerateField:=false)>  _
         Public ReadOnly Property IsMockCustomerCustomMethodInvoked() As Boolean
             Get
                 Return MyBase.IsActionInvoked("MockCustomerCustomMethod")
             End Get
         End Property
-
+        
         ''' <summary>
         ''' Gets a value indicating whether the 'MockCustomerCustomMethod' method can be invoked on this entity.
         ''' </summary>
-        <Display(AutoGenerateField:=False)>
+        <Display(AutoGenerateField:=false)>  _
         Public ReadOnly Property CanMockCustomerCustomMethod() As Boolean
             Get
                 Return MyBase.CanInvokeAction("MockCustomerCustomMethod")
             End Get
         End Property
-
+        
         Private Function FilterCity(ByVal entity As Global.Cities.City) As Boolean
             Return (Object.Equals(entity.Name, Me.CityName) AndAlso Object.Equals(entity.StateName, Me.StateName))
         End Function
-
+        
         Private Function FilterPreviousResidences(ByVal entity As Global.Cities.City) As Boolean
             Return Object.Equals(entity.StateName, Me.StateName)
         End Function
-
+        
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -220,62 +220,62 @@ Namespace TestDomainServices
         Public Overrides Function GetIdentity() As Object
             Return Me._customerId
         End Function
-
+        
         ''' <summary>
         ''' Invokes the 'MockCustomerCustomMethod' action on this entity.
         ''' </summary>
         ''' <param name="expectedStateName">The value to pass to the server method's 'expectedStateName' parameter.</param>
         ''' <param name="expectedOriginalStateName">The value to pass to the server method's 'expectedOriginalStateName' parameter.</param>
-        <EntityAction("MockCustomerCustomMethod", AllowMultipleInvocations:=False)>
+        <EntityAction("MockCustomerCustomMethod", AllowMultipleInvocations:=false)>  _
         Public Sub MockCustomerCustomMethod(ByVal expectedStateName As String, ByVal expectedOriginalStateName As String)
             Me.OnMockCustomerCustomMethodInvoking(expectedStateName, expectedOriginalStateName)
             MyBase.InvokeAction("MockCustomerCustomMethod", expectedStateName, expectedOriginalStateName)
-            Me.OnMockCustomerCustomMethodInvoked()
+            Me.OnMockCustomerCustomMethodInvoked
         End Sub
     End Class
-
+    
     ''' <summary>
     ''' The DomainContext corresponding to the 'MockCustomerDomainService' DomainService.
     ''' </summary>
     Partial Public NotInheritable Class MockCustomerDomainContext
         Inherits DomainContext
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockCustomerDomainContext"/> class.
         ''' </summary>
         Public Sub New()
             Me.New(New Uri("TestDomainServices-MockCustomerDomainService.svc", UriKind.Relative))
         End Sub
-
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockCustomerDomainContext"/> class with the specified service URI.
         ''' </summary>
         ''' <param name="serviceUri">The MockCustomerDomainService service URI.</param>
         Public Sub New(ByVal serviceUri As Uri)
-            Me.New(DomainContext.CreateDomainClient(GetType(IMockCustomerDomainServiceContract), serviceUri, False))
+            Me.New(DomainContext.CreateDomainClient(GetType(IMockCustomerDomainServiceContract), serviceUri, false))
         End Sub
-
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockCustomerDomainContext"/> class with the specified <paramref name="domainClient"/>.
         ''' </summary>
         ''' <param name="domainClient">The DomainClient instance to use for this DomainContext.</param>
         Public Sub New(ByVal domainClient As DomainClient)
             MyBase.New(domainClient)
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Gets the set of <see cref="MockCustomer"/> entity instances that have been loaded into this <see cref="MockCustomerDomainContext"/> instance.
         ''' </summary>
@@ -284,7 +284,7 @@ Namespace TestDomainServices
                 Return MyBase.EntityContainer.GetEntitySet(Of MockCustomer)
             End Get
         End Property
-
+        
         ''' <summary>
         ''' Gets the set of <see cref="MockReport"/> entity instances that have been loaded into this <see cref="MockCustomerDomainContext"/> instance.
         ''' </summary>
@@ -293,25 +293,25 @@ Namespace TestDomainServices
                 Return MyBase.EntityContainer.GetEntitySet(Of MockReport)
             End Get
         End Property
-
+        
         ''' <summary>
         ''' Gets an EntityQuery instance that can be used to load <see cref="MockCustomer"/> entity instances using the 'GetCustomers' query.
         ''' </summary>
         ''' <returns>An EntityQuery that can be loaded to retrieve <see cref="MockCustomer"/> entity instances.</returns>
         Public Function GetCustomersQuery() As EntityQuery(Of MockCustomer)
             Me.ValidateMethod("GetCustomersQuery", Nothing)
-            Return MyBase.CreateQuery(Of MockCustomer)("GetCustomers", Nothing, False, True)
+            Return MyBase.CreateQuery(Of MockCustomer)("GetCustomers", Nothing, false, true)
         End Function
-
+        
         ''' <summary>
         ''' Gets an EntityQuery instance that can be used to load <see cref="MockReport"/> entity instances using the 'GetReports' query.
         ''' </summary>
         ''' <returns>An EntityQuery that can be loaded to retrieve <see cref="MockReport"/> entity instances.</returns>
         Public Function GetReportsQuery() As EntityQuery(Of MockReport)
             Me.ValidateMethod("GetReportsQuery", Nothing)
-            Return MyBase.CreateQuery(Of MockReport)("GetReports", Nothing, False, True)
+            Return MyBase.CreateQuery(Of MockReport)("GetReports", Nothing, false, true)
         End Function
-
+        
         ''' <summary>
         ''' Invokes the 'MockCustomerCustomMethod' method of the specified <see cref="MockCustomer"/> entity.
         ''' </summary>
@@ -321,15 +321,15 @@ Namespace TestDomainServices
         Public Sub MockCustomerCustomMethod(ByVal current As MockCustomer, ByVal expectedStateName As String, ByVal expectedOriginalStateName As String)
             current.MockCustomerCustomMethod(expectedStateName, expectedOriginalStateName)
         End Sub
-
+        
         ''' <summary>
         ''' Invokes the 'MockReportCustomMethod' method of the specified <see cref="MockReport"/> entity.
         ''' </summary>
         ''' <param name="current">The <see cref="MockReport"/> entity instance.</param>
         Public Sub MockReportCustomMethod(ByVal current As MockReport)
-            current.MockReportCustomMethod()
+            current.MockReportCustomMethod
         End Sub
-
+        
         ''' <summary>
         ''' Creates a new EntityContainer for this DomainContext's EntitySets.
         ''' </summary>
@@ -337,44 +337,44 @@ Namespace TestDomainServices
         Protected Overrides Function CreateEntityContainer() As EntityContainer
             Return New MockCustomerDomainContextEntityContainer()
         End Function
-
+        
         ''' <summary>
         ''' Service contract for the 'MockCustomerDomainService' DomainService.
         ''' </summary>
         Public Interface IMockCustomerDomainServiceContract
-
+            
             ''' <summary>
             ''' Asynchronously invokes the 'GetCustomers' operation.
             ''' </summary>
             ''' <param name="callback">Callback to invoke on completion.</param>
             ''' <param name="asyncState">Optional state object.</param>
             ''' <returns>An IAsyncResult that can be used to monitor the request.</returns>
-            <HasSideEffects(False)>
+            <HasSideEffects(false)>  _
             Function BeginGetCustomers(ByVal callback As AsyncCallback, ByVal asyncState As Object) As IAsyncResult
-
+            
             ''' <summary>
             ''' Completes the asynchronous operation begun by 'BeginGetCustomers'.
             ''' </summary>
             ''' <param name="result">The IAsyncResult returned from 'BeginGetCustomers'.</param>
             ''' <returns>The 'QueryResult' returned from the 'GetCustomers' operation.</returns>
             Function EndGetCustomers(ByVal result As IAsyncResult) As QueryResult(Of MockCustomer)
-
+            
             ''' <summary>
             ''' Asynchronously invokes the 'GetReports' operation.
             ''' </summary>
             ''' <param name="callback">Callback to invoke on completion.</param>
             ''' <param name="asyncState">Optional state object.</param>
             ''' <returns>An IAsyncResult that can be used to monitor the request.</returns>
-            <HasSideEffects(False)>
+            <HasSideEffects(false)>  _
             Function BeginGetReports(ByVal callback As AsyncCallback, ByVal asyncState As Object) As IAsyncResult
-
+            
             ''' <summary>
             ''' Completes the asynchronous operation begun by 'BeginGetReports'.
             ''' </summary>
             ''' <param name="result">The IAsyncResult returned from 'BeginGetReports'.</param>
             ''' <returns>The 'QueryResult' returned from the 'GetReports' operation.</returns>
             Function EndGetReports(ByVal result As IAsyncResult) As QueryResult(Of MockReport)
-
+            
             ''' <summary>
             ''' Asynchronously invokes the 'SubmitChanges' operation.
             ''' </summary>
@@ -383,7 +383,7 @@ Namespace TestDomainServices
             ''' <param name="asyncState">Optional state object.</param>
             ''' <returns>An IAsyncResult that can be used to monitor the request.</returns>
             Function BeginSubmitChanges(ByVal changeSet As IEnumerable(Of ChangeSetEntry), ByVal callback As AsyncCallback, ByVal asyncState As Object) As IAsyncResult
-
+            
             ''' <summary>
             ''' Completes the asynchronous operation begun by 'BeginSubmitChanges'.
             ''' </summary>
@@ -391,10 +391,10 @@ Namespace TestDomainServices
             ''' <returns>The collection of change-set entry elements returned from 'SubmitChanges'.</returns>
             Function EndSubmitChanges(ByVal result As IAsyncResult) As IEnumerable(Of ChangeSetEntry)
         End Interface
-
+        
         Friend NotInheritable Class MockCustomerDomainContextEntityContainer
             Inherits EntityContainer
-
+            
             Public Sub New()
                 MyBase.New
                 Me.CreateEntitySet(Of MockCustomer)(EntitySetOperations.Edit)
@@ -402,88 +402,88 @@ Namespace TestDomainServices
             End Sub
         End Class
     End Class
-
+    
     ''' <summary>
     ''' The 'MockReport' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="Mock.Models", Name:="MR"),
-     RoundtripOriginal()>
+    <DataContract([Namespace]:="Mock.Models", Name:="MR"),  _
+     RoundtripOriginal()>  _
     Partial Public NotInheritable Class MockReport
         Inherits Entity
-
+        
         Private _customer As EntityRef(Of MockCustomer)
-
+        
         Private _customerId As Integer
-
+        
         Private _reportBody As MockReportBody
-
+        
         Private _reportElementFieldId As Integer
-
+        
         Private _reportTitle As String
-
+        
         Private _start As DateTime
-
+        
         Private _state As String
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
-        Partial Private Sub OnCustomerIdChanging(ByVal value As Integer)
+        Private Partial Sub OnCustomerIdChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnCustomerIdChanged()
+        Private Partial Sub OnCustomerIdChanged()
         End Sub
-        Partial Private Sub OnReportBodyChanging(ByVal value As MockReportBody)
+        Private Partial Sub OnReportBodyChanging(ByVal value As MockReportBody)
         End Sub
-        Partial Private Sub OnReportBodyChanged()
+        Private Partial Sub OnReportBodyChanged()
         End Sub
-        Partial Private Sub OnReportElementFieldIdChanging(ByVal value As Integer)
+        Private Partial Sub OnReportElementFieldIdChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnReportElementFieldIdChanged()
+        Private Partial Sub OnReportElementFieldIdChanged()
         End Sub
-        Partial Private Sub OnReportTitleChanging(ByVal value As String)
+        Private Partial Sub OnReportTitleChanging(ByVal value As String)
         End Sub
-        Partial Private Sub OnReportTitleChanged()
+        Private Partial Sub OnReportTitleChanged()
         End Sub
-        Partial Private Sub OnStartChanging(ByVal value As DateTime)
+        Private Partial Sub OnStartChanging(ByVal value As DateTime)
         End Sub
-        Partial Private Sub OnStartChanged()
+        Private Partial Sub OnStartChanged()
         End Sub
-        Partial Private Sub OnStateChanging(ByVal value As String)
+        Private Partial Sub OnStateChanging(ByVal value As String)
         End Sub
-        Partial Private Sub OnStateChanged()
+        Private Partial Sub OnStateChanged()
         End Sub
-        Partial Private Sub OnMockReportCustomMethodInvoking()
+        Private Partial Sub OnMockReportCustomMethodInvoking()
         End Sub
-        Partial Private Sub OnMockReportCustomMethodInvoked()
+        Private Partial Sub OnMockReportCustomMethodInvoked()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockReport"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Deserialization ctor for MessagePack support, when any Property is required
         ''' </summary>
-        <PolyType.ConstructorShapeAttribute()>
+        <PolyType.ConstructorShapeAttribute()>  _
         Private Sub New(ByVal ReportTitle As String)
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
             MyBase.OnDeserializing(CType(Nothing, System.Runtime.Serialization.StreamingContext))
             Me.ReportTitle = ReportTitle
         End Sub
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="MockCustomer"/> entity.
         ''' </summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Mocks/MockCustomers.g.vb
@@ -25,65 +25,65 @@ Imports System.Runtime.Serialization
 Imports System.Threading.Tasks
 
 Namespace TestDomainServices
-    
+
     ''' <summary>
     ''' The 'MockCustomer' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
     Partial Public NotInheritable Class MockCustomer
         Inherits Entity
-        
+
         Private _city As EntityRef(Of Global.Cities.City)
-        
+
         Private _cityName As String
-        
+
         Private _customerId As Integer
-        
+
         Private _previousResidences As EntityCollection(Of Global.Cities.City)
-        
+
         Private _stateName As String
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
-        Private Partial Sub OnCityNameChanging(ByVal value As String)
+        Partial Private Sub OnCityNameChanging(ByVal value As String)
         End Sub
-        Private Partial Sub OnCityNameChanged()
+        Partial Private Sub OnCityNameChanged()
         End Sub
-        Private Partial Sub OnCustomerIdChanging(ByVal value As Integer)
+        Partial Private Sub OnCustomerIdChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnCustomerIdChanged()
+        Partial Private Sub OnCustomerIdChanged()
         End Sub
-        Private Partial Sub OnStateNameChanging(ByVal value As String)
+        Partial Private Sub OnStateNameChanging(ByVal value As String)
         End Sub
-        Private Partial Sub OnStateNameChanged()
+        Partial Private Sub OnStateNameChanged()
         End Sub
-        Private Partial Sub OnMockCustomerCustomMethodInvoking(ByVal expectedStateName As String, ByVal expectedOriginalStateName As String)
+        Partial Private Sub OnMockCustomerCustomMethodInvoking(ByVal expectedStateName As String, ByVal expectedOriginalStateName As String)
         End Sub
-        Private Partial Sub OnMockCustomerCustomMethodInvoked()
+        Partial Private Sub OnMockCustomerCustomMethodInvoked()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockCustomer"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="City"/> entity.
         ''' </summary>
-        <EntityAssociation("Customer_City", New String() {"CityName", "StateName"}, New String() {"Name", "StateName"}, IsForeignKey:=true),  _
-         ExternalReference()>  _
+        <EntityAssociation("Customer_City", New String() {"CityName", "StateName"}, New String() {"Name", "StateName"}, IsForeignKey:=True),
+         ExternalReference()>
         Public Property City() As Global.Cities.City
             Get
                 If (Me._city Is Nothing) Then
@@ -93,11 +93,11 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As Global.Cities.City = Me.City
-                If (Object.Equals(previous, value) = false) Then
-                    Me.ValidateProperty("City", value)
-                    If (Not (value) Is Nothing) Then
-                        Me.CityName = value.Name
-                        Me.StateName = value.StateName
+                If (Object.Equals(previous, Value) = False) Then
+                    Me.ValidateProperty("City", Value)
+                    If (Not (Value) Is Nothing) Then
+                        Me.CityName = Value.Name
+                        Me.StateName = Value.StateName
                     Else
                         Me.CityName = CType(Nothing, String)
                         Me.StateName = CType(Nothing, String)
@@ -105,56 +105,56 @@ Namespace TestDomainServices
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'CityName' value.
         ''' </summary>
-        <DataMember(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         RoundtripOriginal()>
         Public Property CityName() As String
             Get
                 Return Me._cityName
             End Get
             Set
-                If (String.Equals(Me._cityName, value) = false) Then
-                    Me.OnCityNameChanging(value)
+                If (String.Equals(Me._cityName, Value) = False) Then
+                    Me.OnCityNameChanging(Value)
                     Me.RaiseDataMemberChanging("CityName")
-                    Me.ValidateProperty("CityName", value)
-                    Me._cityName = value
+                    Me.ValidateProperty("CityName", Value)
+                    Me._cityName = Value
                     Me.RaiseDataMemberChanged("CityName")
-                    Me.OnCityNameChanged
+                    Me.OnCityNameChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'CustomerId' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false, AllowInitialValue:=true),  _
-         Key(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         Editable(False, AllowInitialValue:=True),
+         Key(),
+         RoundtripOriginal()>
         Public Property CustomerId() As Integer
             Get
                 Return Me._customerId
             End Get
             Set
-                If ((Me._customerId = value)  _
-                            = false) Then
-                    Me.OnCustomerIdChanging(value)
-                    Me.ValidateProperty("CustomerId", value)
-                    Me._customerId = value
+                If ((Me._customerId = Value) _
+                            = False) Then
+                    Me.OnCustomerIdChanging(Value)
+                    Me.ValidateProperty("CustomerId", Value)
+                    Me._customerId = Value
                     Me.RaisePropertyChanged("CustomerId")
-                    Me.OnCustomerIdChanged
+                    Me.OnCustomerIdChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets the collection of associated <see cref="City"/> entity instances.
         ''' </summary>
-        <EntityAssociation("Customer_PreviousResidences", "StateName", "StateName"),  _
-         ExternalReference()>  _
+        <EntityAssociation("Customer_PreviousResidences", "StateName", "StateName"),
+         ExternalReference()>
         Public ReadOnly Property PreviousResidences() As EntityCollection(Of Global.Cities.City)
             Get
                 If (Me._previousResidences Is Nothing) Then
@@ -163,56 +163,56 @@ Namespace TestDomainServices
                 Return Me._previousResidences
             End Get
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'StateName' value.
         ''' </summary>
-        <DataMember(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         RoundtripOriginal()>
         Public Property StateName() As String
             Get
                 Return Me._stateName
             End Get
             Set
-                If (String.Equals(Me._stateName, value) = false) Then
-                    Me.OnStateNameChanging(value)
+                If (String.Equals(Me._stateName, Value) = False) Then
+                    Me.OnStateNameChanging(Value)
                     Me.RaiseDataMemberChanging("StateName")
-                    Me.ValidateProperty("StateName", value)
-                    Me._stateName = value
+                    Me.ValidateProperty("StateName", Value)
+                    Me._stateName = Value
                     Me.RaiseDataMemberChanged("StateName")
-                    Me.OnStateNameChanged
+                    Me.OnStateNameChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets a value indicating whether the 'MockCustomerCustomMethod' action has been invoked on this entity.
         ''' </summary>
-        <Display(AutoGenerateField:=false)>  _
+        <Display(AutoGenerateField:=False)>
         Public ReadOnly Property IsMockCustomerCustomMethodInvoked() As Boolean
             Get
                 Return MyBase.IsActionInvoked("MockCustomerCustomMethod")
             End Get
         End Property
-        
+
         ''' <summary>
         ''' Gets a value indicating whether the 'MockCustomerCustomMethod' method can be invoked on this entity.
         ''' </summary>
-        <Display(AutoGenerateField:=false)>  _
+        <Display(AutoGenerateField:=False)>
         Public ReadOnly Property CanMockCustomerCustomMethod() As Boolean
             Get
                 Return MyBase.CanInvokeAction("MockCustomerCustomMethod")
             End Get
         End Property
-        
+
         Private Function FilterCity(ByVal entity As Global.Cities.City) As Boolean
             Return (Object.Equals(entity.Name, Me.CityName) AndAlso Object.Equals(entity.StateName, Me.StateName))
         End Function
-        
+
         Private Function FilterPreviousResidences(ByVal entity As Global.Cities.City) As Boolean
             Return Object.Equals(entity.StateName, Me.StateName)
         End Function
-        
+
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -220,62 +220,62 @@ Namespace TestDomainServices
         Public Overrides Function GetIdentity() As Object
             Return Me._customerId
         End Function
-        
+
         ''' <summary>
         ''' Invokes the 'MockCustomerCustomMethod' action on this entity.
         ''' </summary>
         ''' <param name="expectedStateName">The value to pass to the server method's 'expectedStateName' parameter.</param>
         ''' <param name="expectedOriginalStateName">The value to pass to the server method's 'expectedOriginalStateName' parameter.</param>
-        <EntityAction("MockCustomerCustomMethod", AllowMultipleInvocations:=false)>  _
+        <EntityAction("MockCustomerCustomMethod", AllowMultipleInvocations:=False)>
         Public Sub MockCustomerCustomMethod(ByVal expectedStateName As String, ByVal expectedOriginalStateName As String)
             Me.OnMockCustomerCustomMethodInvoking(expectedStateName, expectedOriginalStateName)
             MyBase.InvokeAction("MockCustomerCustomMethod", expectedStateName, expectedOriginalStateName)
-            Me.OnMockCustomerCustomMethodInvoked
+            Me.OnMockCustomerCustomMethodInvoked()
         End Sub
     End Class
-    
+
     ''' <summary>
     ''' The DomainContext corresponding to the 'MockCustomerDomainService' DomainService.
     ''' </summary>
     Partial Public NotInheritable Class MockCustomerDomainContext
         Inherits DomainContext
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockCustomerDomainContext"/> class.
         ''' </summary>
         Public Sub New()
             Me.New(New Uri("TestDomainServices-MockCustomerDomainService.svc", UriKind.Relative))
         End Sub
-        
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockCustomerDomainContext"/> class with the specified service URI.
         ''' </summary>
         ''' <param name="serviceUri">The MockCustomerDomainService service URI.</param>
         Public Sub New(ByVal serviceUri As Uri)
-            Me.New(DomainContext.CreateDomainClient(GetType(IMockCustomerDomainServiceContract), serviceUri, false))
+            Me.New(DomainContext.CreateDomainClient(GetType(IMockCustomerDomainServiceContract), serviceUri, False))
         End Sub
-        
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockCustomerDomainContext"/> class with the specified <paramref name="domainClient"/>.
         ''' </summary>
         ''' <param name="domainClient">The DomainClient instance to use for this DomainContext.</param>
         Public Sub New(ByVal domainClient As DomainClient)
             MyBase.New(domainClient)
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Gets the set of <see cref="MockCustomer"/> entity instances that have been loaded into this <see cref="MockCustomerDomainContext"/> instance.
         ''' </summary>
@@ -284,7 +284,7 @@ Namespace TestDomainServices
                 Return MyBase.EntityContainer.GetEntitySet(Of MockCustomer)
             End Get
         End Property
-        
+
         ''' <summary>
         ''' Gets the set of <see cref="MockReport"/> entity instances that have been loaded into this <see cref="MockCustomerDomainContext"/> instance.
         ''' </summary>
@@ -293,25 +293,25 @@ Namespace TestDomainServices
                 Return MyBase.EntityContainer.GetEntitySet(Of MockReport)
             End Get
         End Property
-        
+
         ''' <summary>
         ''' Gets an EntityQuery instance that can be used to load <see cref="MockCustomer"/> entity instances using the 'GetCustomers' query.
         ''' </summary>
         ''' <returns>An EntityQuery that can be loaded to retrieve <see cref="MockCustomer"/> entity instances.</returns>
         Public Function GetCustomersQuery() As EntityQuery(Of MockCustomer)
             Me.ValidateMethod("GetCustomersQuery", Nothing)
-            Return MyBase.CreateQuery(Of MockCustomer)("GetCustomers", Nothing, false, true)
+            Return MyBase.CreateQuery(Of MockCustomer)("GetCustomers", Nothing, False, True)
         End Function
-        
+
         ''' <summary>
         ''' Gets an EntityQuery instance that can be used to load <see cref="MockReport"/> entity instances using the 'GetReports' query.
         ''' </summary>
         ''' <returns>An EntityQuery that can be loaded to retrieve <see cref="MockReport"/> entity instances.</returns>
         Public Function GetReportsQuery() As EntityQuery(Of MockReport)
             Me.ValidateMethod("GetReportsQuery", Nothing)
-            Return MyBase.CreateQuery(Of MockReport)("GetReports", Nothing, false, true)
+            Return MyBase.CreateQuery(Of MockReport)("GetReports", Nothing, False, True)
         End Function
-        
+
         ''' <summary>
         ''' Invokes the 'MockCustomerCustomMethod' method of the specified <see cref="MockCustomer"/> entity.
         ''' </summary>
@@ -321,15 +321,15 @@ Namespace TestDomainServices
         Public Sub MockCustomerCustomMethod(ByVal current As MockCustomer, ByVal expectedStateName As String, ByVal expectedOriginalStateName As String)
             current.MockCustomerCustomMethod(expectedStateName, expectedOriginalStateName)
         End Sub
-        
+
         ''' <summary>
         ''' Invokes the 'MockReportCustomMethod' method of the specified <see cref="MockReport"/> entity.
         ''' </summary>
         ''' <param name="current">The <see cref="MockReport"/> entity instance.</param>
         Public Sub MockReportCustomMethod(ByVal current As MockReport)
-            current.MockReportCustomMethod
+            current.MockReportCustomMethod()
         End Sub
-        
+
         ''' <summary>
         ''' Creates a new EntityContainer for this DomainContext's EntitySets.
         ''' </summary>
@@ -337,44 +337,44 @@ Namespace TestDomainServices
         Protected Overrides Function CreateEntityContainer() As EntityContainer
             Return New MockCustomerDomainContextEntityContainer()
         End Function
-        
+
         ''' <summary>
         ''' Service contract for the 'MockCustomerDomainService' DomainService.
         ''' </summary>
         Public Interface IMockCustomerDomainServiceContract
-            
+
             ''' <summary>
             ''' Asynchronously invokes the 'GetCustomers' operation.
             ''' </summary>
             ''' <param name="callback">Callback to invoke on completion.</param>
             ''' <param name="asyncState">Optional state object.</param>
             ''' <returns>An IAsyncResult that can be used to monitor the request.</returns>
-            <HasSideEffects(false)>  _
+            <HasSideEffects(False)>
             Function BeginGetCustomers(ByVal callback As AsyncCallback, ByVal asyncState As Object) As IAsyncResult
-            
+
             ''' <summary>
             ''' Completes the asynchronous operation begun by 'BeginGetCustomers'.
             ''' </summary>
             ''' <param name="result">The IAsyncResult returned from 'BeginGetCustomers'.</param>
             ''' <returns>The 'QueryResult' returned from the 'GetCustomers' operation.</returns>
             Function EndGetCustomers(ByVal result As IAsyncResult) As QueryResult(Of MockCustomer)
-            
+
             ''' <summary>
             ''' Asynchronously invokes the 'GetReports' operation.
             ''' </summary>
             ''' <param name="callback">Callback to invoke on completion.</param>
             ''' <param name="asyncState">Optional state object.</param>
             ''' <returns>An IAsyncResult that can be used to monitor the request.</returns>
-            <HasSideEffects(false)>  _
+            <HasSideEffects(False)>
             Function BeginGetReports(ByVal callback As AsyncCallback, ByVal asyncState As Object) As IAsyncResult
-            
+
             ''' <summary>
             ''' Completes the asynchronous operation begun by 'BeginGetReports'.
             ''' </summary>
             ''' <param name="result">The IAsyncResult returned from 'BeginGetReports'.</param>
             ''' <returns>The 'QueryResult' returned from the 'GetReports' operation.</returns>
             Function EndGetReports(ByVal result As IAsyncResult) As QueryResult(Of MockReport)
-            
+
             ''' <summary>
             ''' Asynchronously invokes the 'SubmitChanges' operation.
             ''' </summary>
@@ -383,7 +383,7 @@ Namespace TestDomainServices
             ''' <param name="asyncState">Optional state object.</param>
             ''' <returns>An IAsyncResult that can be used to monitor the request.</returns>
             Function BeginSubmitChanges(ByVal changeSet As IEnumerable(Of ChangeSetEntry), ByVal callback As AsyncCallback, ByVal asyncState As Object) As IAsyncResult
-            
+
             ''' <summary>
             ''' Completes the asynchronous operation begun by 'BeginSubmitChanges'.
             ''' </summary>
@@ -391,10 +391,10 @@ Namespace TestDomainServices
             ''' <returns>The collection of change-set entry elements returned from 'SubmitChanges'.</returns>
             Function EndSubmitChanges(ByVal result As IAsyncResult) As IEnumerable(Of ChangeSetEntry)
         End Interface
-        
+
         Friend NotInheritable Class MockCustomerDomainContextEntityContainer
             Inherits EntityContainer
-            
+
             Public Sub New()
                 MyBase.New
                 Me.CreateEntitySet(Of MockCustomer)(EntitySetOperations.Edit)
@@ -402,88 +402,88 @@ Namespace TestDomainServices
             End Sub
         End Class
     End Class
-    
+
     ''' <summary>
     ''' The 'MockReport' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="Mock.Models", Name:="MR"),  _
-     RoundtripOriginal()>  _
+    <DataContract([Namespace]:="Mock.Models", Name:="MR"),
+     RoundtripOriginal()>
     Partial Public NotInheritable Class MockReport
         Inherits Entity
-        
+
         Private _customer As EntityRef(Of MockCustomer)
-        
+
         Private _customerId As Integer
-        
+
         Private _reportBody As MockReportBody
-        
+
         Private _reportElementFieldId As Integer
-        
+
         Private _reportTitle As String
-        
+
         Private _start As DateTime
-        
+
         Private _state As String
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
-        Private Partial Sub OnCustomerIdChanging(ByVal value As Integer)
+        Partial Private Sub OnCustomerIdChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnCustomerIdChanged()
+        Partial Private Sub OnCustomerIdChanged()
         End Sub
-        Private Partial Sub OnReportBodyChanging(ByVal value As MockReportBody)
+        Partial Private Sub OnReportBodyChanging(ByVal value As MockReportBody)
         End Sub
-        Private Partial Sub OnReportBodyChanged()
+        Partial Private Sub OnReportBodyChanged()
         End Sub
-        Private Partial Sub OnReportElementFieldIdChanging(ByVal value As Integer)
+        Partial Private Sub OnReportElementFieldIdChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnReportElementFieldIdChanged()
+        Partial Private Sub OnReportElementFieldIdChanged()
         End Sub
-        Private Partial Sub OnReportTitleChanging(ByVal value As String)
+        Partial Private Sub OnReportTitleChanging(ByVal value As String)
         End Sub
-        Private Partial Sub OnReportTitleChanged()
+        Partial Private Sub OnReportTitleChanged()
         End Sub
-        Private Partial Sub OnStartChanging(ByVal value As DateTime)
+        Partial Private Sub OnStartChanging(ByVal value As DateTime)
         End Sub
-        Private Partial Sub OnStartChanged()
+        Partial Private Sub OnStartChanged()
         End Sub
-        Private Partial Sub OnStateChanging(ByVal value As String)
+        Partial Private Sub OnStateChanging(ByVal value As String)
         End Sub
-        Private Partial Sub OnStateChanged()
+        Partial Private Sub OnStateChanged()
         End Sub
-        Private Partial Sub OnMockReportCustomMethodInvoking()
+        Partial Private Sub OnMockReportCustomMethodInvoking()
         End Sub
-        Private Partial Sub OnMockReportCustomMethodInvoked()
+        Partial Private Sub OnMockReportCustomMethodInvoked()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="MockReport"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Deserialization ctor for MessagePack support, when any Property is required
         ''' </summary>
-        <PolyType.ConstructorShapeAttribute()>  _
-        Private Sub New(ByVal CustomerId As Integer)
+        <PolyType.ConstructorShapeAttribute()>
+        Private Sub New(ByVal ReportTitle As String)
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
             MyBase.OnDeserializing(CType(Nothing, System.Runtime.Serialization.StreamingContext))
-            Me.CustomerId = CustomerId
+            Me.ReportTitle = ReportTitle
         End Sub
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="MockCustomer"/> entity.
         ''' </summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
@@ -1330,11 +1330,11 @@ namespace TestDomainServices
         /// Deserialization ctor for MessagePack support, when any Property is required
         /// </summary>
         [PolyType.ConstructorShapeAttribute()]
-        private TestEntity_DataMemberBuddy(int ID)
+        private TestEntity_DataMemberBuddy(int Prop1)
         {
             this.OnCreated();
             base.OnDeserializing(default(System.Runtime.Serialization.StreamingContext));
-            this.ID = ID;
+            this.Prop1 = Prop1;
         }
         
         /// <summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
@@ -27,7 +27,7 @@ Imports System.Threading
 Imports System.Threading.Tasks
 
 Namespace TestDomainServices
-    
+
     'The following attributes were not generated:
     '
     '- The attribute 'System.ComponentModel.DataAnnotations.CustomValidationAttribute' references type 'TestDomainServices.ServerOnlyValidator' that is not accessible in the client project 'MockProject'. If you would like the attribute to be generated, make sure the assembly containing the attribute is referenced on the client.
@@ -37,78 +37,78 @@ Namespace TestDomainServices
     ''' <summary>
     ''' The 'A' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
     Partial Public NotInheritable Class A
         Inherits Entity
-        
+
         Private _b As EntityRef(Of B)
-        
+
         Private _bid1 As Integer
-        
+
         Private _bid2 As Integer
-        
+
         Private _id As Integer
-        
+
         Private _readOnlyData_NoReadOnlyAttribute As String
-        
+
         Private _readOnlyData_NoSetter As String
-        
+
         Private _readOnlyData_WithSetter As String
-        
+
         Private _requiredString As String
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
-        Private Partial Sub OnBID1Changing(ByVal value As Integer)
+        Partial Private Sub OnBID1Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnBID1Changed()
+        Partial Private Sub OnBID1Changed()
         End Sub
-        Private Partial Sub OnBID2Changing(ByVal value As Integer)
+        Partial Private Sub OnBID2Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnBID2Changed()
+        Partial Private Sub OnBID2Changed()
         End Sub
-        Private Partial Sub OnIDChanging(ByVal value As Integer)
+        Partial Private Sub OnIDChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnIDChanged()
+        Partial Private Sub OnIDChanged()
         End Sub
-        Private Partial Sub OnReadOnlyData_NoReadOnlyAttributeChanging(ByVal value As String)
+        Partial Private Sub OnReadOnlyData_NoReadOnlyAttributeChanging(ByVal value As String)
         End Sub
-        Private Partial Sub OnReadOnlyData_NoReadOnlyAttributeChanged()
+        Partial Private Sub OnReadOnlyData_NoReadOnlyAttributeChanged()
         End Sub
-        Private Partial Sub OnReadOnlyData_NoSetterChanging(ByVal value As String)
+        Partial Private Sub OnReadOnlyData_NoSetterChanging(ByVal value As String)
         End Sub
-        Private Partial Sub OnReadOnlyData_NoSetterChanged()
+        Partial Private Sub OnReadOnlyData_NoSetterChanged()
         End Sub
-        Private Partial Sub OnReadOnlyData_WithSetterChanging(ByVal value As String)
+        Partial Private Sub OnReadOnlyData_WithSetterChanging(ByVal value As String)
         End Sub
-        Private Partial Sub OnReadOnlyData_WithSetterChanged()
+        Partial Private Sub OnReadOnlyData_WithSetterChanged()
         End Sub
-        Private Partial Sub OnRequiredStringChanging(ByVal value As String)
+        Partial Private Sub OnRequiredStringChanging(ByVal value As String)
         End Sub
-        Private Partial Sub OnRequiredStringChanged()
+        Partial Private Sub OnRequiredStringChanged()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="A"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="B"/> entity.
         ''' </summary>
-        <EntityAssociation("A_B", New String() {"BID1", "BID2"}, New String() {"ID1", "ID2"}, IsForeignKey:=true)>  _
+        <EntityAssociation("A_B", New String() {"BID1", "BID2"}, New String() {"ID1", "ID2"}, IsForeignKey:=True)>
         Public Property B() As B
             Get
                 If (Me._b Is Nothing) Then
@@ -118,150 +118,150 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As B = Me.B
-                If (Object.Equals(previous, value) = false) Then
-                    Me.ValidateProperty("B", value)
-                    If (Not (value) Is Nothing) Then
-                        Me.BID1 = value.ID1
-                        Me.BID2 = value.ID2
+                If (Object.Equals(previous, Value) = False) Then
+                    Me.ValidateProperty("B", Value)
+                    If (Not (Value) Is Nothing) Then
+                        Me.BID1 = Value.ID1
+                        Me.BID2 = Value.ID2
                     Else
                         Me.BID1 = CType(Nothing, Integer)
                         Me.BID2 = CType(Nothing, Integer)
                     End If
-                    Me._b.Entity = value
+                    Me._b.Entity = Value
                     Me.RaisePropertyChanged("B")
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'BID1' value.
         ''' </summary>
-        <DataMember(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         RoundtripOriginal()>
         Public Property BID1() As Integer
             Get
                 Return Me._bid1
             End Get
             Set
-                If ((Me._bid1 = value)  _
-                            = false) Then
-                    Me.OnBID1Changing(value)
+                If ((Me._bid1 = Value) _
+                            = False) Then
+                    Me.OnBID1Changing(Value)
                     Me.RaiseDataMemberChanging("BID1")
-                    Me.ValidateProperty("BID1", value)
-                    Me._bid1 = value
+                    Me.ValidateProperty("BID1", Value)
+                    Me._bid1 = Value
                     Me.RaiseDataMemberChanged("BID1")
-                    Me.OnBID1Changed
+                    Me.OnBID1Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'BID2' value.
         ''' </summary>
-        <DataMember(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         RoundtripOriginal()>
         Public Property BID2() As Integer
             Get
                 Return Me._bid2
             End Get
             Set
-                If ((Me._bid2 = value)  _
-                            = false) Then
-                    Me.OnBID2Changing(value)
+                If ((Me._bid2 = Value) _
+                            = False) Then
+                    Me.OnBID2Changing(Value)
                     Me.RaiseDataMemberChanging("BID2")
-                    Me.ValidateProperty("BID2", value)
-                    Me._bid2 = value
+                    Me.ValidateProperty("BID2", Value)
+                    Me._bid2 = Value
                     Me.RaiseDataMemberChanged("BID2")
-                    Me.OnBID2Changed
+                    Me.OnBID2Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false, AllowInitialValue:=true),  _
-         Key(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         Editable(False, AllowInitialValue:=True),
+         Key(),
+         RoundtripOriginal()>
         Public Property ID() As Integer
             Get
                 Return Me._id
             End Get
             Set
-                If ((Me._id = value)  _
-                            = false) Then
-                    Me.OnIDChanging(value)
-                    Me.ValidateProperty("ID", value)
-                    Me._id = value
+                If ((Me._id = Value) _
+                            = False) Then
+                    Me.OnIDChanging(Value)
+                    Me.ValidateProperty("ID", Value)
+                    Me._id = Value
                     Me.RaisePropertyChanged("ID")
-                    Me.OnIDChanged
+                    Me.OnIDChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ReadOnlyData_NoReadOnlyAttribute' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false),  _
-         [ReadOnly](true)>  _
+        <DataMember(),
+         Editable(False),
+         [ReadOnly](True)>
         Public Property ReadOnlyData_NoReadOnlyAttribute() As String
             Get
                 Return Me._readOnlyData_NoReadOnlyAttribute
             End Get
             Set
-                If (String.Equals(Me._readOnlyData_NoReadOnlyAttribute, value) = false) Then
-                    Me.OnReadOnlyData_NoReadOnlyAttributeChanging(value)
-                    Me.ValidateProperty("ReadOnlyData_NoReadOnlyAttribute", value)
-                    Me._readOnlyData_NoReadOnlyAttribute = value
+                If (String.Equals(Me._readOnlyData_NoReadOnlyAttribute, Value) = False) Then
+                    Me.OnReadOnlyData_NoReadOnlyAttributeChanging(Value)
+                    Me.ValidateProperty("ReadOnlyData_NoReadOnlyAttribute", Value)
+                    Me._readOnlyData_NoReadOnlyAttribute = Value
                     Me.RaisePropertyChanged("ReadOnlyData_NoReadOnlyAttribute")
-                    Me.OnReadOnlyData_NoReadOnlyAttributeChanged
+                    Me.OnReadOnlyData_NoReadOnlyAttributeChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ReadOnlyData_NoSetter' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false),  _
-         [ReadOnly](true)>  _
+        <DataMember(),
+         Editable(False),
+         [ReadOnly](True)>
         Public Property ReadOnlyData_NoSetter() As String
             Get
                 Return Me._readOnlyData_NoSetter
             End Get
             Set
-                If (String.Equals(Me._readOnlyData_NoSetter, value) = false) Then
-                    Me.OnReadOnlyData_NoSetterChanging(value)
-                    Me.ValidateProperty("ReadOnlyData_NoSetter", value)
-                    Me._readOnlyData_NoSetter = value
+                If (String.Equals(Me._readOnlyData_NoSetter, Value) = False) Then
+                    Me.OnReadOnlyData_NoSetterChanging(Value)
+                    Me.ValidateProperty("ReadOnlyData_NoSetter", Value)
+                    Me._readOnlyData_NoSetter = Value
                     Me.RaisePropertyChanged("ReadOnlyData_NoSetter")
-                    Me.OnReadOnlyData_NoSetterChanged
+                    Me.OnReadOnlyData_NoSetterChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ReadOnlyData_WithSetter' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false)>  _
+        <DataMember(),
+         Editable(False)>
         Public Property ReadOnlyData_WithSetter() As String
             Get
                 Return Me._readOnlyData_WithSetter
             End Get
             Set
-                If (String.Equals(Me._readOnlyData_WithSetter, value) = false) Then
-                    Me.OnReadOnlyData_WithSetterChanging(value)
-                    Me.ValidateProperty("ReadOnlyData_WithSetter", value)
-                    Me._readOnlyData_WithSetter = value
+                If (String.Equals(Me._readOnlyData_WithSetter, Value) = False) Then
+                    Me.OnReadOnlyData_WithSetterChanging(Value)
+                    Me.ValidateProperty("ReadOnlyData_WithSetter", Value)
+                    Me._readOnlyData_WithSetter = Value
                     Me.RaisePropertyChanged("ReadOnlyData_WithSetter")
-                    Me.OnReadOnlyData_WithSetterChanged
+                    Me.OnReadOnlyData_WithSetterChanged()
                 End If
             End Set
         End Property
-        
+
         'The following attributes were not generated:
         '
         '- The attribute 'System.ComponentModel.DataAnnotations.CustomValidationAttribute' references type 'TestDomainServices.ServerOnlyValidator' that is not accessible in the client project 'MockProject'. If you would like the attribute to be generated, make sure the assembly containing the attribute is referenced on the client.
@@ -274,30 +274,30 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the 'RequiredString' value.
         ''' </summary>
-        <Custom(),  _
-         DataMember(),  _
-         Editable(true),  _
-         Required()>  _
+        <Custom(),
+         DataMember(),
+         Editable(True),
+         Required()>
         Public Property RequiredString() As String
             Get
                 Return Me._requiredString
             End Get
             Set
-                If (String.Equals(Me._requiredString, value) = false) Then
-                    Me.OnRequiredStringChanging(value)
+                If (String.Equals(Me._requiredString, Value) = False) Then
+                    Me.OnRequiredStringChanging(Value)
                     Me.RaiseDataMemberChanging("RequiredString")
-                    Me.ValidateProperty("RequiredString", value)
-                    Me._requiredString = value
+                    Me.ValidateProperty("RequiredString", Value)
+                    Me._requiredString = Value
                     Me.RaiseDataMemberChanged("RequiredString")
-                    Me.OnRequiredStringChanged
+                    Me.OnRequiredStringChanged()
                 End If
             End Set
         End Property
-        
+
         Private Function FilterB(ByVal entity As B) As Boolean
             Return (Object.Equals(entity.ID1, Me.BID1) AndAlso Object.Equals(entity.ID2, Me.BID2))
         End Function
-        
+
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -306,53 +306,53 @@ Namespace TestDomainServices
             Return Me._id
         End Function
     End Class
-    
+
     ''' <summary>
     ''' The 'B' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
     Partial Public NotInheritable Class B
         Inherits Entity
-        
+
         Private _cs As EntityCollection(Of C)
-        
+
         Private _id1 As Integer
-        
+
         Private _id2 As Integer
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
-        Private Partial Sub OnID1Changing(ByVal value As Integer)
+        Partial Private Sub OnID1Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnID1Changed()
+        Partial Private Sub OnID1Changed()
         End Sub
-        Private Partial Sub OnID2Changing(ByVal value As Integer)
+        Partial Private Sub OnID2Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnID2Changed()
+        Partial Private Sub OnID2Changed()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="B"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Gets the collection of associated <see cref="C"/> entity instances.
         ''' </summary>
-        <Display(Description:="Cs"),  _
-         EntityAssociation("B_C", New String() {"ID1", "ID2"}, New String() {"BID1", "BID2"})>  _
+        <Display(Description:="Cs"),
+         EntityAssociation("B_C", New String() {"ID1", "ID2"}, New String() {"BID1", "BID2"})>
         Public ReadOnly Property Cs() As EntityCollection(Of C)
             Get
                 If (Me._cs Is Nothing) Then
@@ -361,57 +361,57 @@ Namespace TestDomainServices
                 Return Me._cs
             End Get
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ID1' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false, AllowInitialValue:=true),  _
-         Key(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         Editable(False, AllowInitialValue:=True),
+         Key(),
+         RoundtripOriginal()>
         Public Property ID1() As Integer
             Get
                 Return Me._id1
             End Get
             Set
-                If ((Me._id1 = value)  _
-                            = false) Then
-                    Me.OnID1Changing(value)
-                    Me.ValidateProperty("ID1", value)
-                    Me._id1 = value
+                If ((Me._id1 = Value) _
+                            = False) Then
+                    Me.OnID1Changing(Value)
+                    Me.ValidateProperty("ID1", Value)
+                    Me._id1 = Value
                     Me.RaisePropertyChanged("ID1")
-                    Me.OnID1Changed
+                    Me.OnID1Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ID2' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false, AllowInitialValue:=true),  _
-         Key(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         Editable(False, AllowInitialValue:=True),
+         Key(),
+         RoundtripOriginal()>
         Public Property ID2() As Integer
             Get
                 Return Me._id2
             End Get
             Set
-                If ((Me._id2 = value)  _
-                            = false) Then
-                    Me.OnID2Changing(value)
-                    Me.ValidateProperty("ID2", value)
-                    Me._id2 = value
+                If ((Me._id2 = Value) _
+                            = False) Then
+                    Me.OnID2Changing(Value)
+                    Me.ValidateProperty("ID2", Value)
+                    Me._id2 = Value
                     Me.RaisePropertyChanged("ID2")
-                    Me.OnID2Changed
+                    Me.OnID2Changed()
                 End If
             End Set
         End Property
-        
+
         Private Function FilterCs(ByVal entity As C) As Boolean
             Return (Object.Equals(entity.BID1, Me.ID1) AndAlso Object.Equals(entity.BID2, Me.ID2))
         End Function
-        
+
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -420,115 +420,115 @@ Namespace TestDomainServices
             Return EntityKey.Create(Me._id1, Me._id2)
         End Function
     End Class
-    
+
     ''' <summary>
     ''' The 'C' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
     Partial Public NotInheritable Class C
         Inherits Entity
-        
+
         Private _bid1 As Integer
-        
+
         Private _bid2 As Integer
-        
+
         Private _d_Ref1 As EntityRef(Of D)
-        
+
         Private _d_Ref2 As EntityRef(Of D)
-        
+
         Private _did_Ref1 As Integer
-        
+
         Private _did_Ref2 As Integer
-        
+
         Private _id As Integer
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
-        Private Partial Sub OnBID1Changing(ByVal value As Integer)
+        Partial Private Sub OnBID1Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnBID1Changed()
+        Partial Private Sub OnBID1Changed()
         End Sub
-        Private Partial Sub OnBID2Changing(ByVal value As Integer)
+        Partial Private Sub OnBID2Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnBID2Changed()
+        Partial Private Sub OnBID2Changed()
         End Sub
-        Private Partial Sub OnDID_Ref1Changing(ByVal value As Integer)
+        Partial Private Sub OnDID_Ref1Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnDID_Ref1Changed()
+        Partial Private Sub OnDID_Ref1Changed()
         End Sub
-        Private Partial Sub OnDID_Ref2Changing(ByVal value As Integer)
+        Partial Private Sub OnDID_Ref2Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnDID_Ref2Changed()
+        Partial Private Sub OnDID_Ref2Changed()
         End Sub
-        Private Partial Sub OnIDChanging(ByVal value As Integer)
+        Partial Private Sub OnIDChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnIDChanged()
+        Partial Private Sub OnIDChanged()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="C"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Gets or sets the 'BID1' value.
         ''' </summary>
-        <DataMember()>  _
+        <DataMember()>
         Public Property BID1() As Integer
             Get
                 Return Me._bid1
             End Get
             Set
-                If ((Me._bid1 = value)  _
-                            = false) Then
-                    Me.OnBID1Changing(value)
+                If ((Me._bid1 = Value) _
+                            = False) Then
+                    Me.OnBID1Changing(Value)
                     Me.RaiseDataMemberChanging("BID1")
-                    Me.ValidateProperty("BID1", value)
-                    Me._bid1 = value
+                    Me.ValidateProperty("BID1", Value)
+                    Me._bid1 = Value
                     Me.RaiseDataMemberChanged("BID1")
-                    Me.OnBID1Changed
+                    Me.OnBID1Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'BID2' value.
         ''' </summary>
-        <DataMember()>  _
+        <DataMember()>
         Public Property BID2() As Integer
             Get
                 Return Me._bid2
             End Get
             Set
-                If ((Me._bid2 = value)  _
-                            = false) Then
-                    Me.OnBID2Changing(value)
+                If ((Me._bid2 = Value) _
+                            = False) Then
+                    Me.OnBID2Changing(Value)
                     Me.RaiseDataMemberChanging("BID2")
-                    Me.ValidateProperty("BID2", value)
-                    Me._bid2 = value
+                    Me.ValidateProperty("BID2", Value)
+                    Me._bid2 = Value
                     Me.RaiseDataMemberChanged("BID2")
-                    Me.OnBID2Changed
+                    Me.OnBID2Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Display(Description:="D_Ref1"),  _
-         EntityAssociation("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey:=true)>  _
+        <Display(Description:="D_Ref1"),
+         EntityAssociation("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey:=True)>
         Public Property D_Ref1() As D
             Get
                 If (Me._d_Ref1 Is Nothing) Then
@@ -538,30 +538,30 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D_Ref1
-                If (Object.Equals(previous, value) = false) Then
-                    Me.ValidateProperty("D_Ref1", value)
+                If (Object.Equals(previous, Value) = False) Then
+                    Me.ValidateProperty("D_Ref1", Value)
                     If (Not (previous) Is Nothing) Then
                         Me._d_Ref1.Entity = Nothing
                         previous.C = Nothing
                     End If
-                    If (Not (value) Is Nothing) Then
-                        Me.DID_Ref1 = value.ID
+                    If (Not (Value) Is Nothing) Then
+                        Me.DID_Ref1 = Value.ID
                     Else
                         Me.DID_Ref1 = CType(Nothing, Integer)
                     End If
-                    Me._d_Ref1.Entity = value
-                    If (Not (value) Is Nothing) Then
-                        value.C = Me
+                    Me._d_Ref1.Entity = Value
+                    If (Not (Value) Is Nothing) Then
+                        Value.C = Me
                     End If
                     Me.RaisePropertyChanged("D_Ref1")
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey:=true)>  _
+        <EntityAssociation("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey:=True)>
         Public Property D_Ref2() As D
             Get
                 If (Me._d_Ref2 Is Nothing) Then
@@ -571,94 +571,94 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D_Ref2
-                If (Object.Equals(previous, value) = false) Then
-                    Me.ValidateProperty("D_Ref2", value)
-                    If (Not (value) Is Nothing) Then
-                        Me.DID_Ref2 = value.ID
+                If (Object.Equals(previous, Value) = False) Then
+                    Me.ValidateProperty("D_Ref2", Value)
+                    If (Not (Value) Is Nothing) Then
+                        Me.DID_Ref2 = Value.ID
                     Else
                         Me.DID_Ref2 = CType(Nothing, Integer)
                     End If
-                    Me._d_Ref2.Entity = value
+                    Me._d_Ref2.Entity = Value
                     Me.RaisePropertyChanged("D_Ref2")
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'DID_Ref1' value.
         ''' </summary>
-        <DataMember(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         RoundtripOriginal()>
         Public Property DID_Ref1() As Integer
             Get
                 Return Me._did_Ref1
             End Get
             Set
-                If ((Me._did_Ref1 = value)  _
-                            = false) Then
-                    Me.OnDID_Ref1Changing(value)
+                If ((Me._did_Ref1 = Value) _
+                            = False) Then
+                    Me.OnDID_Ref1Changing(Value)
                     Me.RaiseDataMemberChanging("DID_Ref1")
-                    Me.ValidateProperty("DID_Ref1", value)
-                    Me._did_Ref1 = value
+                    Me.ValidateProperty("DID_Ref1", Value)
+                    Me._did_Ref1 = Value
                     Me.RaiseDataMemberChanged("DID_Ref1")
-                    Me.OnDID_Ref1Changed
+                    Me.OnDID_Ref1Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'DID_Ref2' value.
         ''' </summary>
-        <DataMember(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         RoundtripOriginal()>
         Public Property DID_Ref2() As Integer
             Get
                 Return Me._did_Ref2
             End Get
             Set
-                If ((Me._did_Ref2 = value)  _
-                            = false) Then
-                    Me.OnDID_Ref2Changing(value)
+                If ((Me._did_Ref2 = Value) _
+                            = False) Then
+                    Me.OnDID_Ref2Changing(Value)
                     Me.RaiseDataMemberChanging("DID_Ref2")
-                    Me.ValidateProperty("DID_Ref2", value)
-                    Me._did_Ref2 = value
+                    Me.ValidateProperty("DID_Ref2", Value)
+                    Me._did_Ref2 = Value
                     Me.RaiseDataMemberChanged("DID_Ref2")
-                    Me.OnDID_Ref2Changed
+                    Me.OnDID_Ref2Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false, AllowInitialValue:=true),  _
-         Key(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         Editable(False, AllowInitialValue:=True),
+         Key(),
+         RoundtripOriginal()>
         Public Property ID() As Integer
             Get
                 Return Me._id
             End Get
             Set
-                If ((Me._id = value)  _
-                            = false) Then
-                    Me.OnIDChanging(value)
-                    Me.ValidateProperty("ID", value)
-                    Me._id = value
+                If ((Me._id = Value) _
+                            = False) Then
+                    Me.OnIDChanging(Value)
+                    Me.ValidateProperty("ID", Value)
+                    Me._id = Value
                     Me.RaisePropertyChanged("ID")
-                    Me.OnIDChanged
+                    Me.OnIDChanged()
                 End If
             End Set
         End Property
-        
+
         Private Function FilterD_Ref1(ByVal entity As D) As Boolean
             Return Object.Equals(entity.ID, Me.DID_Ref1)
         End Function
-        
+
         Private Function FilterD_Ref2(ByVal entity As D) As Boolean
             Return Object.Equals(entity.ID, Me.DID_Ref2)
         End Function
-        
+
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -667,104 +667,104 @@ Namespace TestDomainServices
             Return Me._id
         End Function
     End Class
-    
+
     ''' <summary>
     ''' The 'D' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
     Partial Public NotInheritable Class D
         Inherits Entity
-        
+
         Private _binaryData() As Byte
-        
+
         Private _c As EntityRef(Of C)
-        
+
         Private _d1 As EntityRef(Of D)
-        
+
         Private _d2 As EntityRef(Of D)
-        
+
         Private _d2_BackRef As EntityRef(Of D)
-        
+
         Private _ds As EntityCollection(Of D)
-        
+
         Private _dSelfRef_ID1 As Integer
-        
+
         Private _dSelfRef_ID2 As Integer
-        
+
         Private _id As Integer
-        
+
         Private _projectedD1BinaryData() As Byte
-        
+
         Private _projectedD1ID As Integer
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
-        Private Partial Sub OnBinaryDataChanging(ByVal value() As Byte)
+        Partial Private Sub OnBinaryDataChanging(ByVal value() As Byte)
         End Sub
-        Private Partial Sub OnBinaryDataChanged()
+        Partial Private Sub OnBinaryDataChanged()
         End Sub
-        Private Partial Sub OnDSelfRef_ID1Changing(ByVal value As Integer)
+        Partial Private Sub OnDSelfRef_ID1Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnDSelfRef_ID1Changed()
+        Partial Private Sub OnDSelfRef_ID1Changed()
         End Sub
-        Private Partial Sub OnDSelfRef_ID2Changing(ByVal value As Integer)
+        Partial Private Sub OnDSelfRef_ID2Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnDSelfRef_ID2Changed()
+        Partial Private Sub OnDSelfRef_ID2Changed()
         End Sub
-        Private Partial Sub OnIDChanging(ByVal value As Integer)
+        Partial Private Sub OnIDChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnIDChanged()
+        Partial Private Sub OnIDChanged()
         End Sub
-        Private Partial Sub OnProjectedD1BinaryDataChanging(ByVal value() As Byte)
+        Partial Private Sub OnProjectedD1BinaryDataChanging(ByVal value() As Byte)
         End Sub
-        Private Partial Sub OnProjectedD1BinaryDataChanged()
+        Partial Private Sub OnProjectedD1BinaryDataChanged()
         End Sub
-        Private Partial Sub OnProjectedD1IDChanging(ByVal value As Integer)
+        Partial Private Sub OnProjectedD1IDChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnProjectedD1IDChanged()
+        Partial Private Sub OnProjectedD1IDChanged()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="D"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Gets or sets the 'BinaryData' value.
         ''' </summary>
-        <DataMember()>  _
+        <DataMember()>
         Public Property BinaryData() As Byte()
             Get
                 Return Me._binaryData
             End Get
             Set
-                If (Object.Equals(Me._binaryData, value) = false) Then
-                    Me.OnBinaryDataChanging(value)
+                If (Object.Equals(Me._binaryData, Value) = False) Then
+                    Me.OnBinaryDataChanging(Value)
                     Me.RaiseDataMemberChanging("BinaryData")
-                    Me.ValidateProperty("BinaryData", value)
-                    Me._binaryData = value
+                    Me.ValidateProperty("BinaryData", Value)
+                    Me._binaryData = Value
                     Me.RaiseDataMemberChanged("BinaryData")
-                    Me.OnBinaryDataChanged
+                    Me.OnBinaryDataChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="C"/> entity.
         ''' </summary>
-        <EntityAssociation("C_D_Ref1", "ID", "DID_Ref1")>  _
+        <EntityAssociation("C_D_Ref1", "ID", "DID_Ref1")>
         Public Property C() As C
             Get
                 If (Me._c Is Nothing) Then
@@ -774,25 +774,25 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As C = Me.C
-                If (Object.Equals(previous, value) = false) Then
-                    Me.ValidateProperty("C", value)
+                If (Object.Equals(previous, Value) = False) Then
+                    Me.ValidateProperty("C", Value)
                     If (Not (previous) Is Nothing) Then
                         Me._c.Entity = Nothing
                         previous.D_Ref1 = Nothing
                     End If
-                    Me._c.Entity = value
-                    If (Not (value) Is Nothing) Then
-                        value.D_Ref1 = Me
+                    Me._c.Entity = Value
+                    If (Not (Value) Is Nothing) Then
+                        Value.D_Ref1 = Me
                     End If
                     Me.RaisePropertyChanged("C")
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D", "DSelfRef_ID1", "ID", IsForeignKey:=true)>  _
+        <EntityAssociation("D_D", "DSelfRef_ID1", "ID", IsForeignKey:=True)>
         Public Property D1() As D
             Get
                 If (Me._d1 Is Nothing) Then
@@ -802,30 +802,30 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D1
-                If (Object.Equals(previous, value) = false) Then
-                    Me.ValidateProperty("D1", value)
+                If (Object.Equals(previous, Value) = False) Then
+                    Me.ValidateProperty("D1", Value)
                     If (Not (previous) Is Nothing) Then
                         Me._d1.Entity = Nothing
                         previous.Ds.Remove(Me)
                     End If
-                    If (Not (value) Is Nothing) Then
-                        Me.DSelfRef_ID1 = value.ID
+                    If (Not (Value) Is Nothing) Then
+                        Me.DSelfRef_ID1 = Value.ID
                     Else
                         Me.DSelfRef_ID1 = CType(Nothing, Integer)
                     End If
-                    Me._d1.Entity = value
-                    If (Not (value) Is Nothing) Then
-                        value.Ds.Add(Me)
+                    Me._d1.Entity = Value
+                    If (Not (Value) Is Nothing) Then
+                        Value.Ds.Add(Me)
                     End If
                     Me.RaisePropertyChanged("D1")
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D2", "DSelfRef_ID2", "ID", IsForeignKey:=true)>  _
+        <EntityAssociation("D_D2", "DSelfRef_ID2", "ID", IsForeignKey:=True)>
         Public Property D2() As D
             Get
                 If (Me._d2 Is Nothing) Then
@@ -835,30 +835,30 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D2
-                If (Object.Equals(previous, value) = false) Then
-                    Me.ValidateProperty("D2", value)
+                If (Object.Equals(previous, Value) = False) Then
+                    Me.ValidateProperty("D2", Value)
                     If (Not (previous) Is Nothing) Then
                         Me._d2.Entity = Nothing
                         previous.D2_BackRef = Nothing
                     End If
-                    If (Not (value) Is Nothing) Then
-                        Me.DSelfRef_ID2 = value.ID
+                    If (Not (Value) Is Nothing) Then
+                        Me.DSelfRef_ID2 = Value.ID
                     Else
                         Me.DSelfRef_ID2 = CType(Nothing, Integer)
                     End If
-                    Me._d2.Entity = value
-                    If (Not (value) Is Nothing) Then
-                        value.D2_BackRef = Me
+                    Me._d2.Entity = Value
+                    If (Not (Value) Is Nothing) Then
+                        Value.D2_BackRef = Me
                     End If
                     Me.RaisePropertyChanged("D2")
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D2", "ID", "DSelfRef_ID2")>  _
+        <EntityAssociation("D_D2", "ID", "DSelfRef_ID2")>
         Public Property D2_BackRef() As D
             Get
                 If (Me._d2_BackRef Is Nothing) Then
@@ -868,25 +868,25 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D2_BackRef
-                If (Object.Equals(previous, value) = false) Then
-                    Me.ValidateProperty("D2_BackRef", value)
+                If (Object.Equals(previous, Value) = False) Then
+                    Me.ValidateProperty("D2_BackRef", Value)
                     If (Not (previous) Is Nothing) Then
                         Me._d2_BackRef.Entity = Nothing
                         previous.D2 = Nothing
                     End If
-                    Me._d2_BackRef.Entity = value
-                    If (Not (value) Is Nothing) Then
-                        value.D2 = Me
+                    Me._d2_BackRef.Entity = Value
+                    If (Not (Value) Is Nothing) Then
+                        Value.D2 = Me
                     End If
                     Me.RaisePropertyChanged("D2_BackRef")
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets the collection of associated <see cref="D"/> entity instances.
         ''' </summary>
-        <EntityAssociation("D_D", "ID", "DSelfRef_ID1")>  _
+        <EntityAssociation("D_D", "ID", "DSelfRef_ID1")>
         Public ReadOnly Property Ds() As EntityCollection(Of D)
             Get
                 If (Me._ds Is Nothing) Then
@@ -895,146 +895,146 @@ Namespace TestDomainServices
                 Return Me._ds
             End Get
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'DSelfRef_ID1' value.
         ''' </summary>
-        <DataMember(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         RoundtripOriginal()>
         Public Property DSelfRef_ID1() As Integer
             Get
                 Return Me._dSelfRef_ID1
             End Get
             Set
-                If ((Me._dSelfRef_ID1 = value)  _
-                            = false) Then
-                    Me.OnDSelfRef_ID1Changing(value)
+                If ((Me._dSelfRef_ID1 = Value) _
+                            = False) Then
+                    Me.OnDSelfRef_ID1Changing(Value)
                     Me.RaiseDataMemberChanging("DSelfRef_ID1")
-                    Me.ValidateProperty("DSelfRef_ID1", value)
-                    Me._dSelfRef_ID1 = value
+                    Me.ValidateProperty("DSelfRef_ID1", Value)
+                    Me._dSelfRef_ID1 = Value
                     Me.RaiseDataMemberChanged("DSelfRef_ID1")
-                    Me.OnDSelfRef_ID1Changed
+                    Me.OnDSelfRef_ID1Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'DSelfRef_ID2' value.
         ''' </summary>
-        <DataMember(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         RoundtripOriginal()>
         Public Property DSelfRef_ID2() As Integer
             Get
                 Return Me._dSelfRef_ID2
             End Get
             Set
-                If ((Me._dSelfRef_ID2 = value)  _
-                            = false) Then
-                    Me.OnDSelfRef_ID2Changing(value)
+                If ((Me._dSelfRef_ID2 = Value) _
+                            = False) Then
+                    Me.OnDSelfRef_ID2Changing(Value)
                     Me.RaiseDataMemberChanging("DSelfRef_ID2")
-                    Me.ValidateProperty("DSelfRef_ID2", value)
-                    Me._dSelfRef_ID2 = value
+                    Me.ValidateProperty("DSelfRef_ID2", Value)
+                    Me._dSelfRef_ID2 = Value
                     Me.RaiseDataMemberChanged("DSelfRef_ID2")
-                    Me.OnDSelfRef_ID2Changed
+                    Me.OnDSelfRef_ID2Changed()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false, AllowInitialValue:=true),  _
-         Key(),  _
-         Range(0, 99999),  _
-         RoundtripOriginal(),  _
-         UIHint("TextBlock")>  _
+        <DataMember(),
+         Editable(False, AllowInitialValue:=True),
+         Key(),
+         Range(0, 99999),
+         RoundtripOriginal(),
+         UIHint("TextBlock")>
         Public Property ID() As Integer
             Get
                 Return Me._id
             End Get
             Set
-                If ((Me._id = value)  _
-                            = false) Then
-                    Me.OnIDChanging(value)
-                    Me.ValidateProperty("ID", value)
-                    Me._id = value
+                If ((Me._id = Value) _
+                            = False) Then
+                    Me.OnIDChanging(Value)
+                    Me.ValidateProperty("ID", Value)
+                    Me._id = Value
                     Me.RaisePropertyChanged("ID")
-                    Me.OnIDChanged
+                    Me.OnIDChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ProjectedD1BinaryData' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false)>  _
+        <DataMember(),
+         Editable(False)>
         Public Property ProjectedD1BinaryData() As Byte()
             Get
                 Return Me._projectedD1BinaryData
             End Get
             Set
-                If (Object.Equals(Me._projectedD1BinaryData, value) = false) Then
-                    Me.OnProjectedD1BinaryDataChanging(value)
-                    Me.ValidateProperty("ProjectedD1BinaryData", value)
-                    Me._projectedD1BinaryData = value
+                If (Object.Equals(Me._projectedD1BinaryData, Value) = False) Then
+                    Me.OnProjectedD1BinaryDataChanging(Value)
+                    Me.ValidateProperty("ProjectedD1BinaryData", Value)
+                    Me._projectedD1BinaryData = Value
                     Me.RaisePropertyChanged("ProjectedD1BinaryData")
-                    Me.OnProjectedD1BinaryDataChanged
+                    Me.OnProjectedD1BinaryDataChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'ProjectedD1ID' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false),  _
-         UIHint("TextBlock")>  _
+        <DataMember(),
+         Editable(False),
+         UIHint("TextBlock")>
         Public Property ProjectedD1ID() As Integer
             Get
                 Return Me._projectedD1ID
             End Get
             Set
-                If ((Me._projectedD1ID = value)  _
-                            = false) Then
-                    Me.OnProjectedD1IDChanging(value)
-                    Me.ValidateProperty("ProjectedD1ID", value)
-                    Me._projectedD1ID = value
+                If ((Me._projectedD1ID = Value) _
+                            = False) Then
+                    Me.OnProjectedD1IDChanging(Value)
+                    Me.ValidateProperty("ProjectedD1ID", Value)
+                    Me._projectedD1ID = Value
                     Me.RaisePropertyChanged("ProjectedD1ID")
-                    Me.OnProjectedD1IDChanged
+                    Me.OnProjectedD1IDChanged()
                 End If
             End Set
         End Property
-        
+
         Private Function FilterC(ByVal entity As C) As Boolean
             Return Object.Equals(entity.DID_Ref1, Me.ID)
         End Function
-        
+
         Private Function FilterD1(ByVal entity As D) As Boolean
             Return Object.Equals(entity.ID, Me.DSelfRef_ID1)
         End Function
-        
+
         Private Function FilterD2(ByVal entity As D) As Boolean
             Return Object.Equals(entity.ID, Me.DSelfRef_ID2)
         End Function
-        
+
         Private Function FilterD2_BackRef(ByVal entity As D) As Boolean
             Return Object.Equals(entity.DSelfRef_ID2, Me.ID)
         End Function
-        
+
         Private Sub AttachDs(ByVal entity As D)
             entity.D1 = Me
         End Sub
-        
+
         Private Sub DetachDs(ByVal entity As D)
             entity.D1 = Nothing
         End Sub
-        
+
         Private Function FilterDs(ByVal entity As D) As Boolean
             Return Object.Equals(entity.DSelfRef_ID1, Me.ID)
         End Function
-        
+
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -1043,131 +1043,131 @@ Namespace TestDomainServices
             Return Me._id
         End Function
     End Class
-    
+
     ''' <summary>
     ''' Enum ImageKindEnum
     ''' </summary>
     Public Enum ImageKindEnum
-        
+
         ''' <summary>
         ''' ThumbNail
         ''' </summary>
         ThumbNail = 0
-        
+
         ''' <summary>
         ''' Full
         ''' </summary>
         Full = 1
     End Enum
-    
+
     ''' <summary>
     ''' The 'SpecialDataTypes' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
     Partial Public NotInheritable Class SpecialDataTypes
         Inherits Entity
-        
+
         Private _booleanProperty As IEnumerable(Of Nullable(Of Boolean))
-        
+
         Private _dateTimeProperty As IEnumerable(Of Nullable(Of DateTime))
-        
+
         Private _id As Integer
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
-        Private Partial Sub OnBooleanPropertyChanging(ByVal value As IEnumerable(Of Nullable(Of Boolean)))
+        Partial Private Sub OnBooleanPropertyChanging(ByVal value As IEnumerable(Of Nullable(Of Boolean)))
         End Sub
-        Private Partial Sub OnBooleanPropertyChanged()
+        Partial Private Sub OnBooleanPropertyChanged()
         End Sub
-        Private Partial Sub OnDateTimePropertyChanging(ByVal value As IEnumerable(Of Nullable(Of DateTime)))
+        Partial Private Sub OnDateTimePropertyChanging(ByVal value As IEnumerable(Of Nullable(Of DateTime)))
         End Sub
-        Private Partial Sub OnDateTimePropertyChanged()
+        Partial Private Sub OnDateTimePropertyChanged()
         End Sub
-        Private Partial Sub OnIdChanging(ByVal value As Integer)
+        Partial Private Sub OnIdChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnIdChanged()
+        Partial Private Sub OnIdChanged()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="SpecialDataTypes"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Gets or sets the 'BooleanProperty' value.
         ''' </summary>
-        <DataMember()>  _
+        <DataMember()>
         Public Property BooleanProperty() As IEnumerable(Of Nullable(Of Boolean))
             Get
                 Return Me._booleanProperty
             End Get
             Set
-                If (Object.Equals(Me._booleanProperty, value) = false) Then
-                    Me.OnBooleanPropertyChanging(value)
+                If (Object.Equals(Me._booleanProperty, Value) = False) Then
+                    Me.OnBooleanPropertyChanging(Value)
                     Me.RaiseDataMemberChanging("BooleanProperty")
-                    Me.ValidateProperty("BooleanProperty", value)
-                    Me._booleanProperty = value
+                    Me.ValidateProperty("BooleanProperty", Value)
+                    Me._booleanProperty = Value
                     Me.RaiseDataMemberChanged("BooleanProperty")
-                    Me.OnBooleanPropertyChanged
+                    Me.OnBooleanPropertyChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'DateTimeProperty' value.
         ''' </summary>
-        <DataMember()>  _
+        <DataMember()>
         Public Property DateTimeProperty() As IEnumerable(Of Nullable(Of DateTime))
             Get
                 Return Me._dateTimeProperty
             End Get
             Set
-                If (Object.Equals(Me._dateTimeProperty, value) = false) Then
-                    Me.OnDateTimePropertyChanging(value)
+                If (Object.Equals(Me._dateTimeProperty, Value) = False) Then
+                    Me.OnDateTimePropertyChanging(Value)
                     Me.RaiseDataMemberChanging("DateTimeProperty")
-                    Me.ValidateProperty("DateTimeProperty", value)
-                    Me._dateTimeProperty = value
+                    Me.ValidateProperty("DateTimeProperty", Value)
+                    Me._dateTimeProperty = Value
                     Me.RaiseDataMemberChanged("DateTimeProperty")
-                    Me.OnDateTimePropertyChanged
+                    Me.OnDateTimePropertyChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Gets or sets the 'Id' value.
         ''' </summary>
-        <DataMember(),  _
-         Editable(false, AllowInitialValue:=true),  _
-         Key(),  _
-         RoundtripOriginal()>  _
+        <DataMember(),
+         Editable(False, AllowInitialValue:=True),
+         Key(),
+         RoundtripOriginal()>
         Public Property Id() As Integer
             Get
                 Return Me._id
             End Get
             Set
-                If ((Me._id = value)  _
-                            = false) Then
-                    Me.OnIdChanging(value)
-                    Me.ValidateProperty("Id", value)
-                    Me._id = value
+                If ((Me._id = Value) _
+                            = False) Then
+                    Me.OnIdChanging(Value)
+                    Me.ValidateProperty("Id", Value)
+                    Me._id = Value
                     Me.RaisePropertyChanged("Id")
-                    Me.OnIdChanged
+                    Me.OnIdChanged()
                 End If
             End Set
         End Property
-        
+
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -1176,57 +1176,57 @@ Namespace TestDomainServices
             Return Me._id
         End Function
     End Class
-    
+
     ''' <summary>
     ''' The 'TestEntity_DataMemberBuddy' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
     Partial Public NotInheritable Class TestEntity_DataMemberBuddy
         Inherits Entity
-        
+
         Private _id As Integer
-        
+
         Private _prop1 As Integer
-        
-        #Region "Extensibility Method Definitions"
+
+#Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Private Partial Sub OnCreated()
+        Partial Private Sub OnCreated()
         End Sub
-        Private Partial Sub OnIDChanging(ByVal value As Integer)
+        Partial Private Sub OnIDChanging(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnIDChanged()
+        Partial Private Sub OnIDChanged()
         End Sub
-        Private Partial Sub OnProp1Changing(ByVal value As Integer)
+        Partial Private Sub OnProp1Changing(ByVal value As Integer)
         End Sub
-        Private Partial Sub OnProp1Changed()
+        Partial Private Sub OnProp1Changed()
         End Sub
 
-        #End Region
-        
-        
+#End Region
+
+
         ''' <summary>
         ''' Initializes a new instance of the <see cref="TestEntity_DataMemberBuddy"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
         End Sub
-        
+
         ''' <summary>
         ''' Deserialization ctor for MessagePack support, when any Property is required
         ''' </summary>
-        <PolyType.ConstructorShapeAttribute()>  _
-        Private Sub New(ByVal ID As Integer)
+        <PolyType.ConstructorShapeAttribute()>
+        Private Sub New(ByVal Prop1 As Integer)
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
             MyBase.OnDeserializing(CType(Nothing, System.Runtime.Serialization.StreamingContext))
-            Me.ID = ID
+            Me.Prop1 = Prop1
         End Sub
-        
+
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/Default/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
@@ -27,7 +27,7 @@ Imports System.Threading
 Imports System.Threading.Tasks
 
 Namespace TestDomainServices
-
+    
     'The following attributes were not generated:
     '
     '- The attribute 'System.ComponentModel.DataAnnotations.CustomValidationAttribute' references type 'TestDomainServices.ServerOnlyValidator' that is not accessible in the client project 'MockProject'. If you would like the attribute to be generated, make sure the assembly containing the attribute is referenced on the client.
@@ -37,78 +37,78 @@ Namespace TestDomainServices
     ''' <summary>
     ''' The 'A' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
     Partial Public NotInheritable Class A
         Inherits Entity
-
+        
         Private _b As EntityRef(Of B)
-
+        
         Private _bid1 As Integer
-
+        
         Private _bid2 As Integer
-
+        
         Private _id As Integer
-
+        
         Private _readOnlyData_NoReadOnlyAttribute As String
-
+        
         Private _readOnlyData_NoSetter As String
-
+        
         Private _readOnlyData_WithSetter As String
-
+        
         Private _requiredString As String
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
-        Partial Private Sub OnBID1Changing(ByVal value As Integer)
+        Private Partial Sub OnBID1Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnBID1Changed()
+        Private Partial Sub OnBID1Changed()
         End Sub
-        Partial Private Sub OnBID2Changing(ByVal value As Integer)
+        Private Partial Sub OnBID2Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnBID2Changed()
+        Private Partial Sub OnBID2Changed()
         End Sub
-        Partial Private Sub OnIDChanging(ByVal value As Integer)
+        Private Partial Sub OnIDChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnIDChanged()
+        Private Partial Sub OnIDChanged()
         End Sub
-        Partial Private Sub OnReadOnlyData_NoReadOnlyAttributeChanging(ByVal value As String)
+        Private Partial Sub OnReadOnlyData_NoReadOnlyAttributeChanging(ByVal value As String)
         End Sub
-        Partial Private Sub OnReadOnlyData_NoReadOnlyAttributeChanged()
+        Private Partial Sub OnReadOnlyData_NoReadOnlyAttributeChanged()
         End Sub
-        Partial Private Sub OnReadOnlyData_NoSetterChanging(ByVal value As String)
+        Private Partial Sub OnReadOnlyData_NoSetterChanging(ByVal value As String)
         End Sub
-        Partial Private Sub OnReadOnlyData_NoSetterChanged()
+        Private Partial Sub OnReadOnlyData_NoSetterChanged()
         End Sub
-        Partial Private Sub OnReadOnlyData_WithSetterChanging(ByVal value As String)
+        Private Partial Sub OnReadOnlyData_WithSetterChanging(ByVal value As String)
         End Sub
-        Partial Private Sub OnReadOnlyData_WithSetterChanged()
+        Private Partial Sub OnReadOnlyData_WithSetterChanged()
         End Sub
-        Partial Private Sub OnRequiredStringChanging(ByVal value As String)
+        Private Partial Sub OnRequiredStringChanging(ByVal value As String)
         End Sub
-        Partial Private Sub OnRequiredStringChanged()
+        Private Partial Sub OnRequiredStringChanged()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="A"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="B"/> entity.
         ''' </summary>
-        <EntityAssociation("A_B", New String() {"BID1", "BID2"}, New String() {"ID1", "ID2"}, IsForeignKey:=True)>
+        <EntityAssociation("A_B", New String() {"BID1", "BID2"}, New String() {"ID1", "ID2"}, IsForeignKey:=true)>  _
         Public Property B() As B
             Get
                 If (Me._b Is Nothing) Then
@@ -118,150 +118,150 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As B = Me.B
-                If (Object.Equals(previous, Value) = False) Then
-                    Me.ValidateProperty("B", Value)
-                    If (Not (Value) Is Nothing) Then
-                        Me.BID1 = Value.ID1
-                        Me.BID2 = Value.ID2
+                If (Object.Equals(previous, value) = false) Then
+                    Me.ValidateProperty("B", value)
+                    If (Not (value) Is Nothing) Then
+                        Me.BID1 = value.ID1
+                        Me.BID2 = value.ID2
                     Else
                         Me.BID1 = CType(Nothing, Integer)
                         Me.BID2 = CType(Nothing, Integer)
                     End If
-                    Me._b.Entity = Value
+                    Me._b.Entity = value
                     Me.RaisePropertyChanged("B")
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'BID1' value.
         ''' </summary>
-        <DataMember(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         RoundtripOriginal()>  _
         Public Property BID1() As Integer
             Get
                 Return Me._bid1
             End Get
             Set
-                If ((Me._bid1 = Value) _
-                            = False) Then
-                    Me.OnBID1Changing(Value)
+                If ((Me._bid1 = value)  _
+                            = false) Then
+                    Me.OnBID1Changing(value)
                     Me.RaiseDataMemberChanging("BID1")
-                    Me.ValidateProperty("BID1", Value)
-                    Me._bid1 = Value
+                    Me.ValidateProperty("BID1", value)
+                    Me._bid1 = value
                     Me.RaiseDataMemberChanged("BID1")
-                    Me.OnBID1Changed()
+                    Me.OnBID1Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'BID2' value.
         ''' </summary>
-        <DataMember(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         RoundtripOriginal()>  _
         Public Property BID2() As Integer
             Get
                 Return Me._bid2
             End Get
             Set
-                If ((Me._bid2 = Value) _
-                            = False) Then
-                    Me.OnBID2Changing(Value)
+                If ((Me._bid2 = value)  _
+                            = false) Then
+                    Me.OnBID2Changing(value)
                     Me.RaiseDataMemberChanging("BID2")
-                    Me.ValidateProperty("BID2", Value)
-                    Me._bid2 = Value
+                    Me.ValidateProperty("BID2", value)
+                    Me._bid2 = value
                     Me.RaiseDataMemberChanged("BID2")
-                    Me.OnBID2Changed()
+                    Me.OnBID2Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False, AllowInitialValue:=True),
-         Key(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         Editable(false, AllowInitialValue:=true),  _
+         Key(),  _
+         RoundtripOriginal()>  _
         Public Property ID() As Integer
             Get
                 Return Me._id
             End Get
             Set
-                If ((Me._id = Value) _
-                            = False) Then
-                    Me.OnIDChanging(Value)
-                    Me.ValidateProperty("ID", Value)
-                    Me._id = Value
+                If ((Me._id = value)  _
+                            = false) Then
+                    Me.OnIDChanging(value)
+                    Me.ValidateProperty("ID", value)
+                    Me._id = value
                     Me.RaisePropertyChanged("ID")
-                    Me.OnIDChanged()
+                    Me.OnIDChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ReadOnlyData_NoReadOnlyAttribute' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False),
-         [ReadOnly](True)>
+        <DataMember(),  _
+         Editable(false),  _
+         [ReadOnly](true)>  _
         Public Property ReadOnlyData_NoReadOnlyAttribute() As String
             Get
                 Return Me._readOnlyData_NoReadOnlyAttribute
             End Get
             Set
-                If (String.Equals(Me._readOnlyData_NoReadOnlyAttribute, Value) = False) Then
-                    Me.OnReadOnlyData_NoReadOnlyAttributeChanging(Value)
-                    Me.ValidateProperty("ReadOnlyData_NoReadOnlyAttribute", Value)
-                    Me._readOnlyData_NoReadOnlyAttribute = Value
+                If (String.Equals(Me._readOnlyData_NoReadOnlyAttribute, value) = false) Then
+                    Me.OnReadOnlyData_NoReadOnlyAttributeChanging(value)
+                    Me.ValidateProperty("ReadOnlyData_NoReadOnlyAttribute", value)
+                    Me._readOnlyData_NoReadOnlyAttribute = value
                     Me.RaisePropertyChanged("ReadOnlyData_NoReadOnlyAttribute")
-                    Me.OnReadOnlyData_NoReadOnlyAttributeChanged()
+                    Me.OnReadOnlyData_NoReadOnlyAttributeChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ReadOnlyData_NoSetter' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False),
-         [ReadOnly](True)>
+        <DataMember(),  _
+         Editable(false),  _
+         [ReadOnly](true)>  _
         Public Property ReadOnlyData_NoSetter() As String
             Get
                 Return Me._readOnlyData_NoSetter
             End Get
             Set
-                If (String.Equals(Me._readOnlyData_NoSetter, Value) = False) Then
-                    Me.OnReadOnlyData_NoSetterChanging(Value)
-                    Me.ValidateProperty("ReadOnlyData_NoSetter", Value)
-                    Me._readOnlyData_NoSetter = Value
+                If (String.Equals(Me._readOnlyData_NoSetter, value) = false) Then
+                    Me.OnReadOnlyData_NoSetterChanging(value)
+                    Me.ValidateProperty("ReadOnlyData_NoSetter", value)
+                    Me._readOnlyData_NoSetter = value
                     Me.RaisePropertyChanged("ReadOnlyData_NoSetter")
-                    Me.OnReadOnlyData_NoSetterChanged()
+                    Me.OnReadOnlyData_NoSetterChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ReadOnlyData_WithSetter' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False)>
+        <DataMember(),  _
+         Editable(false)>  _
         Public Property ReadOnlyData_WithSetter() As String
             Get
                 Return Me._readOnlyData_WithSetter
             End Get
             Set
-                If (String.Equals(Me._readOnlyData_WithSetter, Value) = False) Then
-                    Me.OnReadOnlyData_WithSetterChanging(Value)
-                    Me.ValidateProperty("ReadOnlyData_WithSetter", Value)
-                    Me._readOnlyData_WithSetter = Value
+                If (String.Equals(Me._readOnlyData_WithSetter, value) = false) Then
+                    Me.OnReadOnlyData_WithSetterChanging(value)
+                    Me.ValidateProperty("ReadOnlyData_WithSetter", value)
+                    Me._readOnlyData_WithSetter = value
                     Me.RaisePropertyChanged("ReadOnlyData_WithSetter")
-                    Me.OnReadOnlyData_WithSetterChanged()
+                    Me.OnReadOnlyData_WithSetterChanged
                 End If
             End Set
         End Property
-
+        
         'The following attributes were not generated:
         '
         '- The attribute 'System.ComponentModel.DataAnnotations.CustomValidationAttribute' references type 'TestDomainServices.ServerOnlyValidator' that is not accessible in the client project 'MockProject'. If you would like the attribute to be generated, make sure the assembly containing the attribute is referenced on the client.
@@ -274,30 +274,30 @@ Namespace TestDomainServices
         ''' <summary>
         ''' Gets or sets the 'RequiredString' value.
         ''' </summary>
-        <Custom(),
-         DataMember(),
-         Editable(True),
-         Required()>
+        <Custom(),  _
+         DataMember(),  _
+         Editable(true),  _
+         Required()>  _
         Public Property RequiredString() As String
             Get
                 Return Me._requiredString
             End Get
             Set
-                If (String.Equals(Me._requiredString, Value) = False) Then
-                    Me.OnRequiredStringChanging(Value)
+                If (String.Equals(Me._requiredString, value) = false) Then
+                    Me.OnRequiredStringChanging(value)
                     Me.RaiseDataMemberChanging("RequiredString")
-                    Me.ValidateProperty("RequiredString", Value)
-                    Me._requiredString = Value
+                    Me.ValidateProperty("RequiredString", value)
+                    Me._requiredString = value
                     Me.RaiseDataMemberChanged("RequiredString")
-                    Me.OnRequiredStringChanged()
+                    Me.OnRequiredStringChanged
                 End If
             End Set
         End Property
-
+        
         Private Function FilterB(ByVal entity As B) As Boolean
             Return (Object.Equals(entity.ID1, Me.BID1) AndAlso Object.Equals(entity.ID2, Me.BID2))
         End Function
-
+        
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -306,53 +306,53 @@ Namespace TestDomainServices
             Return Me._id
         End Function
     End Class
-
+    
     ''' <summary>
     ''' The 'B' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
     Partial Public NotInheritable Class B
         Inherits Entity
-
+        
         Private _cs As EntityCollection(Of C)
-
+        
         Private _id1 As Integer
-
+        
         Private _id2 As Integer
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
-        Partial Private Sub OnID1Changing(ByVal value As Integer)
+        Private Partial Sub OnID1Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnID1Changed()
+        Private Partial Sub OnID1Changed()
         End Sub
-        Partial Private Sub OnID2Changing(ByVal value As Integer)
+        Private Partial Sub OnID2Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnID2Changed()
+        Private Partial Sub OnID2Changed()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="B"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Gets the collection of associated <see cref="C"/> entity instances.
         ''' </summary>
-        <Display(Description:="Cs"),
-         EntityAssociation("B_C", New String() {"ID1", "ID2"}, New String() {"BID1", "BID2"})>
+        <Display(Description:="Cs"),  _
+         EntityAssociation("B_C", New String() {"ID1", "ID2"}, New String() {"BID1", "BID2"})>  _
         Public ReadOnly Property Cs() As EntityCollection(Of C)
             Get
                 If (Me._cs Is Nothing) Then
@@ -361,57 +361,57 @@ Namespace TestDomainServices
                 Return Me._cs
             End Get
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ID1' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False, AllowInitialValue:=True),
-         Key(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         Editable(false, AllowInitialValue:=true),  _
+         Key(),  _
+         RoundtripOriginal()>  _
         Public Property ID1() As Integer
             Get
                 Return Me._id1
             End Get
             Set
-                If ((Me._id1 = Value) _
-                            = False) Then
-                    Me.OnID1Changing(Value)
-                    Me.ValidateProperty("ID1", Value)
-                    Me._id1 = Value
+                If ((Me._id1 = value)  _
+                            = false) Then
+                    Me.OnID1Changing(value)
+                    Me.ValidateProperty("ID1", value)
+                    Me._id1 = value
                     Me.RaisePropertyChanged("ID1")
-                    Me.OnID1Changed()
+                    Me.OnID1Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ID2' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False, AllowInitialValue:=True),
-         Key(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         Editable(false, AllowInitialValue:=true),  _
+         Key(),  _
+         RoundtripOriginal()>  _
         Public Property ID2() As Integer
             Get
                 Return Me._id2
             End Get
             Set
-                If ((Me._id2 = Value) _
-                            = False) Then
-                    Me.OnID2Changing(Value)
-                    Me.ValidateProperty("ID2", Value)
-                    Me._id2 = Value
+                If ((Me._id2 = value)  _
+                            = false) Then
+                    Me.OnID2Changing(value)
+                    Me.ValidateProperty("ID2", value)
+                    Me._id2 = value
                     Me.RaisePropertyChanged("ID2")
-                    Me.OnID2Changed()
+                    Me.OnID2Changed
                 End If
             End Set
         End Property
-
+        
         Private Function FilterCs(ByVal entity As C) As Boolean
             Return (Object.Equals(entity.BID1, Me.ID1) AndAlso Object.Equals(entity.BID2, Me.ID2))
         End Function
-
+        
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -420,115 +420,115 @@ Namespace TestDomainServices
             Return EntityKey.Create(Me._id1, Me._id2)
         End Function
     End Class
-
+    
     ''' <summary>
     ''' The 'C' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
     Partial Public NotInheritable Class C
         Inherits Entity
-
+        
         Private _bid1 As Integer
-
+        
         Private _bid2 As Integer
-
+        
         Private _d_Ref1 As EntityRef(Of D)
-
+        
         Private _d_Ref2 As EntityRef(Of D)
-
+        
         Private _did_Ref1 As Integer
-
+        
         Private _did_Ref2 As Integer
-
+        
         Private _id As Integer
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
-        Partial Private Sub OnBID1Changing(ByVal value As Integer)
+        Private Partial Sub OnBID1Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnBID1Changed()
+        Private Partial Sub OnBID1Changed()
         End Sub
-        Partial Private Sub OnBID2Changing(ByVal value As Integer)
+        Private Partial Sub OnBID2Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnBID2Changed()
+        Private Partial Sub OnBID2Changed()
         End Sub
-        Partial Private Sub OnDID_Ref1Changing(ByVal value As Integer)
+        Private Partial Sub OnDID_Ref1Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnDID_Ref1Changed()
+        Private Partial Sub OnDID_Ref1Changed()
         End Sub
-        Partial Private Sub OnDID_Ref2Changing(ByVal value As Integer)
+        Private Partial Sub OnDID_Ref2Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnDID_Ref2Changed()
+        Private Partial Sub OnDID_Ref2Changed()
         End Sub
-        Partial Private Sub OnIDChanging(ByVal value As Integer)
+        Private Partial Sub OnIDChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnIDChanged()
+        Private Partial Sub OnIDChanged()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="C"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Gets or sets the 'BID1' value.
         ''' </summary>
-        <DataMember()>
+        <DataMember()>  _
         Public Property BID1() As Integer
             Get
                 Return Me._bid1
             End Get
             Set
-                If ((Me._bid1 = Value) _
-                            = False) Then
-                    Me.OnBID1Changing(Value)
+                If ((Me._bid1 = value)  _
+                            = false) Then
+                    Me.OnBID1Changing(value)
                     Me.RaiseDataMemberChanging("BID1")
-                    Me.ValidateProperty("BID1", Value)
-                    Me._bid1 = Value
+                    Me.ValidateProperty("BID1", value)
+                    Me._bid1 = value
                     Me.RaiseDataMemberChanged("BID1")
-                    Me.OnBID1Changed()
+                    Me.OnBID1Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'BID2' value.
         ''' </summary>
-        <DataMember()>
+        <DataMember()>  _
         Public Property BID2() As Integer
             Get
                 Return Me._bid2
             End Get
             Set
-                If ((Me._bid2 = Value) _
-                            = False) Then
-                    Me.OnBID2Changing(Value)
+                If ((Me._bid2 = value)  _
+                            = false) Then
+                    Me.OnBID2Changing(value)
                     Me.RaiseDataMemberChanging("BID2")
-                    Me.ValidateProperty("BID2", Value)
-                    Me._bid2 = Value
+                    Me.ValidateProperty("BID2", value)
+                    Me._bid2 = value
                     Me.RaiseDataMemberChanged("BID2")
-                    Me.OnBID2Changed()
+                    Me.OnBID2Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <Display(Description:="D_Ref1"),
-         EntityAssociation("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey:=True)>
+        <Display(Description:="D_Ref1"),  _
+         EntityAssociation("C_D_Ref1", "DID_Ref1", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref1() As D
             Get
                 If (Me._d_Ref1 Is Nothing) Then
@@ -538,30 +538,30 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D_Ref1
-                If (Object.Equals(previous, Value) = False) Then
-                    Me.ValidateProperty("D_Ref1", Value)
+                If (Object.Equals(previous, value) = false) Then
+                    Me.ValidateProperty("D_Ref1", value)
                     If (Not (previous) Is Nothing) Then
                         Me._d_Ref1.Entity = Nothing
                         previous.C = Nothing
                     End If
-                    If (Not (Value) Is Nothing) Then
-                        Me.DID_Ref1 = Value.ID
+                    If (Not (value) Is Nothing) Then
+                        Me.DID_Ref1 = value.ID
                     Else
                         Me.DID_Ref1 = CType(Nothing, Integer)
                     End If
-                    Me._d_Ref1.Entity = Value
-                    If (Not (Value) Is Nothing) Then
-                        Value.C = Me
+                    Me._d_Ref1.Entity = value
+                    If (Not (value) Is Nothing) Then
+                        value.C = Me
                     End If
                     Me.RaisePropertyChanged("D_Ref1")
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey:=True)>
+        <EntityAssociation("C_D_Ref2", "DID_Ref2", "ID", IsForeignKey:=true)>  _
         Public Property D_Ref2() As D
             Get
                 If (Me._d_Ref2 Is Nothing) Then
@@ -571,94 +571,94 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D_Ref2
-                If (Object.Equals(previous, Value) = False) Then
-                    Me.ValidateProperty("D_Ref2", Value)
-                    If (Not (Value) Is Nothing) Then
-                        Me.DID_Ref2 = Value.ID
+                If (Object.Equals(previous, value) = false) Then
+                    Me.ValidateProperty("D_Ref2", value)
+                    If (Not (value) Is Nothing) Then
+                        Me.DID_Ref2 = value.ID
                     Else
                         Me.DID_Ref2 = CType(Nothing, Integer)
                     End If
-                    Me._d_Ref2.Entity = Value
+                    Me._d_Ref2.Entity = value
                     Me.RaisePropertyChanged("D_Ref2")
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'DID_Ref1' value.
         ''' </summary>
-        <DataMember(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         RoundtripOriginal()>  _
         Public Property DID_Ref1() As Integer
             Get
                 Return Me._did_Ref1
             End Get
             Set
-                If ((Me._did_Ref1 = Value) _
-                            = False) Then
-                    Me.OnDID_Ref1Changing(Value)
+                If ((Me._did_Ref1 = value)  _
+                            = false) Then
+                    Me.OnDID_Ref1Changing(value)
                     Me.RaiseDataMemberChanging("DID_Ref1")
-                    Me.ValidateProperty("DID_Ref1", Value)
-                    Me._did_Ref1 = Value
+                    Me.ValidateProperty("DID_Ref1", value)
+                    Me._did_Ref1 = value
                     Me.RaiseDataMemberChanged("DID_Ref1")
-                    Me.OnDID_Ref1Changed()
+                    Me.OnDID_Ref1Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'DID_Ref2' value.
         ''' </summary>
-        <DataMember(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         RoundtripOriginal()>  _
         Public Property DID_Ref2() As Integer
             Get
                 Return Me._did_Ref2
             End Get
             Set
-                If ((Me._did_Ref2 = Value) _
-                            = False) Then
-                    Me.OnDID_Ref2Changing(Value)
+                If ((Me._did_Ref2 = value)  _
+                            = false) Then
+                    Me.OnDID_Ref2Changing(value)
                     Me.RaiseDataMemberChanging("DID_Ref2")
-                    Me.ValidateProperty("DID_Ref2", Value)
-                    Me._did_Ref2 = Value
+                    Me.ValidateProperty("DID_Ref2", value)
+                    Me._did_Ref2 = value
                     Me.RaiseDataMemberChanged("DID_Ref2")
-                    Me.OnDID_Ref2Changed()
+                    Me.OnDID_Ref2Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False, AllowInitialValue:=True),
-         Key(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         Editable(false, AllowInitialValue:=true),  _
+         Key(),  _
+         RoundtripOriginal()>  _
         Public Property ID() As Integer
             Get
                 Return Me._id
             End Get
             Set
-                If ((Me._id = Value) _
-                            = False) Then
-                    Me.OnIDChanging(Value)
-                    Me.ValidateProperty("ID", Value)
-                    Me._id = Value
+                If ((Me._id = value)  _
+                            = false) Then
+                    Me.OnIDChanging(value)
+                    Me.ValidateProperty("ID", value)
+                    Me._id = value
                     Me.RaisePropertyChanged("ID")
-                    Me.OnIDChanged()
+                    Me.OnIDChanged
                 End If
             End Set
         End Property
-
+        
         Private Function FilterD_Ref1(ByVal entity As D) As Boolean
             Return Object.Equals(entity.ID, Me.DID_Ref1)
         End Function
-
+        
         Private Function FilterD_Ref2(ByVal entity As D) As Boolean
             Return Object.Equals(entity.ID, Me.DID_Ref2)
         End Function
-
+        
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -667,104 +667,104 @@ Namespace TestDomainServices
             Return Me._id
         End Function
     End Class
-
+    
     ''' <summary>
     ''' The 'D' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
     Partial Public NotInheritable Class D
         Inherits Entity
-
+        
         Private _binaryData() As Byte
-
+        
         Private _c As EntityRef(Of C)
-
+        
         Private _d1 As EntityRef(Of D)
-
+        
         Private _d2 As EntityRef(Of D)
-
+        
         Private _d2_BackRef As EntityRef(Of D)
-
+        
         Private _ds As EntityCollection(Of D)
-
+        
         Private _dSelfRef_ID1 As Integer
-
+        
         Private _dSelfRef_ID2 As Integer
-
+        
         Private _id As Integer
-
+        
         Private _projectedD1BinaryData() As Byte
-
+        
         Private _projectedD1ID As Integer
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
-        Partial Private Sub OnBinaryDataChanging(ByVal value() As Byte)
+        Private Partial Sub OnBinaryDataChanging(ByVal value() As Byte)
         End Sub
-        Partial Private Sub OnBinaryDataChanged()
+        Private Partial Sub OnBinaryDataChanged()
         End Sub
-        Partial Private Sub OnDSelfRef_ID1Changing(ByVal value As Integer)
+        Private Partial Sub OnDSelfRef_ID1Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnDSelfRef_ID1Changed()
+        Private Partial Sub OnDSelfRef_ID1Changed()
         End Sub
-        Partial Private Sub OnDSelfRef_ID2Changing(ByVal value As Integer)
+        Private Partial Sub OnDSelfRef_ID2Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnDSelfRef_ID2Changed()
+        Private Partial Sub OnDSelfRef_ID2Changed()
         End Sub
-        Partial Private Sub OnIDChanging(ByVal value As Integer)
+        Private Partial Sub OnIDChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnIDChanged()
+        Private Partial Sub OnIDChanged()
         End Sub
-        Partial Private Sub OnProjectedD1BinaryDataChanging(ByVal value() As Byte)
+        Private Partial Sub OnProjectedD1BinaryDataChanging(ByVal value() As Byte)
         End Sub
-        Partial Private Sub OnProjectedD1BinaryDataChanged()
+        Private Partial Sub OnProjectedD1BinaryDataChanged()
         End Sub
-        Partial Private Sub OnProjectedD1IDChanging(ByVal value As Integer)
+        Private Partial Sub OnProjectedD1IDChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnProjectedD1IDChanged()
+        Private Partial Sub OnProjectedD1IDChanged()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="D"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Gets or sets the 'BinaryData' value.
         ''' </summary>
-        <DataMember()>
+        <DataMember()>  _
         Public Property BinaryData() As Byte()
             Get
                 Return Me._binaryData
             End Get
             Set
-                If (Object.Equals(Me._binaryData, Value) = False) Then
-                    Me.OnBinaryDataChanging(Value)
+                If (Object.Equals(Me._binaryData, value) = false) Then
+                    Me.OnBinaryDataChanging(value)
                     Me.RaiseDataMemberChanging("BinaryData")
-                    Me.ValidateProperty("BinaryData", Value)
-                    Me._binaryData = Value
+                    Me.ValidateProperty("BinaryData", value)
+                    Me._binaryData = value
                     Me.RaiseDataMemberChanged("BinaryData")
-                    Me.OnBinaryDataChanged()
+                    Me.OnBinaryDataChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="C"/> entity.
         ''' </summary>
-        <EntityAssociation("C_D_Ref1", "ID", "DID_Ref1")>
+        <EntityAssociation("C_D_Ref1", "ID", "DID_Ref1")>  _
         Public Property C() As C
             Get
                 If (Me._c Is Nothing) Then
@@ -774,25 +774,25 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As C = Me.C
-                If (Object.Equals(previous, Value) = False) Then
-                    Me.ValidateProperty("C", Value)
+                If (Object.Equals(previous, value) = false) Then
+                    Me.ValidateProperty("C", value)
                     If (Not (previous) Is Nothing) Then
                         Me._c.Entity = Nothing
                         previous.D_Ref1 = Nothing
                     End If
-                    Me._c.Entity = Value
-                    If (Not (Value) Is Nothing) Then
-                        Value.D_Ref1 = Me
+                    Me._c.Entity = value
+                    If (Not (value) Is Nothing) Then
+                        value.D_Ref1 = Me
                     End If
                     Me.RaisePropertyChanged("C")
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D", "DSelfRef_ID1", "ID", IsForeignKey:=True)>
+        <EntityAssociation("D_D", "DSelfRef_ID1", "ID", IsForeignKey:=true)>  _
         Public Property D1() As D
             Get
                 If (Me._d1 Is Nothing) Then
@@ -802,30 +802,30 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D1
-                If (Object.Equals(previous, Value) = False) Then
-                    Me.ValidateProperty("D1", Value)
+                If (Object.Equals(previous, value) = false) Then
+                    Me.ValidateProperty("D1", value)
                     If (Not (previous) Is Nothing) Then
                         Me._d1.Entity = Nothing
                         previous.Ds.Remove(Me)
                     End If
-                    If (Not (Value) Is Nothing) Then
-                        Me.DSelfRef_ID1 = Value.ID
+                    If (Not (value) Is Nothing) Then
+                        Me.DSelfRef_ID1 = value.ID
                     Else
                         Me.DSelfRef_ID1 = CType(Nothing, Integer)
                     End If
-                    Me._d1.Entity = Value
-                    If (Not (Value) Is Nothing) Then
-                        Value.Ds.Add(Me)
+                    Me._d1.Entity = value
+                    If (Not (value) Is Nothing) Then
+                        value.Ds.Add(Me)
                     End If
                     Me.RaisePropertyChanged("D1")
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D2", "DSelfRef_ID2", "ID", IsForeignKey:=True)>
+        <EntityAssociation("D_D2", "DSelfRef_ID2", "ID", IsForeignKey:=true)>  _
         Public Property D2() As D
             Get
                 If (Me._d2 Is Nothing) Then
@@ -835,30 +835,30 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D2
-                If (Object.Equals(previous, Value) = False) Then
-                    Me.ValidateProperty("D2", Value)
+                If (Object.Equals(previous, value) = false) Then
+                    Me.ValidateProperty("D2", value)
                     If (Not (previous) Is Nothing) Then
                         Me._d2.Entity = Nothing
                         previous.D2_BackRef = Nothing
                     End If
-                    If (Not (Value) Is Nothing) Then
-                        Me.DSelfRef_ID2 = Value.ID
+                    If (Not (value) Is Nothing) Then
+                        Me.DSelfRef_ID2 = value.ID
                     Else
                         Me.DSelfRef_ID2 = CType(Nothing, Integer)
                     End If
-                    Me._d2.Entity = Value
-                    If (Not (Value) Is Nothing) Then
-                        Value.D2_BackRef = Me
+                    Me._d2.Entity = value
+                    If (Not (value) Is Nothing) Then
+                        value.D2_BackRef = Me
                     End If
                     Me.RaisePropertyChanged("D2")
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the associated <see cref="D"/> entity.
         ''' </summary>
-        <EntityAssociation("D_D2", "ID", "DSelfRef_ID2")>
+        <EntityAssociation("D_D2", "ID", "DSelfRef_ID2")>  _
         Public Property D2_BackRef() As D
             Get
                 If (Me._d2_BackRef Is Nothing) Then
@@ -868,25 +868,25 @@ Namespace TestDomainServices
             End Get
             Set
                 Dim previous As D = Me.D2_BackRef
-                If (Object.Equals(previous, Value) = False) Then
-                    Me.ValidateProperty("D2_BackRef", Value)
+                If (Object.Equals(previous, value) = false) Then
+                    Me.ValidateProperty("D2_BackRef", value)
                     If (Not (previous) Is Nothing) Then
                         Me._d2_BackRef.Entity = Nothing
                         previous.D2 = Nothing
                     End If
-                    Me._d2_BackRef.Entity = Value
-                    If (Not (Value) Is Nothing) Then
-                        Value.D2 = Me
+                    Me._d2_BackRef.Entity = value
+                    If (Not (value) Is Nothing) Then
+                        value.D2 = Me
                     End If
                     Me.RaisePropertyChanged("D2_BackRef")
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets the collection of associated <see cref="D"/> entity instances.
         ''' </summary>
-        <EntityAssociation("D_D", "ID", "DSelfRef_ID1")>
+        <EntityAssociation("D_D", "ID", "DSelfRef_ID1")>  _
         Public ReadOnly Property Ds() As EntityCollection(Of D)
             Get
                 If (Me._ds Is Nothing) Then
@@ -895,146 +895,146 @@ Namespace TestDomainServices
                 Return Me._ds
             End Get
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'DSelfRef_ID1' value.
         ''' </summary>
-        <DataMember(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         RoundtripOriginal()>  _
         Public Property DSelfRef_ID1() As Integer
             Get
                 Return Me._dSelfRef_ID1
             End Get
             Set
-                If ((Me._dSelfRef_ID1 = Value) _
-                            = False) Then
-                    Me.OnDSelfRef_ID1Changing(Value)
+                If ((Me._dSelfRef_ID1 = value)  _
+                            = false) Then
+                    Me.OnDSelfRef_ID1Changing(value)
                     Me.RaiseDataMemberChanging("DSelfRef_ID1")
-                    Me.ValidateProperty("DSelfRef_ID1", Value)
-                    Me._dSelfRef_ID1 = Value
+                    Me.ValidateProperty("DSelfRef_ID1", value)
+                    Me._dSelfRef_ID1 = value
                     Me.RaiseDataMemberChanged("DSelfRef_ID1")
-                    Me.OnDSelfRef_ID1Changed()
+                    Me.OnDSelfRef_ID1Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'DSelfRef_ID2' value.
         ''' </summary>
-        <DataMember(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         RoundtripOriginal()>  _
         Public Property DSelfRef_ID2() As Integer
             Get
                 Return Me._dSelfRef_ID2
             End Get
             Set
-                If ((Me._dSelfRef_ID2 = Value) _
-                            = False) Then
-                    Me.OnDSelfRef_ID2Changing(Value)
+                If ((Me._dSelfRef_ID2 = value)  _
+                            = false) Then
+                    Me.OnDSelfRef_ID2Changing(value)
                     Me.RaiseDataMemberChanging("DSelfRef_ID2")
-                    Me.ValidateProperty("DSelfRef_ID2", Value)
-                    Me._dSelfRef_ID2 = Value
+                    Me.ValidateProperty("DSelfRef_ID2", value)
+                    Me._dSelfRef_ID2 = value
                     Me.RaiseDataMemberChanged("DSelfRef_ID2")
-                    Me.OnDSelfRef_ID2Changed()
+                    Me.OnDSelfRef_ID2Changed
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False, AllowInitialValue:=True),
-         Key(),
-         Range(0, 99999),
-         RoundtripOriginal(),
-         UIHint("TextBlock")>
+        <DataMember(),  _
+         Editable(false, AllowInitialValue:=true),  _
+         Key(),  _
+         Range(0, 99999),  _
+         RoundtripOriginal(),  _
+         UIHint("TextBlock")>  _
         Public Property ID() As Integer
             Get
                 Return Me._id
             End Get
             Set
-                If ((Me._id = Value) _
-                            = False) Then
-                    Me.OnIDChanging(Value)
-                    Me.ValidateProperty("ID", Value)
-                    Me._id = Value
+                If ((Me._id = value)  _
+                            = false) Then
+                    Me.OnIDChanging(value)
+                    Me.ValidateProperty("ID", value)
+                    Me._id = value
                     Me.RaisePropertyChanged("ID")
-                    Me.OnIDChanged()
+                    Me.OnIDChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ProjectedD1BinaryData' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False)>
+        <DataMember(),  _
+         Editable(false)>  _
         Public Property ProjectedD1BinaryData() As Byte()
             Get
                 Return Me._projectedD1BinaryData
             End Get
             Set
-                If (Object.Equals(Me._projectedD1BinaryData, Value) = False) Then
-                    Me.OnProjectedD1BinaryDataChanging(Value)
-                    Me.ValidateProperty("ProjectedD1BinaryData", Value)
-                    Me._projectedD1BinaryData = Value
+                If (Object.Equals(Me._projectedD1BinaryData, value) = false) Then
+                    Me.OnProjectedD1BinaryDataChanging(value)
+                    Me.ValidateProperty("ProjectedD1BinaryData", value)
+                    Me._projectedD1BinaryData = value
                     Me.RaisePropertyChanged("ProjectedD1BinaryData")
-                    Me.OnProjectedD1BinaryDataChanged()
+                    Me.OnProjectedD1BinaryDataChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'ProjectedD1ID' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False),
-         UIHint("TextBlock")>
+        <DataMember(),  _
+         Editable(false),  _
+         UIHint("TextBlock")>  _
         Public Property ProjectedD1ID() As Integer
             Get
                 Return Me._projectedD1ID
             End Get
             Set
-                If ((Me._projectedD1ID = Value) _
-                            = False) Then
-                    Me.OnProjectedD1IDChanging(Value)
-                    Me.ValidateProperty("ProjectedD1ID", Value)
-                    Me._projectedD1ID = Value
+                If ((Me._projectedD1ID = value)  _
+                            = false) Then
+                    Me.OnProjectedD1IDChanging(value)
+                    Me.ValidateProperty("ProjectedD1ID", value)
+                    Me._projectedD1ID = value
                     Me.RaisePropertyChanged("ProjectedD1ID")
-                    Me.OnProjectedD1IDChanged()
+                    Me.OnProjectedD1IDChanged
                 End If
             End Set
         End Property
-
+        
         Private Function FilterC(ByVal entity As C) As Boolean
             Return Object.Equals(entity.DID_Ref1, Me.ID)
         End Function
-
+        
         Private Function FilterD1(ByVal entity As D) As Boolean
             Return Object.Equals(entity.ID, Me.DSelfRef_ID1)
         End Function
-
+        
         Private Function FilterD2(ByVal entity As D) As Boolean
             Return Object.Equals(entity.ID, Me.DSelfRef_ID2)
         End Function
-
+        
         Private Function FilterD2_BackRef(ByVal entity As D) As Boolean
             Return Object.Equals(entity.DSelfRef_ID2, Me.ID)
         End Function
-
+        
         Private Sub AttachDs(ByVal entity As D)
             entity.D1 = Me
         End Sub
-
+        
         Private Sub DetachDs(ByVal entity As D)
             entity.D1 = Nothing
         End Sub
-
+        
         Private Function FilterDs(ByVal entity As D) As Boolean
             Return Object.Equals(entity.DSelfRef_ID1, Me.ID)
         End Function
-
+        
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -1043,131 +1043,131 @@ Namespace TestDomainServices
             Return Me._id
         End Function
     End Class
-
+    
     ''' <summary>
     ''' Enum ImageKindEnum
     ''' </summary>
     Public Enum ImageKindEnum
-
+        
         ''' <summary>
         ''' ThumbNail
         ''' </summary>
         ThumbNail = 0
-
+        
         ''' <summary>
         ''' Full
         ''' </summary>
         Full = 1
     End Enum
-
+    
     ''' <summary>
     ''' The 'SpecialDataTypes' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
     Partial Public NotInheritable Class SpecialDataTypes
         Inherits Entity
-
+        
         Private _booleanProperty As IEnumerable(Of Nullable(Of Boolean))
-
+        
         Private _dateTimeProperty As IEnumerable(Of Nullable(Of DateTime))
-
+        
         Private _id As Integer
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
-        Partial Private Sub OnBooleanPropertyChanging(ByVal value As IEnumerable(Of Nullable(Of Boolean)))
+        Private Partial Sub OnBooleanPropertyChanging(ByVal value As IEnumerable(Of Nullable(Of Boolean)))
         End Sub
-        Partial Private Sub OnBooleanPropertyChanged()
+        Private Partial Sub OnBooleanPropertyChanged()
         End Sub
-        Partial Private Sub OnDateTimePropertyChanging(ByVal value As IEnumerable(Of Nullable(Of DateTime)))
+        Private Partial Sub OnDateTimePropertyChanging(ByVal value As IEnumerable(Of Nullable(Of DateTime)))
         End Sub
-        Partial Private Sub OnDateTimePropertyChanged()
+        Private Partial Sub OnDateTimePropertyChanged()
         End Sub
-        Partial Private Sub OnIdChanging(ByVal value As Integer)
+        Private Partial Sub OnIdChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnIdChanged()
+        Private Partial Sub OnIdChanged()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="SpecialDataTypes"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Gets or sets the 'BooleanProperty' value.
         ''' </summary>
-        <DataMember()>
+        <DataMember()>  _
         Public Property BooleanProperty() As IEnumerable(Of Nullable(Of Boolean))
             Get
                 Return Me._booleanProperty
             End Get
             Set
-                If (Object.Equals(Me._booleanProperty, Value) = False) Then
-                    Me.OnBooleanPropertyChanging(Value)
+                If (Object.Equals(Me._booleanProperty, value) = false) Then
+                    Me.OnBooleanPropertyChanging(value)
                     Me.RaiseDataMemberChanging("BooleanProperty")
-                    Me.ValidateProperty("BooleanProperty", Value)
-                    Me._booleanProperty = Value
+                    Me.ValidateProperty("BooleanProperty", value)
+                    Me._booleanProperty = value
                     Me.RaiseDataMemberChanged("BooleanProperty")
-                    Me.OnBooleanPropertyChanged()
+                    Me.OnBooleanPropertyChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'DateTimeProperty' value.
         ''' </summary>
-        <DataMember()>
+        <DataMember()>  _
         Public Property DateTimeProperty() As IEnumerable(Of Nullable(Of DateTime))
             Get
                 Return Me._dateTimeProperty
             End Get
             Set
-                If (Object.Equals(Me._dateTimeProperty, Value) = False) Then
-                    Me.OnDateTimePropertyChanging(Value)
+                If (Object.Equals(Me._dateTimeProperty, value) = false) Then
+                    Me.OnDateTimePropertyChanging(value)
                     Me.RaiseDataMemberChanging("DateTimeProperty")
-                    Me.ValidateProperty("DateTimeProperty", Value)
-                    Me._dateTimeProperty = Value
+                    Me.ValidateProperty("DateTimeProperty", value)
+                    Me._dateTimeProperty = value
                     Me.RaiseDataMemberChanged("DateTimeProperty")
-                    Me.OnDateTimePropertyChanged()
+                    Me.OnDateTimePropertyChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Gets or sets the 'Id' value.
         ''' </summary>
-        <DataMember(),
-         Editable(False, AllowInitialValue:=True),
-         Key(),
-         RoundtripOriginal()>
+        <DataMember(),  _
+         Editable(false, AllowInitialValue:=true),  _
+         Key(),  _
+         RoundtripOriginal()>  _
         Public Property Id() As Integer
             Get
                 Return Me._id
             End Get
             Set
-                If ((Me._id = Value) _
-                            = False) Then
-                    Me.OnIdChanging(Value)
-                    Me.ValidateProperty("Id", Value)
-                    Me._id = Value
+                If ((Me._id = value)  _
+                            = false) Then
+                    Me.OnIdChanging(value)
+                    Me.ValidateProperty("Id", value)
+                    Me._id = value
                     Me.RaisePropertyChanged("Id")
-                    Me.OnIdChanged()
+                    Me.OnIdChanged
                 End If
             End Set
         End Property
-
+        
         ''' <summary>
         ''' Computes a value from the key fields that uniquely identifies this entity instance.
         ''' </summary>
@@ -1176,57 +1176,57 @@ Namespace TestDomainServices
             Return Me._id
         End Function
     End Class
-
+    
     ''' <summary>
     ''' The 'TestEntity_DataMemberBuddy' entity class.
     ''' </summary>
-    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>
+    <DataContract([Namespace]:="http://schemas.datacontract.org/2004/07/TestDomainServices")>  _
     Partial Public NotInheritable Class TestEntity_DataMemberBuddy
         Inherits Entity
-
+        
         Private _id As Integer
-
+        
         Private _prop1 As Integer
-
-#Region "Extensibility Method Definitions"
+        
+        #Region "Extensibility Method Definitions"
 
         ''' <summary>
         ''' This method is invoked from the constructor once initialization is complete and
         ''' can be used for further object setup.
         ''' </summary>
-        Partial Private Sub OnCreated()
+        Private Partial Sub OnCreated()
         End Sub
-        Partial Private Sub OnIDChanging(ByVal value As Integer)
+        Private Partial Sub OnIDChanging(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnIDChanged()
+        Private Partial Sub OnIDChanged()
         End Sub
-        Partial Private Sub OnProp1Changing(ByVal value As Integer)
+        Private Partial Sub OnProp1Changing(ByVal value As Integer)
         End Sub
-        Partial Private Sub OnProp1Changed()
+        Private Partial Sub OnProp1Changed()
         End Sub
 
-#End Region
-
-
+        #End Region
+        
+        
         ''' <summary>
         ''' Initializes a new instance of the <see cref="TestEntity_DataMemberBuddy"/> class.
         ''' </summary>
         Public Sub New()
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Deserialization ctor for MessagePack support, when any Property is required
         ''' </summary>
-        <PolyType.ConstructorShapeAttribute()>
+        <PolyType.ConstructorShapeAttribute()>  _
         Private Sub New(ByVal Prop1 As Integer)
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
             MyBase.OnDeserializing(CType(Nothing, System.Runtime.Serialization.StreamingContext))
             Me.Prop1 = Prop1
         End Sub
-
+        
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.cs
@@ -1318,11 +1318,11 @@ namespace TestDomainServices
         /// Deserialization ctor for MessagePack support, when any Property is required
         /// </summary>
         [global::PolyType.ConstructorShapeAttribute()]
-        private TestEntity_DataMemberBuddy(int ID)
+        private TestEntity_DataMemberBuddy(int Prop1)
         {
             this.OnCreated();
             base.OnDeserializing(default(global::System.Runtime.Serialization.StreamingContext));
-            this.ID = ID;
+            this.Prop1 = Prop1;
         }
         
         /// <summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
@@ -1203,18 +1203,18 @@ Namespace TestDomainServices
             MyBase.New
             Me.OnCreated
         End Sub
-        
+
         ''' <summary>
         ''' Deserialization ctor for MessagePack support, when any Property is required
         ''' </summary>
-        <Global.PolyType.ConstructorShapeAttribute()>  _
-        Private Sub New(ByVal ID As Integer)
+        <Global.PolyType.ConstructorShapeAttribute()>
+        Private Sub New(ByVal Prop1 As Integer)
             MyBase.New
-            Me.OnCreated
+            Me.OnCreated()
             MyBase.OnDeserializing(CType(Nothing, Global.System.Runtime.Serialization.StreamingContext))
-            Me.ID = ID
+            Me.Prop1 = Prop1
         End Sub
-        
+
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>

--- a/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
+++ b/src/Test/Desktop/OpenRiaServices.Common.DomainServices.Test/Baselines/FullTypeNames/Scenarios/TestProvider_Scenarios_CodeGen.g.vb
@@ -1203,18 +1203,18 @@ Namespace TestDomainServices
             MyBase.New
             Me.OnCreated
         End Sub
-
+        
         ''' <summary>
         ''' Deserialization ctor for MessagePack support, when any Property is required
         ''' </summary>
-        <Global.PolyType.ConstructorShapeAttribute()>
+        <Global.PolyType.ConstructorShapeAttribute()>  _
         Private Sub New(ByVal Prop1 As Integer)
             MyBase.New
-            Me.OnCreated()
+            Me.OnCreated
             MyBase.OnDeserializing(CType(Nothing, Global.System.Runtime.Serialization.StreamingContext))
             Me.Prop1 = Prop1
         End Sub
-
+        
         ''' <summary>
         ''' Gets or sets the 'ID' value.
         ''' </summary>


### PR DESCRIPTION
**Dependency updates:**

* Upgraded `Nerdbank.MessagePack` to version 1.2.36 and added `PolyType` version 1.4.1 and update code to work with the latest versions.

**Serialization and constructor generation improvements:**

* Fixed code generation for types that has only required properties by chaning PolyType deserialization constructor generation to accept only required properties.  (Removed workaround required due to old PolyType behavior)

**MessagePack/PolyType integration fixes:**

* Modified the MessagePack serialization provider to disable additional discriminators for surrogate types by updating `DerivedTypeUnions` when surrogates are used, preventing serialization issues with derived types. 
(Seems to be a change in behavior of messagepack?)

**NuGet packaging cleanup:**

* Cleaned up the nuspec file by removing commented-out file entries for `netstandard2.0` and `OpenRiaServices.Client.Web`, focusing the package on supported targets and binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MessagePack/PolyType deserialization for entities with required data members by generating constructor shapes that initialize all required properties.
  * Updated serialization behavior to align derived-type union handling during surrogate-based deserialization.
  * Fixed test-generated deserialization constructor expectations to match the new required-property initialization.

* **Chores**
  * Bumped MessagePack dependency versions and added PolyType support across the supported projects.
  * Refreshed generated baseline and scenario artifacts to reflect updated serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->